### PR TITLE
Update repo name: oss/go/microsoft/alpha/golang

### DIFF
--- a/Dockerfile-windows-nanoserver.template
+++ b/Dockerfile-windows-nanoserver.template
@@ -5,7 +5,7 @@
 # stage name that we can reference later.
 # * https://github.com/docker/for-mac/issues/2155
 # * https://github.com/moby/moby/issues/34482
-ARG REPO=mcr.microsoft.com/oss/go/golang
+ARG REPO=mcr.microsoft.com/oss/go/microsoft/alpha/golang
 # It's easy to download Go and install it in server core, but not nanoserver. So, to build
 # nanoserver, copy over the server core installation.
 ARG DOWNLOADER_TAG={{ .version }}-windowsservercore-{{ env.windowsRelease }}

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "repos": [
     {
       "id": "golang",
-      "name": "oss/go/golang/alpha",
+      "name": "oss/go/microsoft/alpha/golang",
       "images": [
         {
           "productVersion": "1.15",

--- a/src/microsoft/1.15/windows/nanoserver-1809/Dockerfile
+++ b/src/microsoft/1.15/windows/nanoserver-1809/Dockerfile
@@ -11,7 +11,7 @@
 # stage name that we can reference later.
 # * https://github.com/docker/for-mac/issues/2155
 # * https://github.com/moby/moby/issues/34482
-ARG REPO=mcr.microsoft.com/oss/go/golang
+ARG REPO=mcr.microsoft.com/oss/go/microsoft/alpha/golang
 # It's easy to download Go and install it in server core, but not nanoserver. So, to build
 # nanoserver, copy over the server core installation.
 ARG DOWNLOADER_TAG=1.15.14-windowsservercore-1809

--- a/src/microsoft/1.16/windows/nanoserver-1809/Dockerfile
+++ b/src/microsoft/1.16/windows/nanoserver-1809/Dockerfile
@@ -11,7 +11,7 @@
 # stage name that we can reference later.
 # * https://github.com/docker/for-mac/issues/2155
 # * https://github.com/moby/moby/issues/34482
-ARG REPO=mcr.microsoft.com/oss/go/golang
+ARG REPO=mcr.microsoft.com/oss/go/microsoft/alpha/golang
 # It's easy to download Go and install it in server core, but not nanoserver. So, to build
 # nanoserver, copy over the server core installation.
 ARG DOWNLOADER_TAG=1.16.6-windowsservercore-1809


### PR DESCRIPTION
This brings us back in line with <https://github.com/microsoft/mcr/blob/main/teams/oss/golang.yml> so the images get published to MCR.