### PR TITLE
Prepare models for auto-update: match format, remove JSON comment

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,10 +11,12 @@
         {
           "productVersion": "1.15",
           "sharedTags": {
-            "1.15.14-buster": {},
+            "1.15": {},
             "1.15-buster": {},
             "1.15.14": {},
-            "1.15": {}
+            "1.15.14-1": {},
+            "1.15.14-1-buster": {},
+            "1.15.14-buster": {}
           },
           "platforms": [
             {
@@ -22,7 +24,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "1.15.14-buster-amd64": {}
+                "1.15.14-1-buster-amd64": {}
               }
             }
           ]
@@ -30,8 +32,9 @@
         {
           "productVersion": "1.15",
           "sharedTags": {
-            "1.15.14-stretch": {},
-            "1.15-stretch": {}
+            "1.15-stretch": {},
+            "1.15.14-1-stretch": {},
+            "1.15.14-stretch": {}
           },
           "platforms": [
             {
@@ -39,7 +42,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "1.15.14-stretch-amd64": {}
+                "1.15.14-1-stretch-amd64": {}
               }
             }
           ]
@@ -47,8 +50,9 @@
         {
           "productVersion": "1.15",
           "sharedTags": {
-            "1.15.14-windowsservercore-1809": {},
-            "1.15-windowsservercore-1809": {}
+            "1.15-windowsservercore-1809": {},
+            "1.15.14-1-windowsservercore-1809": {},
+            "1.15.14-windowsservercore-1809": {}
           },
           "platforms": [
             {
@@ -56,7 +60,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1809",
               "tags": {
-                "1.15.14-windowsservercore-1809-amd64": {}
+                "1.15.14-1-windowsservercore-1809-amd64": {}
               }
             }
           ]
@@ -64,21 +68,21 @@
         {
           "productVersion": "1.15",
           "sharedTags": {
-            "1.15.14-nanoserver-1809": {},
-            "1.15-nanoserver-1809": {}
+            "1.15-nanoserver-1809": {},
+            "1.15.14-1-nanoserver-1809": {},
+            "1.15.14-nanoserver-1809": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "REPO": "$(Repo:golang)",
-                // Specify the complete platform tag of the server core image so ImageBuilder can detect this dependency.
-                "DOWNLOADER_TAG": "1.15.14-windowsservercore-1809-amd64"
+                "DOWNLOADER_TAG": "1.15.14-1-windowsservercore-1809-amd64",
+                "REPO": "$(Repo:golang)"
               },
               "dockerfile": "src/microsoft/1.15/windows/nanoserver-1809",
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "1.15.14-nanoserver-1809-amd64": {}
+                "1.15.14-1-nanoserver-1809-amd64": {}
               }
             }
           ]
@@ -86,8 +90,9 @@
         {
           "productVersion": "1.15",
           "sharedTags": {
-            "1.15.14-windowsservercore-ltsc2016": {},
-            "1.15-windowsservercore-ltsc2016": {}
+            "1.15-windowsservercore-ltsc2016": {},
+            "1.15.14-1-windowsservercore-ltsc2016": {},
+            "1.15.14-windowsservercore-ltsc2016": {}
           },
           "platforms": [
             {
@@ -95,22 +100,23 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
               "tags": {
-                "1.15.14-windowsservercore-ltsc2016-amd64": {}
+                "1.15.14-1-windowsservercore-ltsc2016-amd64": {}
               }
             }
           ]
         },
-
         {
           "productVersion": "1.16",
           "sharedTags": {
-            "1.16.6-buster": {},
-            "1.16-buster": {},
-            "1-buster": {},
-            "buster": {},
-            "1.16.6": {},
-            "1.16": {},
             "1": {},
+            "1-buster": {},
+            "1.16": {},
+            "1.16-buster": {},
+            "1.16.6": {},
+            "1.16.6-1": {},
+            "1.16.6-1-buster": {},
+            "1.16.6-buster": {},
+            "buster": {},
             "latest": {}
           },
           "platforms": [
@@ -119,7 +125,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "1.16.6-buster-amd64": {}
+                "1.16.6-1-buster-amd64": {}
               }
             }
           ]
