### PR TITLE
Update eng/common and fix official build

### DIFF
--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -35,7 +35,7 @@ else {
 
 if (!(Test-Path $DotnetInstallScript)) {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
-    Invoke-WebRequest "https://dot.net/v1/$DotnetInstallScript" -OutFile $InstallPath/$DotnetInstallScript
+    & "$PSScriptRoot/Invoke-WithRetry.ps1" "Invoke-WebRequest 'https://dot.net/v1/$DotnetInstallScript' -OutFile $InstallPath/$DotnetInstallScript"
 }
 
 $DotnetChannel = "5.0"

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -2,21 +2,21 @@
 
 <#
     .SYNOPSIS
-        Builds the .NET Core Dockerfiles
+        Builds the Dockerfiles
 #>
 
 [cmdletbinding()]
 param(
-    # Version of .NET Core to filter by
-    [string]$Version = "*",
+    # Product versions to filter by
+    [string[]]$Version = "*",
 
-    # Name of OS to filter by
-    [string]$OS,
+    # Names of OS to filter by
+    [string[]]$OS,
 
     # Type of architecture to filter by
     [string]$Architecture,
 
-    # Additional custom path filters (overrides Version)
+    # Additional custom path filters
     [string[]]$Paths,
 
     # Path to manifest file
@@ -49,8 +49,12 @@ pushd $PSScriptRoot/../..
 try {
     $args = $OptionalImageBuilderArgs
 
+    if ($Version) {
+        $args += " --version " + ($Version -join " --version ")
+    }
+
     if ($OS) {
-        $args += " --os-version $OS"
+        $args += " --os-version " + ($OS -join " --os-version ")
     }
 
     if ($Architecture) {
@@ -59,9 +63,6 @@ try {
 
     if ($Paths) {
         $args += " --path " + ($Paths -join " --path ")
-    }
-    else {
-        $args += " --path 'src/*/$Version/*'"
     }
 
     if ($Manifest) {

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -9,7 +9,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  condition: and(succeeded(), ${{ parameters.matrix }})
+  condition: and(${{ parameters.matrix }}, in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
   dependsOn:
   - PreBuildValidation
   - CopyBaseImages
@@ -47,9 +47,12 @@ jobs:
 
         $engCommonPath = "$(Build.Repository.LocalPath)/$buildRepoName/$(engCommonRelativePath)"
         $engPath = "$(Build.Repository.LocalPath)/$buildRepoName/eng"
-        $testScriptPath = "$buildRepoName/$(testScriptPath)"
         $manifest = "$buildRepoName/$(manifest)"
         $testResultsDirectory = "$buildRepoName/$testResultsDirectory"
+
+        if ("$(testScriptPath)") {
+          $testScriptPath = "$buildRepoName/$(testScriptPath)"
+        }
 
         echo "##vso[task.setvariable variable=buildRepoName]$buildRepoName"
         echo "##vso[task.setvariable variable=manifest]$manifest"
@@ -91,4 +94,6 @@ jobs:
     displayName: Publish Image Info File Artifact
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
     - template: ${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}
+      parameters:
+        condition: ne(variables.testScriptPath, '')
   - template: ${{ format('../steps/cleanup-docker-{0}.yml', parameters.dockerClientOS) }}

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -91,6 +91,12 @@ jobs:
       $(dryRunArg)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Image Info
+    # NO MICROSOFT_UPSTREAM: Add a condition that allows us to disable image info publish from the
+    # root pipeline. Enabling this publish tracked by https://github.com/microsoft/go/issues/157.
+    # Related issue about this step running unconditionally and seeming to require that the versions
+    # repo already have an image-info file: https://github.com/dotnet/docker-tools/issues/832.
+    condition: and(succeeded(), ne(variables['publishImageInfo'], 'false'))
+    # END NO MICROSOFT_UPSTREAM
   - script: >
       $(runImageBuilderCmd) ingestKustoImageInfo
       '$(artifactsPath)/image-info.json'

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -91,12 +91,6 @@ jobs:
       $(dryRunArg)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Image Info
-    # NO MICROSOFT_UPSTREAM: Add a condition that allows us to disable image info publish from the
-    # root pipeline. Enabling this publish tracked by https://github.com/microsoft/go/issues/157.
-    # Related issue about this step running unconditionally and seeming to require that the versions
-    # repo already have an image-info file: https://github.com/dotnet/docker-tools/issues/832.
-    condition: and(succeeded(), ne(variables['publishImageInfo'], 'false'))
-    # END NO MICROSOFT_UPSTREAM
   - script: >
       $(runImageBuilderCmd) ingestKustoImageInfo
       '$(artifactsPath)/image-info.json'
@@ -112,9 +106,5 @@ jobs:
       $(dryRunArg)
       $(imageBuilder.commonCmdArgs)
     displayName: Ingest Kusto Image Info
-    # MICROSOFT_UPSTREAM: Add a condition that allows us to disable telemetry ingestion from the
-    # root pipeline. Enabling this publish tracked by https://github.com/microsoft/go/issues/192.
-    # Upstream issue: https://github.com/dotnet/docker-tools/issues/851.
-    condition: and(succeeded(), ne(variables['ingestImageInfo'], 'false'))
-    # END MICROSOFT_UPSTREAM
+    condition: and(succeeded(), eq(variables['ingestKustoImageInfo'], 'true'))
   - template: ../steps/cleanup-docker-linux.yml

--- a/eng/common/templates/jobs/test-images-linux-client.yml
+++ b/eng/common/templates/jobs/test-images-linux-client.yml
@@ -11,6 +11,8 @@ jobs:
     dependsOn: GenerateTestMatrix
     strategy:
       matrix: $[ ${{ parameters.matrix }} ]
+  ${{ if eq(parameters.preBuildValidation, 'true') }}:
+    condition: and(succeeded(), ne(variables.testScriptPath, ''))
   pool: ${{ parameters.pool }}
   timeoutInMinutes: ${{ parameters.testJobTimeout }}
   steps:

--- a/eng/common/templates/jobs/validate-image-sizes.yml
+++ b/eng/common/templates/jobs/validate-image-sizes.yml
@@ -35,7 +35,7 @@ jobs:
       dockerClientOS: linux
       validationMode: integrity
 - job: WindowsPerfTests
-  pool: Docker-20H2-${{ variables['System.TeamProject'] }}
+  pool: Docker-2022-${{ variables['System.TeamProject'] }}
   workspace:
     clean: all
   steps:

--- a/eng/common/templates/jobs/wait-for-ingestion.yml
+++ b/eng/common/templates/jobs/wait-for-ingestion.yml
@@ -7,7 +7,7 @@ jobs:
   - template: ../steps/download-build-artifact.yml
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
-      condition: and(succeeded(), ne(variables['sourceBuildId'], ''))
+      condition: ne(variables['sourceBuildId'], '')
   - powershell: |
       # Get the last image info artifact that was published
       $imageInfoDirName = @($(dir $(Build.ArtifactStagingDirectory)/image-info-final-* | select -ExpandProperty Name))[-1]

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -145,12 +145,14 @@ stages:
     dependsOn: Post_Build
     condition: "
       and(
-        contains(variables['stages'], 'test'),
-        or(
-          and(
-            succeeded(),
-            contains(variables['stages'], 'build')),
-          not(contains(variables['stages'], 'build'))))"
+        ne(variables['testScriptPath'], ''),
+        and(
+          contains(variables['stages'], 'test'),
+          or(
+            and(
+              succeeded(),
+              contains(variables['stages'], 'build')),
+            not(contains(variables['stages'], 'build')))))"
     jobs:
     - template: ../jobs/generate-matrix.yml
       parameters:
@@ -236,13 +238,13 @@ stages:
               succeeded('Post_Build')),
             and(
               contains(variables['stages'], 'test'),
-              succeeded('Test'))),
+              in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
           or(
             and(
               not(contains(variables['stages'], 'build')),
               and(
                 contains(variables['stages'], 'test'),
-                succeeded('Test'))),
+                in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
             and(
               not(contains(variables['stages'], 'test')),
               and(

--- a/eng/common/templates/steps/clean-acr-images.yml
+++ b/eng/common/templates/steps/clean-acr-images.yml
@@ -1,0 +1,19 @@
+parameters:
+  repo: null
+  action: null
+  age: null
+  customArgs: ""
+steps:
+  - script: >
+      $(runImageBuilderCmd) cleanAcrImages
+      ${{ parameters.repo }}
+      $(acr.servicePrincipalName)
+      $(app-dotnetdockerbuild-client-secret)
+      $(acr.servicePrincipalTenant)
+      $(acr.subscription)
+      $(acr.resourceGroup)
+      $(acr.server)
+      --action ${{ parameters.action }}
+      --age ${{ parameters.age }}
+      ${{ parameters.customArgs }}
+    displayName: Clean ACR Images - ${{ parameters.repo }}

--- a/eng/common/templates/steps/cleanup-docker-linux.yml
+++ b/eng/common/templates/steps/cleanup-docker-linux.yml
@@ -1,12 +1,15 @@
+parameters:
+  condition: true
+
 steps:
   ################################################################################
   # Cleanup local Docker server
   ################################################################################
 - script: docker stop $(docker ps -q) || true
   displayName: Stop Running Containers
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
 - script: docker system prune -a -f --volumes
   displayName: Cleanup Docker
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true

--- a/eng/common/templates/steps/cleanup-docker-windows.yml
+++ b/eng/common/templates/steps/cleanup-docker-windows.yml
@@ -1,15 +1,18 @@
+parameters:
+  condition: true
+  
 steps:
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
 - powershell: $(engCommonPath)/Invoke-CleanupDocker.ps1
   displayName: Cleanup Docker Images
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
 - powershell: |
     if (Test-Path $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder) {
       Remove-Item $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder -Force -Recurse;
     }
   displayName: Cleanup Image Builder
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true

--- a/eng/common/templates/steps/download-build-artifact.yml
+++ b/eng/common/templates/steps/download-build-artifact.yml
@@ -14,4 +14,4 @@ steps:
     targetPath: ${{ parameters.targetPath }}
     artifactName: ${{ parameters.artifactName }}
   displayName: Download Build Artifact(s)
-  condition: ${{ parameters.condition }}
+  condition: and(succeeded(), ${{ parameters.condition }})

--- a/eng/common/templates/steps/init-common.yml
+++ b/eng/common/templates/steps/init-common.yml
@@ -1,5 +1,9 @@
+parameters:
+  condition: true
+
 steps:
 - powershell: |
     $sourceBranch=$Env:BUILD_SOURCEBRANCH -replace "refs/heads/","" -replace "refs/tags/","" -replace "refs/pull/","" 
     echo "##vso[task.setvariable variable=sourceBranch]$sourceBranch"
   displayName: Define Source Branch Variable
+  condition: and(succeeded(), ${{ parameters.condition }})

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -2,17 +2,23 @@ parameters:
   setupImageBuilder: true
   setupTestRunner: false
   cleanupDocker: true
+  condition: true
 
 steps:
 - template: init-common.yml
+  parameters:
+    condition: ${{ parameters.condition }}
 - script: echo "##vso[task.setvariable variable=artifactsPath]/artifacts"
   displayName: Define Artifacts Path Variable
+  condition: and(succeeded(), ${{ parameters.condition }})
 
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
 - ${{ if eq(parameters.cleanupDocker, 'true') }}:
   - template: cleanup-docker-linux.yml
+    parameters:
+      condition: ${{ parameters.condition }}
 
   ################################################################################
   # Setup Image Builder (Optional)
@@ -20,12 +26,14 @@ steps:
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
   - script: $(engCommonPath)/pull-image.sh $(imageNames.imageBuilder)
     displayName: Pull Image Builder
+    condition: and(succeeded(), ${{ parameters.condition }})
   - script: >
       docker build
       -t $(imageNames.imageBuilder.withrepo)
       --build-arg IMAGE=$(imageNames.imageBuilder)
       -f $(engCommonPath)/Dockerfile.WithRepo .
     displayName: Build Image for Image Builder
+    condition: and(succeeded(), ${{ parameters.condition }})
   - script: >
       echo "##vso[task.setvariable variable=runImageBuilderCmd]
       docker run --rm
@@ -35,6 +43,7 @@ steps:
       $(imageBuilderDockerRunExtraOptions)
       $(imageNames.imageBuilder.withrepo)"
     displayName: Define runImageBuilderCmd Variable
+    condition: and(succeeded(), ${{ parameters.condition }})
 
   ################################################################################
   # Setup Test Runner (Optional)
@@ -42,9 +51,11 @@ steps:
 - ${{ if eq(parameters.setupTestRunner, 'true') }}:
   - script: $(engCommonPath)/pull-image.sh $(imageNames.testrunner)
     displayName: Pull Test Runner
+    condition: and(succeeded(), ${{ parameters.condition }})
   - script: >
       docker build
       -t $(imageNames.testRunner.withrepo)
       --build-arg IMAGE=$(imageNames.testrunner)
       -f $(engCommonPath)/Dockerfile.WithRepo .
     displayName: Build Test Runner Image
+    condition: and(succeeded(), ${{ parameters.condition }})

--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -1,15 +1,21 @@
 parameters:
   setupImageBuilder: true
+  condition: true
 
 steps:
 - template: init-common.yml
+  parameters:
+    condition: ${{ parameters.condition }}
 - powershell: echo "##vso[task.setvariable variable=artifactsPath]$(Build.ArtifactStagingDirectory)"
   displayName: Define Artifacts Path Variable
+  condition: and(succeeded(), ${{ parameters.condition }})
 
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
 - template: cleanup-docker-windows.yml
+  parameters:
+    condition: ${{ parameters.condition }}
 
   ################################################################################
   # Setup Image Builder (Optional)
@@ -17,18 +23,22 @@ steps:
 - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
   - powershell: $(engCommonPath)/Invoke-WithRetry.ps1 "docker pull $(imageNames.imageBuilder)"
     displayName: Pull Image Builder
+    condition: and(succeeded(), ${{ parameters.condition }})
   - script: docker create --name setupImageBuilder-$(Build.BuildId)-$(System.JobId) $(imageNames.imageBuilder)
     displayName: Create Setup Container
+    condition: and(succeeded(), ${{ parameters.condition }})
   - script: >
       docker cp
       setupImageBuilder-$(Build.BuildId)-$(System.JobId):/image-builder
       $(Build.BinariesDirectory)/.Microsoft.DotNet.ImageBuilder
     displayName: Copy Image Builder
+    condition: and(succeeded(), ${{ parameters.condition }})
   - script: docker rm -f setupImageBuilder-$(Build.BuildId)-$(System.JobId)
     displayName: Cleanup Setup Container
-    condition: always()
+    condition: and(always(), ${{ parameters.condition }})
     continueOnError: true
   - powershell: >
       echo "##vso[task.setvariable variable=runImageBuilderCmd]
       $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe"
     displayName: Define runImageBuilderCmd Variable
+    condition: and(succeeded(), ${{ parameters.condition }})

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -1,5 +1,6 @@
 parameters:
   preBuildValidation: false
+  condition: true
 
 steps:
 - template: init-docker-linux.yml
@@ -7,6 +8,7 @@ steps:
     setupImageBuilder: false
     setupTestRunner: true
     cleanupDocker: ${{ eq(variables['System.TeamProject'], 'internal') }}
+    condition: ${{ parameters.condition }}
 - script: |
     echo "##vso[task.setvariable variable=testRunner.container]testrunner-$(Build.BuildId)-$(System.JobId)"
 
@@ -23,6 +25,7 @@ steps:
     fi
     echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
   displayName: Set Test Variables
+  condition: and(succeeded(), ${{ parameters.condition }})
 - script: >
     docker run -t -d
     -v /var/run/docker.sock:/var/run/docker.sock
@@ -31,16 +34,19 @@ steps:
     --name $(testRunner.container)
     $(imageNames.testRunner.withrepo)
   displayName: Start Test Runner Container
+  condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - script: >
       docker exec $(testRunner.container) pwsh
       -File $(engCommonRelativePath)/Invoke-WithRetry.ps1
       "docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)"
     displayName: Docker login
+    condition: and(succeeded(), ${{ parameters.condition }})
   - ${{ if eq(parameters.preBuildValidation, 'false') }}:
     - template: ../steps/download-build-artifact.yml
       parameters:
         targetPath: $(Build.ArtifactStagingDirectory)
+        condition: ${{ parameters.condition }}
 - script: >
     docker exec $(testRunner.container) pwsh
     -File $(testScriptPath)
@@ -49,21 +55,22 @@ steps:
     -Architecture '$(architecture)'
     $(optionalTestArgs)
   displayName: Test Images
+  condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - script: docker exec $(testRunner.container) docker logout $(acr.server)
     displayName: Docker logout
-    condition: always()
+    condition: and(always(), ${{ parameters.condition }})
     continueOnError: true
 - script: >
     docker cp
     $(testRunner.container):/repo/$(testResultsDirectory)
     $(Common.TestResultsDirectory)/.
   displayName: Copy Test Results
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
 - task: PublishTestResults@2
   displayName: Publish Test Results
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
   inputs:
     testRunner: vSTest
@@ -77,7 +84,9 @@ steps:
       testRunTitle: Pre-Build Validation
 - script: docker rm -f $(testRunner.container)
   displayName: Cleanup TestRunner Container
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: cleanup-docker-linux.yml
+    parameters:
+      condition: ${{ parameters.condition }}

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -1,12 +1,17 @@
+parameters:
+  condition: true
+
 steps:
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: init-docker-windows.yml
     parameters:
       setupImageBuilder: false
+      condition: ${{ parameters.condition }}
   - powershell: >
       $(engCommonPath)/Invoke-WithRetry.ps1
       "cmd /c 'docker login -u $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server) 2>&1'"
     displayName: Docker login
+    condition: and(succeeded(), ${{ parameters.condition }})
 - powershell: |
     if ("${{ eq(variables['System.TeamProject'], 'public') }}" -eq "False") {
       $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
@@ -16,26 +21,30 @@ steps:
     }
     echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
   displayName: Set Test Variables
+  condition: and(succeeded(), ${{ parameters.condition }})
 - powershell: Get-ChildItem -Path tests -r | Where {$_.Extension -match "trx"} | Remove-Item
   displayName: Cleanup Old Test Results
+  condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: ../steps/download-build-artifact.yml
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
+      condition: ${{ parameters.condition }}
 - powershell: >
     $(testScriptPath)
     -Version '$(productVersion)'
     -OS '$(osVariant)'
     $(optionalTestArgs)
   displayName: Test Images
+  condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - script: docker logout $(acr.server)
     displayName: Docker logout
-    condition: always()
+    condition: and(always(), ${{ parameters.condition }})
     continueOnError: true
 - task: PublishTestResults@2
   displayName: Publish Test Results
-  condition: always()
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
   inputs:
     testRunner: vSTest
@@ -45,3 +54,5 @@ steps:
     testRunTitle: $(productVersion) $(osVariant) amd64
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: cleanup-docker-windows.yml
+    parameters:
+      condition: ${{ parameters.condition }}

--- a/eng/common/templates/variables/common-paths.yml
+++ b/eng/common/templates/variables/common-paths.yml
@@ -2,4 +2,4 @@ variables:
   engCommonRelativePath: eng/common
   engCommonPath: $(Build.Repository.LocalPath)/$(engCommonRelativePath)
   engPath: $(Build.Repository.LocalPath)/eng
-  testScriptPath: ./tests/run-tests.ps1
+  testScriptPath: ""

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -15,6 +15,8 @@ variables:
   value: 2
 - name: imageInfoVariant
   value: ""
+- name: ingestKustoImageInfo
+  value: true
 - name: manifestVariables
   value: ""
 - name: defaultLinuxAmd64PoolImage

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1287932
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1383683
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -14,7 +14,7 @@ variables:
   value: 2
 - name: officialBranches
   # list multiple branches as "'branch1', 'branch2', etc."
-  value: "'microsoft/docker-images','docker'"
+  value: "'microsoft/main'"
 - name: manifest
   value: manifest.json
 

--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -7,8 +7,8 @@ variables:
 # https://github.com/microsoft/go/issues/157 tracks enabling publishImageInfo.
 - name: publishImageInfo
   value: false
-# https://github.com/microsoft/go/issues/192 tracks enabling ingestImageInfo.
-- name: ingestImageInfo
+# https://github.com/microsoft/go/issues/192 tracks enabling ingestKustoImageInfo.
+- name: ingestKustoImageInfo
   value: false
 - name: productVersionComponents
   value: 2
@@ -17,8 +17,6 @@ variables:
   value: "'microsoft/docker-images','docker'"
 - name: manifest
   value: manifest.json
-- name: testScriptPath
-  value: 'eng/run-tests.ps1'
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: go-docker-common

--- a/eng/run-tests.ps1
+++ b/eng/run-tests.ps1
@@ -1,5 +1,0 @@
-# This script does nothing because the repository has no tests. It is here so we can plug it into
-# the .NET Infrastructure for the "run tests" step.
-#
-# Making the .NET Docker infrastructure better at handling repositories that don't have tests is
-# tracked by: https://github.com/dotnet/docker-tools/issues/830


### PR DESCRIPTION
A few commits to get eng/common up to date and get the official build working:

* Update eng/common to dotnet/docker-tools@2dddfe2
  * **Skip review**: this is an exact copy of `eng/common` into this repo.
  * The update includes some changes based on the feedback I sent when I was working on the initial onboarding.
* Reapply publishImageInfo workaround; uptake other improvements
  * We still need the `publishImageInfo` workaround for now, so I reapplied it on top of the overwritten files.
    * https://github.com/microsoft/go/issues/157 tracks getting rid of it.
  * Instead of reapplying the `ingestImageInfo` workaround, use the now-standard `ingestKustoImageInfo` variable.
  * Get rid of the placeholder test script: an empty path is now respected.
* Update official branch to `microsoft/main`
  * Since `eng/common` is updated, we have the fix for https://github.com/dotnet/docker-tools/issues/828.
    * This means we can specify `microsoft/main` and have it be an exact match.
  * Without the update, the official build fails because it detects we're trying to build/publish to official locations with a non-official branch.