### PR TITLE
Fix go-docker CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Require review from golang-compiler team for changes in any file. This keeps us in the loop on
+# auto-merge PRs. The review bot is also an owner so that it can still trigger auto-merge for sync
+# PRs on its own. We may remove this rule once auto-merges are routine.
+* @microsoft/golang-compiler @microsoft-golang-review-bot
+
+# Automatically request review from golang-compiler team for changes in the Microsoft-specific
+# files. This takes precedence over earlier rules in the file.
+/eng/ @microsoft/golang-compiler

--- a/eng/pipeline/go-docker-pr-pipeline.yml
+++ b/eng/pipeline/go-docker-pr-pipeline.yml
@@ -2,7 +2,7 @@ trigger: none
 pr:
   branches:
     include:
-      - microsoft/docker-images
+      - microsoft/*
 
 variables:
   - template: variables/common.yml

--- a/eng/pipeline/go-docker-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline.yml
@@ -2,7 +2,7 @@ trigger:
   batch: true
   branches:
     include:
-      - microsoft/docker-images
+      - microsoft/*
 pr: none
 
 variables:


### PR DESCRIPTION
Update branch triggers so it works on `microsoft/main`. This repo is a fork, so keep using the `microsoft/*` pattern. (Not just `main`.)

Add codeowners for future PR by copying over what we have in microsoft/go.