@@ -127,9 +133,10 @@
         {
           "productVersion": "1.16",
           "sharedTags": {
-            "1.16.6-stretch": {},
-            "1.16-stretch": {},
             "1-stretch": {},
+            "1.16-stretch": {},
+            "1.16.6-1-stretch": {},
+            "1.16.6-stretch": {},
             "stretch": {}
           },
           "platforms": [
@@ -138,7 +145,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "1.16.6-stretch-amd64": {}
+                "1.16.6-1-stretch-amd64": {}
               }
             }
           ]
@@ -146,9 +153,10 @@
         {
           "productVersion": "1.16",
           "sharedTags": {
-            "1.16.6-windowsservercore-1809": {},
-            "1.16-windowsservercore-1809": {},
             "1-windowsservercore-1809": {},
+            "1.16-windowsservercore-1809": {},
+            "1.16.6-1-windowsservercore-1809": {},
+            "1.16.6-windowsservercore-1809": {},
             "windowsservercore-1809": {}
           },
           "platforms": [
@@ -157,7 +165,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1809",
               "tags": {
-                "1.16.6-windowsservercore-1809-amd64": {}
+                "1.16.6-1-windowsservercore-1809-amd64": {}
               }
             }
           ]
@@ -165,23 +173,23 @@
         {
           "productVersion": "1.16",
           "sharedTags": {
-            "1.16.6-nanoserver-1809": {},
-            "1.16-nanoserver-1809": {},
             "1-nanoserver-1809": {},
+            "1.16-nanoserver-1809": {},
+            "1.16.6-1-nanoserver-1809": {},
+            "1.16.6-nanoserver-1809": {},
             "nanoserver-1809": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "REPO": "$(Repo:golang)",
-                // Specify the complete platform tag of the server core image so ImageBuilder can detect this dependency.
-                "DOWNLOADER_TAG": "1.16.6-windowsservercore-1809-amd64"
+                "DOWNLOADER_TAG": "1.16.6-1-windowsservercore-1809-amd64",
+                "REPO": "$(Repo:golang)"
               },
               "dockerfile": "src/microsoft/1.16/windows/nanoserver-1809",
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "1.16.6-nanoserver-1809-amd64": {}
+                "1.16.6-1-nanoserver-1809-amd64": {}
               }
             }
           ]
@@ -189,9 +197,10 @@
         {
           "productVersion": "1.16",
           "sharedTags": {
-            "1.16.6-windowsservercore-ltsc2016": {},
-            "1.16-windowsservercore-ltsc2016": {},
             "1-windowsservercore-ltsc2016": {},
+            "1.16-windowsservercore-ltsc2016": {},
+            "1.16.6-1-windowsservercore-ltsc2016": {},
+            "1.16.6-windowsservercore-ltsc2016": {},
             "windowsservercore-ltsc2016": {}
           },
           "platforms": [
@@ -200,7 +209,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
               "tags": {
-                "1.16.6-windowsservercore-ltsc2016-amd64": {}
+                "1.16.6-1-windowsservercore-ltsc2016-amd64": {}
               }
             }
           ]

--- a/src/microsoft/1.15/buster/Dockerfile
+++ b/src/microsoft/1.15/buster/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.15.5
+ENV GOLANG_VERSION 1.15.14
 
 RUN set -eux; \
 	\

--- a/src/microsoft/1.15/stretch/Dockerfile
+++ b/src/microsoft/1.15/stretch/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.15.5
+ENV GOLANG_VERSION 1.15.14
 
 RUN set -eux; \
 	\

--- a/src/microsoft/1.15/windows/nanoserver-1809/Dockerfile
+++ b/src/microsoft/1.15/windows/nanoserver-1809/Dockerfile
@@ -14,7 +14,7 @@
 ARG REPO=mcr.microsoft.com/oss/go/golang
 # It's easy to download Go and install it in server core, but not nanoserver. So, to build
 # nanoserver, copy over the server core installation.
-ARG DOWNLOADER_TAG=1.15.5-windowsservercore-1809
+ARG DOWNLOADER_TAG=1.15.14-windowsservercore-1809
 FROM $REPO:$DOWNLOADER_TAG AS downloader
 # END NO MICROSOFT_UPSTREAM
 
@@ -35,7 +35,7 @@ RUN setx /m PATH "%GOPATH%\bin;C:\go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.15.5
+ENV GOLANG_VERSION 1.15.14
 
 # Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
 # NO MICROSOFT_UPSTREAM: Use "downloader" stage defined earlier.

--- a/src/microsoft/1.15/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.15/windows/windowsservercore-1809/Dockerfile
@@ -53,7 +53,7 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.15.5
+ENV GOLANG_VERSION 1.15.14
 
 RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.15/20210817.4/go.20210817.4.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \

--- a/src/microsoft/1.15/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/1.15/windows/windowsservercore-ltsc2016/Dockerfile
@@ -53,7 +53,7 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.15.5
+ENV GOLANG_VERSION 1.15.14
 
 RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.15/20210817.4/go.20210817.4.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \

--- a/src/microsoft/README.md
+++ b/src/microsoft/README.md
@@ -22,3 +22,17 @@ generating the Dockerfiles.
 
 Use the `/eng/update-dockerfiles.sh` script to generate the Dockerfiles based on
 this `versions.json` file.
+
+This file is also used to generate `/manifest.json`, the file that drives the
+.NET Docker build infrastructure used to build our Docker images. This means
+there are some extra things to consider:
+* The order of the `variants` array is critical: it must be in dependency order.
+  For example, `windows/nanoserver-1809` depends on
+  `windows/windowsservercore-1809`, so nanoserver must be later than
+  windowsservercore.
+* The `preferredMajor` key refers to `1` in `1.16.6`, and should only exist
+  once. It determines the version to tag `latest`.
+* The `preferredMinor` key refers to `1.16` in `1.16.6`, and should only exist
+  once per major version. It determines the version to tag `1`.
+* The `preferredVariant` key determines the platform to use in tags that don't
+  include a specific platform, like `1.16.6` (vs. `1.16.6-buster`).

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -24,10 +24,11 @@
       "buster",
       "stretch",
       "windows/windowsservercore-1809",
-      "windows/windowsservercore-ltsc2016",
-      "windows/nanoserver-1809"
+      "windows/nanoserver-1809",
+      "windows/windowsservercore-ltsc2016"
     ],
-    "version": "1.15.5"
+    "version": "1.15.14",
+    "preferredVariant": "buster"
   },
   "1.16": {
     "arches": {
@@ -54,9 +55,12 @@
       "buster",
       "stretch",
       "windows/windowsservercore-1809",
-      "windows/windowsservercore-ltsc2016",
-      "windows/nanoserver-1809"
+      "windows/nanoserver-1809",
+      "windows/windowsservercore-ltsc2016"
     ],
-    "version": "1.16.6"
+    "version": "1.16.6",
+    "preferredMajor": true,
+    "preferredMinor": true,
+    "preferredVariant": "buster"
   }
 }


### PR DESCRIPTION
Sorting the manifest and including a revision number in the tags matches it up with what auto-update generates, so the diff of the first auto-update will be purer. The JSON comment needed to go because Go's JSON parser fails when it sees it. The `buildArgs` object will be described in the manifest.json generator now--just an implementation detail of generating a file that the .NET Docker build infra can use.

I also added a description of the non-standard `version.json` keys to `src/microsoft/README.md`.