### PR TITLE
Update eng/common after usage flexibility refactor

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -17,8 +17,10 @@ param(
     [string]$OptionalImageBuilderArgs
 )
 
-# See https://github.com/dotnet/dotnet-docker/blob/main/build-and-test.ps1 when adding more
-# configurability to this script. Follow the .NET Docker methodology when possible for consistency.
+# This script is copied from .NET Docker and modified to suit our usage. See the original script
+# (https://github.com/dotnet/dotnet-docker/blob/main/build-and-test.ps1) when adding more
+# functionality here. Follow the .NET Docker methodology when possible for consistency and
+# compatibility with changes to the core .NET Docker shared infrastructure.
 
 # Build the product images.
 & $PSScriptRoot/common/build.ps1 `

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -1,5 +1,9 @@
 #!/usr/bin/env pwsh
 param(
+    # Version of Go to filter by.
+    # This is '*' in upstream, but empty here to work around an issue when building on Linux: https://github.com/dotnet/dotnet-docker/issues/3288
+    [string]$Version = "",
+
     # Name of OS to filter by
     [string]$OS,
 
@@ -18,6 +22,7 @@ param(
 
 # Build the product images.
 & $PSScriptRoot/common/build.ps1 `
+    -Version $Version `
     -OS $OS `
     -Architecture $Architecture `
     -Paths $Paths `

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -6,6 +6,10 @@ parameters:
   buildJobTimeout: 60
   customInitSteps: []
   noCache: false
+  internalProjectName: null
+  publicProjectName: null
+  internalVersionsRepoRef: null
+  publicVersionsRepoRef: null
 
 jobs:
 - job: ${{ parameters.name }}
@@ -29,11 +33,11 @@ jobs:
       pipelineDisabledCache: true
   steps:
   - checkout: self
-  - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(parameters.noCache, false)) }}:
-    - checkout: VersionsRepo
+  - ${{ if and(eq(variables['System.TeamProject'], parameters.publicProjectName), eq(parameters.noCache, false)) }}:
+    - checkout: ${{ parameters.publicVersionsRepoRef }}
       path: s/$(versionsRepoPath)
-  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.noCache, false)) }}:
-    - checkout: git://internal/dotnet-versions
+  - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), eq(parameters.noCache, false)) }}:
+    - checkout: ${{ parameters.internalVersionsRepoRef }}
       path: s/$(versionsRepoPath)
   - ${{ if eq(parameters.noCache, false) }}:
     - powershell: |
@@ -64,10 +68,12 @@ jobs:
   - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}
   - ${{ parameters.customInitSteps }}
   - template: ../steps/set-image-info-path-var.yml
+    parameters:
+      publicSourceBranch: $(publicSourceBranch)
   - powershell: |
       $imageBuilderBuildArgs = "$(imageBuilder.queueArgs) --image-info-output-path $(artifactsPath)/$(legName)-image-info.json"
-      if ($env:SYSTEM_TEAMPROJECT -eq "internal") {
-        $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push --registry-creds ""$(acr.server)=$(acr.userName);$(BotAccount-dotnet-docker-acr-bot-password)"""
+      if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.internalProjectName }}") {
+        $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push --registry-creds ""$(acr.server)=$(acr.userName);$(acr.password)"""
       }
 
       # If the pipeline isn't configured to disable the cache and a build variable hasn't been set to disable the cache
@@ -92,7 +98,7 @@ jobs:
   - publish: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
     artifact: $(legName)-image-info-$(System.JobAttempt)
     displayName: Publish Image Info File Artifact
-  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
     - template: ${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}
       parameters:
         condition: ne(variables.testScriptPath, '')

--- a/eng/common/templates/jobs/copy-base-images.yml
+++ b/eng/common/templates/jobs/copy-base-images.yml
@@ -1,24 +1,25 @@
 parameters:
   name: null
+  pool: {}
   additionalOptions: null
+  publicProjectName: null
   
 jobs:
 - job: ${{ parameters.name }}
-  pool:
-    vmImage: $(defaultLinuxAmd64PoolImage)
+  pool: ${{ parameters.pool }}
   steps:
   - template: ../steps/init-docker-linux.yml
-  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
     - template: ../steps/set-dry-run.yml
   - script: >
       $(runImageBuilderCmd)
       copyBaseImages
       '$(acr.servicePrincipalName)'
-      '$(app-dotnetdockerbuild-client-secret)'
+      '$(acr.servicePrincipalPassword)'
       '$(acr.servicePrincipalTenant)'
       '$(acr.subscription)'
       '$(acr.resourceGroup)'
-      --registry-creds 'docker.io=$(dotnetDockerHubBot.userName);$(BotAccount-dotnet-dockerhub-bot-PAT)'
+      $(mirrorRegistryCreds)
       --repo-prefix $(mirrorRepoPrefix)
       --registry-override '$(acr.server)'
       --os-type 'linux'

--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -1,16 +1,19 @@
 parameters:
   matrixType: null
   name: null
+  pool: {}
   customBuildLegGroupArgs: ""
   isTestStage: false
+  internalProjectName: null
 
 jobs:
 - job: ${{ parameters.name }}
-  pool:
-    vmImage: $(defaultLinuxAmd64PoolImage)
+  pool: ${{ parameters.pool }}
   steps:
   - template: ../steps/init-docker-linux.yml
   - template: ../steps/validate-branch.yml
+    parameters:
+      internalProjectName: ${{ parameters.internalProjectName }}
   - ${{ if eq(parameters.isTestStage, true) }}:
     - template: ../steps/download-build-artifact.yml
       parameters:

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -1,25 +1,33 @@
 parameters:
   pool: {}
+  internalProjectName: null
+  customInitSteps: []
+  customPublishVariables: []
+
 jobs:
 - job: Publish
   pool: ${{ parameters.pool }}
   variables:
-  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    - group: DotNet-AllOrgs-Darc-Pats
   - name: imageBuilder.commonCmdArgs
     value: >
       --manifest '$(manifest)'
       --registry-override '$(acr.server)'
       $(manifestVariables)
       $(imageBuilder.queueArgs)
+  - ${{ parameters.customPublishVariables }}
   steps:
   - template: ../steps/init-docker-linux.yml
+  - ${{ parameters.customInitSteps }}
   - template: ../steps/validate-branch.yml
+    parameters:
+      internalProjectName: ${{ parameters.internalProjectName }}
   - template: ../steps/download-build-artifact.yml
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
       artifactName: image-info
   - template: ../steps/set-image-info-path-var.yml
+    parameters:
+      publicSourceBranch: $(publicSourceBranch)
   - template: ../steps/set-dry-run.yml
   - script: echo $(sourceBuildId) > $(Build.ArtifactStagingDirectory)/source-build-id.txt
     displayName: Write Source Build ID to File
@@ -35,7 +43,7 @@ jobs:
   - script: >
       $(runImageBuilderCmd) copyAcrImages
       '$(acr.servicePrincipalName)'
-      '$(app-dotnetdockerbuild-client-secret)'
+      '$(acr.servicePrincipalPassword)'
       '$(acr.servicePrincipalTenant)'
       '$(acr.subscription)'
       '$(acr.resourceGroup)'
@@ -52,7 +60,7 @@ jobs:
       $(runImageBuilderCmd) publishManifest
       '$(artifactsPath)/image-info.json'
       --repo-prefix '$(publishRepoPrefix)'
-      --registry-creds '$(acr.server)=$(acr.userName);$(BotAccount-dotnet-docker-acr-bot-password)'
+      --registry-creds '$(acr.server)=$(acr.userName);$(acr.password)'
       --os-type '*'
       --architecture '*'
       $(dryRunArg)
@@ -75,28 +83,22 @@ jobs:
   - script: >
       $(runImageBuilderCmd) publishImageInfo
       '$(artifactsPath)/image-info.json'
-      '$(dotnetDockerBot.userName)'
-      '$(dotnetDockerBot.email)'
-      '$(BotAccount-dotnet-docker-bot-PAT)'
-      '$(dn-bot-devdiv-dnceng-rw-code-pat)'
-      'dnceng'
-      'internal'
-      --git-owner 'dotnet'
-      --git-repo 'versions'
-      --git-branch 'main'
-      --git-path '$(imageInfoVersionsPath)'
-      --azdo-repo 'dotnet-versions'
-      --azdo-branch 'main'
-      --azdo-path '$(imageInfoVersionsPath)'
+      '$(gitHubVersionsRepoInfo.userName)'
+      '$(gitHubVersionsRepoInfo.email)'
+      '$(gitHubVersionsRepoInfo.accessToken)'
+      '$(azdoVersionsRepoInfo.accessToken)'
+      '$(azdoVersionsRepoInfo.org)'
+      '$(azdoVersionsRepoInfo.project)'
+      --git-owner '$(gitHubVersionsRepoInfo.org)'
+      --git-repo '$(gitHubVersionsRepoInfo.repo)'
+      --git-branch '$(gitHubVersionsRepoInfo.branch)'
+      --git-path '$(gitHubImageInfoVersionsPath)'
+      --azdo-repo '$(azdoVersionsRepoInfo.repo)'
+      --azdo-branch '$(azdoVersionsRepoInfo.branch)'
+      --azdo-path '$(azdoImageInfoVersionsPath)'
       $(dryRunArg)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Image Info
-    # NO MICROSOFT_UPSTREAM: Add a condition that allows us to disable image info publish from the
-    # root pipeline. Enabling this publish tracked by https://github.com/microsoft/go/issues/157.
-    # Related issue about this step running unconditionally and seeming to require that the versions
-    # repo already have an image-info file: https://github.com/dotnet/docker-tools/issues/832.
-    condition: and(succeeded(), ne(variables['publishImageInfo'], 'false'))
-    # END NO MICROSOFT_UPSTREAM
   - script: >
       $(runImageBuilderCmd) ingestKustoImageInfo
       '$(artifactsPath)/image-info.json'
@@ -105,7 +107,7 @@ jobs:
       '$(kusto.imageTable)'
       '$(kusto.layerTable)'
       '$(kusto.servicePrincipalName)'
-      '$(app-DotnetDockerTelemetryIngestion-client-secret)'
+      '$(kusto.servicePrincipalPassword)'
       '$(kusto.servicePrincipalTenant)'
       --os-type '*'
       --architecture '*'

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -99,6 +99,12 @@ jobs:
       $(dryRunArg)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Image Info
+    # NO MICROSOFT_UPSTREAM: Add a condition that allows us to disable image info publish from the
+    # root pipeline. Enabling this publish tracked by https://github.com/microsoft/go/issues/157.
+    # Related issue about this step running unconditionally and seeming to require that the versions
+    # repo already have an image-info file: https://github.com/dotnet/docker-tools/issues/832.
+    condition: and(succeeded(), ne(variables['publishImageInfo'], 'false'))
+    # END NO MICROSOFT_UPSTREAM
   - script: >
       $(runImageBuilderCmd) ingestKustoImageInfo
       '$(artifactsPath)/image-info.json'

--- a/eng/common/templates/jobs/test-images-linux-client.yml
+++ b/eng/common/templates/jobs/test-images-linux-client.yml
@@ -4,6 +4,8 @@ parameters:
   matrix: {}
   testJobTimeout: 60
   preBuildValidation: false
+  internalProjectName: null
+
 jobs:
 - job: ${{ parameters.name }}
   ${{ if eq(parameters.preBuildValidation, 'false') }}:
@@ -19,3 +21,4 @@ jobs:
   - template: ../steps/test-images-linux-client.yml
     parameters:
       preBuildValidation: ${{ parameters.preBuildValidation }}
+      internalProjectName: ${{ parameters.internalProjectName }}

--- a/eng/common/templates/jobs/test-images-windows-client.yml
+++ b/eng/common/templates/jobs/test-images-windows-client.yml
@@ -3,6 +3,8 @@ parameters:
   pool: {}
   matrix: {}
   testJobTimeout: 60
+  internalProjectName: null
+
 jobs:
 - job: ${{ parameters.name }}
   condition: and(succeeded(), ${{ parameters.matrix }})
@@ -13,3 +15,5 @@ jobs:
   timeoutInMinutes: ${{ parameters.testJobTimeout }}
   steps:
   - template: ../steps/test-images-windows-client.yml
+    parameters:
+      internalProjectName: ${{ parameters.internalProjectName }}

--- a/eng/common/templates/jobs/validate-image-sizes.yml
+++ b/eng/common/templates/jobs/validate-image-sizes.yml
@@ -1,5 +1,9 @@
+parameters:
+  internalProjectName: null
+  publicProjectName: null
+
 jobs:
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
   # Split the Linux images into separate jobs in order to compensate for less
   # disk space on the Linux agents. See https://github.com/dotnet/dotnet-docker/issues/1588
   - job: LinuxAmd64PerfTests
@@ -42,5 +46,5 @@ jobs:
   - template: ../steps/validate-image-sizes.yml
     parameters:
       dockerClientOS: windows
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
         validationMode: integrity

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -4,6 +4,8 @@ parameters:
   buildMatrixCustomBuildLegGroupArgs: ""
   testMatrixCustomBuildLegGroupArgs: ""
   customBuildInitSteps: []
+  customPublishInitSteps: []
+  customPublishVariables: []
   
   linuxAmdBuildJobTimeout: 60
   linuxArmBuildJobTimeout: 60
@@ -13,10 +15,31 @@ parameters:
   linuxArmTestJobTimeout: 60
   windowsAmdTestJobTimeout: 60
 
-  linuxAmd64BuildPool:
-    vmImage: $(defaultLinuxAmd64PoolImage)
-
   noCache: false
+
+  internalProjectName: null
+  publicProjectName: null
+
+  internalVersionsRepoRef: null
+  publicVersionsRepoRef: null
+
+  linuxAmd64Pool:
+    vmImage: $(defaultLinuxAmd64PoolImage)
+  linuxArm32Pool:
+    vmImage: $(defaultLinuxArm32PoolImage)
+  linuxArm64Pool:
+    vmImage: $(defaultLinuxArm64PoolImage)
+  windows2016Pool:
+    vmImage: $(defaultWindows2016PoolImage)
+  windows1809Pool:
+    vmImage: $(defaultWindows1809PoolImage)
+  windows2004Pool:
+    vmImage: $(defaultWindows2004PoolImage)
+  windows20H2Pool:
+    vmImage: $(defaultWindows20H2PoolImage)
+  windows2022Pool:
+    vmImage: $(defaultWindows2022PoolImage)
+
 stages:
 
 ################################################################################
@@ -28,105 +51,129 @@ stages:
   - template: ../jobs/test-images-linux-client.yml
     parameters:
       name: PreBuildValidation
-      pool:
-        vmImage: $(defaultLinuxAmd64PoolImage)
+      pool: ${{ parameters.linuxAmd64Pool }}
       testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
       preBuildValidation: true
+      internalProjectName: ${{ parameters.internalProjectName }}
   - template: ../jobs/copy-base-images.yml
     parameters:
       name: CopyBaseImages
+      pool: ${{ parameters.linuxAmd64Pool }}
       additionalOptions: "--manifest '$(manifest)' $(manifestVariables)"
+      publicProjectName: ${{ parameters.publicProjectName }}
   - template: ../jobs/generate-matrix.yml
     parameters:
       matrixType: ${{ parameters.buildMatrixType }}
       name: GenerateBuildMatrix
+      pool: ${{ parameters.linuxAmd64Pool }}
       customBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
+      internalProjectName: ${{ parameters.internalProjectName }}
+      internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
+      publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
   - template: ../jobs/build-images.yml
     parameters:
       name: Linux_amd64
-      pool: ${{ parameters.linuxAmd64BuildPool }}
+      pool: ${{ parameters.linuxAmd64Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxAmd64']
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
+      internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
+      publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
   - template: ../jobs/build-images.yml
     parameters:
       name: Linux_arm64v8
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: DotNetCore-Docker-Public
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: DotNetCore-Docker
-        demands:
-        - Agent.OS -equals linux
-        - Agent.OSArchitecture -equals ARM64
+      pool: ${{ parameters.linuxArm64Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm64v8']
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
+      internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
+      publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
   - template: ../jobs/build-images.yml
     parameters:
       name: Linux_arm32v7
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: DotNetCore-Docker-Public
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: DotNetCore-Docker
-        demands:
-        - Agent.OS -equals linux
-        - Agent.OSArchitecture -equals ARM64
+      pool: ${{ parameters.linuxArm32Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm32v7']
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
+      internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
+      publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
   - template: ../jobs/build-images.yml
     parameters:
       name: Windows1809_amd64
-      pool: Docker-1809-${{ variables['System.TeamProject'] }}
+      pool: ${{ parameters.windows1809Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows1809Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
+      internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
+      publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
   - template: ../jobs/build-images.yml
     parameters:
       name: Windows2004_amd64
-      pool: Docker-2004-${{ variables['System.TeamProject'] }}
+      pool: ${{ parameters.windows2004Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows2004Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
+      internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
+      publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
   - template: ../jobs/build-images.yml
     parameters:
       name: Windows20H2_amd64
-      pool: Docker-20H2-${{ variables['System.TeamProject'] }}
+      pool: ${{ parameters.windows20H2Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows20H2Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
+      internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
+      publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
   - template: ../jobs/build-images.yml
     parameters:
       name: Windows2022_amd64
-      pool: Docker-2022-${{ variables['System.TeamProject'] }}
+      pool: ${{ parameters.windows2022Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.WindowsLtsc2022Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
+      internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
+      publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
   - template: ../jobs/build-images.yml
     parameters:
       name: WindowsLtsc2016_amd64
-      pool: Docker-2016-${{ variables['System.TeamProject'] }}
+      pool: ${{ parameters.windows2016Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.WindowsLtsc2016Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
       noCache: ${{ parameters.noCache }}
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
+      internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
+      publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
 
 ################################################################################
 # Post-Build
@@ -140,7 +187,7 @@ stages:
 ################################################################################
 # Test Images
 ################################################################################
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
   - stage: Test
     dependsOn: Post_Build
     condition: "
@@ -158,74 +205,76 @@ stages:
       parameters:
         matrixType: ${{ parameters.testMatrixType }}
         name: GenerateTestMatrix
+        pool: ${{ parameters.linuxAmd64Pool }}
         customBuildLegGroupArgs: ${{ parameters.testMatrixCustomBuildLegGroupArgs }}
         isTestStage: true
+        internalProjectName: ${{ parameters.internalProjectName }}
+        publicProjectName: ${{ parameters.publicProjectName }}
 
     - template: ../jobs/test-images-linux-client.yml
       parameters:
         name: Linux_amd64
-        pool:
-          vmImage: $(defaultLinuxAmd64PoolImage)
+        pool: ${{ parameters.linuxAmd64Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxAmd64']
         testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
+        internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-linux-client.yml
       parameters:
         name: Linux_arm64v8
-        pool:
-          name: DotNetCore-Docker
-          demands:
-          - Agent.OS -equals linux
-          - Agent.OSArchitecture -equals ARM64
+        pool: ${{ parameters.linuxArm64Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm64v8']
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
+        internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-linux-client.yml
       parameters:
         name: Linux_arm32v7
-        pool:
-          name: DotNetCore-Docker
-          demands:
-          - Agent.OS -equals linux
-          - Agent.OSArchitecture -equals ARM64
+        pool: ${{ parameters.linuxArm32Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm32v7']
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
+        internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows1809_amd64
-        pool: Docker-1809-${{ variables['System.TeamProject'] }}
+        pool: ${{ parameters.windows1809Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1809Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
+        internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows2004_amd64
-        pool: Docker-2004-${{ variables['System.TeamProject'] }}
+        pool: ${{ parameters.windows2004Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows2004Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
+        internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows20H2_amd64
-        pool: Docker-20H2-${{ variables['System.TeamProject'] }}
+        pool: ${{ parameters.windows20H2Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows20H2Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
+        internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: Windows2022_amd64
-        pool: Docker-2022-${{ variables['System.TeamProject'] }}
+        pool: ${{ parameters.windows2022Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.WindowsLtsc2022Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
+        internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-windows-client.yml
       parameters:
         name: WindowsLtsc2016_amd64
-        pool: Docker-2016-${{ variables['System.TeamProject'] }}
+        pool: ${{ parameters.windows2016Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.WindowsLtsc2016Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
+        internalProjectName: ${{ parameters.internalProjectName }}
 
 ################################################################################
 # Publish Images
 ################################################################################
 - stage: Publish
-  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
     dependsOn: Test
-  ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
     dependsOn: Post_Build
   condition: "
     and(
@@ -257,5 +306,7 @@ stages:
   jobs:
   - template: ../jobs/publish.yml
     parameters:
-      pool:
-        vmImage: $(defaultLinuxAmd64PoolImage)
+      pool: ${{ parameters.linuxAmd64Pool }}
+      internalProjectName: ${{ parameters.internalProjectName }}
+      customPublishVariables: ${{ parameters.customPublishVariables }}
+      customInitSteps: ${{ parameters.customPublishInitSteps }}

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -1,0 +1,62 @@
+# A wrapper template around the common build-test-publish-repo template with settings
+# specific to the .NET team's infrastructure.
+
+parameters:
+  noCache: false
+  internalProjectName: null
+  publicProjectName: null
+  buildMatrixCustomBuildLegGroupArgs: ""
+  customBuildInitSteps: []
+  customPublishInitSteps: []
+  windowsAmdBuildJobTimeout: 60
+  windowsAmdTestJobTimeout: 60
+  linuxAmdBuildJobTimeout: 60
+  linuxAmd64Pool:
+    vmImage: $(defaultLinuxAmd64PoolImage)
+  buildMatrixType: platformDependencyGraph
+  testMatrixType: platformVersionedOs
+
+stages:
+- template: ../build-test-publish-repo.yml
+  parameters:
+    noCache: ${{ parameters.noCache }}
+    internalProjectName: ${{ parameters.internalProjectName }}
+    publicProjectName: ${{ parameters.publicProjectName }}
+    buildMatrixCustomBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
+    customBuildInitSteps: ${{ parameters.customBuildInitSteps }}
+    customPublishInitSteps: ${{ parameters.customPublishInitSteps }}
+    windowsAmdBuildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
+    windowsAmdTestJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
+    linuxAmdBuildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
+    buildMatrixType: ${{ parameters.buildMatrixType }}
+    testMatrixType: ${{ parameters.testMatrixType }}
+
+    internalVersionsRepoRef: InternalVersionsRepo
+    publicVersionsRepoRef: PublicVersionsRepo
+    
+    ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+      customPublishVariables:
+      - group: DotNet-AllOrgs-Darc-Pats
+
+    linuxAmd64Pool: ${{ parameters.linuxAmd64Pool }}
+    linuxArm64Pool:
+        ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+          name: DotNetCore-Docker-Public
+        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+          name: DotNetCore-Docker
+        demands:
+        - Agent.OS -equals linux
+        - Agent.OSArchitecture -equals ARM64
+    linuxArm32Pool:
+        ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+          name: DotNetCore-Docker-Public
+        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+          name: DotNetCore-Docker
+        demands:
+        - Agent.OS -equals linux
+        - Agent.OSArchitecture -equals ARM64
+    windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
+    windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
+    windows2004Pool: Docker-2004-${{ variables['System.TeamProject'] }}
+    windows20H2Pool: Docker-20H2-${{ variables['System.TeamProject'] }}
+    windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}

--- a/eng/common/templates/steps/publish-readmes.yml
+++ b/eng/common/templates/steps/publish-readmes.yml
@@ -3,23 +3,13 @@ parameters:
   condition: true
 
 steps:
-- powershell: >
-    if ($env:SOURCEBRANCH -eq "nightly" -or $env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "nightly") {
-        $additionalPublishMcrDocsArgs = "--exclude-product-family"
-    }
-    else {
-        $additionalPublishMcrDocsArgs = ""
-    }
-
-    echo "##vso[task.setvariable variable=additionalPublishMcrDocsArgs]$additionalPublishMcrDocsArgs"
-  displayName: Set publishMcrDocs Args
 - script: >
     $(runImageBuilderCmd) publishMcrDocs
     --manifest '$(manifest)'
     --registry-override '$(acr.server)'
-    '$(dotnetDockerBot.userName)'
-    '$(dotnetDockerBot.email)'
-    '$(BotAccount-dotnet-docker-bot-PAT)'
+    '$(mcrDocsRepoInfo.userName)'
+    '$(mcrDocsRepoInfo.email)'
+    '$(mcrDocsRepoInfo.accessToken)'
     '$(publicGitRepoUri)'
     ${{ parameters.dryRunArg }}
     $(manifestVariables)

--- a/eng/common/templates/steps/set-dry-run.yml
+++ b/eng/common/templates/steps/set-dry-run.yml
@@ -2,7 +2,7 @@ steps:
 - script: |
       # Use dry-run option for certain publish operations if this is not a production build
       dryRunArg=""
-      if [[ "$PUBLISHREPOPREFIX" != "public/" || "$SYSTEM_TEAMPROJECT" == "public" ]]; then
+      if [[ "$PUBLISHREPOPREFIX" != "$OFFICIALREPOPREFIX" || "$SYSTEM_TEAMPROJECT" == "$PUBLICPROJECTNAME" ]]; then
         dryRunArg=" --dry-run"
       fi
       

--- a/eng/common/templates/steps/set-image-info-path-var.yml
+++ b/eng/common/templates/steps/set-image-info-path-var.yml
@@ -1,19 +1,25 @@
-steps:
-- powershell: >
-    $buildRepoName = $env:BUILD_REPOSITORY_NAME.Replace("/", "-")
+parameters:
+  publicSourceBranch: null
 
-      # publicSourceBranch is not necessarily the working branch, it is the branch referenced in the readme Dockerfile source links
-    if ($env:PUBLICSOURCEBRANCH) {
-        $publicSourceBranch = $env:PUBLICSOURCEBRANCH
-    }
-    elseif (-not $env:MANIFEST.Contains("samples") -and ($env:SOURCEBRANCH -eq "nightly" -or $env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "nightly")) {
-        $publicSourceBranch = "nightly"
+steps:
+- powershell: |
+    if ("$(System.TeamProject)" -eq "$(publicProjectName)") {
+        $basePath = "$(gitHubVersionsRepoInfo.path)"
     }
     else {
-        $publicSourceBranch = "main"
+        $basePath= "$(azdoVersionsRepoInfo.path)"
     }
 
-    $imageInfoVersionsPath = "build-info/docker/image-info.$buildRepoName-$publicSourceBranch$env:IMAGEINFOVARIANT.json"
+    $publicSourceBranch = "${{ parameters.publicSourceBranch }}"
 
-    echo "##vso[task.setvariable variable=imageInfoVersionsPath]$imageInfoVersionsPath"
-  displayName: Set Image Info Path Var
+    if ($publicSourceBranch -eq "") {
+        throw "publicSourceBranch variable is not set"
+    }
+
+    $buildRepoName = "$(Build.Repository.Name)".Replace("/", "-")
+    $imageInfoName = "image-info.$buildRepoName-$publicSourceBranch$(imageInfoVariant).json"
+
+    echo "##vso[task.setvariable variable=imageInfoVersionsPath]$basePath/$imageInfoName"
+    echo "##vso[task.setvariable variable=gitHubImageInfoVersionsPath]$(gitHubVersionsRepoInfo.path)/$imageInfoName"
+    echo "##vso[task.setvariable variable=azdoImageInfoVersionsPath]$(azdoVersionsRepoInfo.path)/$imageInfoName"
+  displayName: Set Image Info Path Vars

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -1,5 +1,6 @@
 parameters:
   preBuildValidation: false
+  internalProjectName: null
   condition: true
 
 steps:
@@ -7,7 +8,7 @@ steps:
   parameters:
     setupImageBuilder: false
     setupTestRunner: true
-    cleanupDocker: ${{ eq(variables['System.TeamProject'], 'internal') }}
+    cleanupDocker: ${{ eq(variables['System.TeamProject'], parameters.internalProjectName) }}
     condition: ${{ parameters.condition }}
 - script: |
     echo "##vso[task.setvariable variable=testRunner.container]testrunner-$(Build.BuildId)-$(System.JobId)"
@@ -16,7 +17,7 @@ steps:
     if [ "${{ parameters.preBuildValidation }}" == "true" ]; then
       optionalTestArgs="$optionalTestArgs -TestCategories pre-build"
     else
-      if [ "${{ eq(variables['System.TeamProject'], 'public') }}" == "False" ]; then
+      if [ "${{ variables['System.TeamProject'] }}" == "${{ parameters.internalProjectName }}" ]; then
         optionalTestArgs="$optionalTestArgs -PullImages -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
       fi
       if [ "$REPOTESTARGS" != "" ]; then
@@ -35,11 +36,11 @@ steps:
     $(imageNames.testRunner.withrepo)
   displayName: Start Test Runner Container
   condition: and(succeeded(), ${{ parameters.condition }})
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
   - script: >
       docker exec $(testRunner.container) pwsh
       -File $(engCommonRelativePath)/Invoke-WithRetry.ps1
-      "docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)"
+      "docker login -u $(acr.userName) -p $(acr.password) $(acr.server)"
     displayName: Docker login
     condition: and(succeeded(), ${{ parameters.condition }})
   - ${{ if eq(parameters.preBuildValidation, 'false') }}:
@@ -51,12 +52,12 @@ steps:
     docker exec $(testRunner.container) pwsh
     -File $(testScriptPath)
     -Version '$(productVersion)'
-    -OS '$(osVariant)*'
+    -OS '$(osVariant)'
     -Architecture '$(architecture)'
     $(optionalTestArgs)
   displayName: Test Images
   condition: and(succeeded(), ${{ parameters.condition }})
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
   - script: docker exec $(testRunner.container) docker logout $(acr.server)
     displayName: Docker logout
     condition: and(always(), ${{ parameters.condition }})
@@ -86,7 +87,7 @@ steps:
   displayName: Cleanup TestRunner Container
   condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
   - template: cleanup-docker-linux.yml
     parameters:
       condition: ${{ parameters.condition }}

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -1,19 +1,20 @@
 parameters:
+  internalProjectName: null
   condition: true
 
 steps:
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
   - template: init-docker-windows.yml
     parameters:
       setupImageBuilder: false
       condition: ${{ parameters.condition }}
   - powershell: >
       $(engCommonPath)/Invoke-WithRetry.ps1
-      "cmd /c 'docker login -u $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server) 2>&1'"
+      "cmd /c 'docker login -u $(acr.userName) --password $(acr.password) $(acr.server) 2>&1'"
     displayName: Docker login
     condition: and(succeeded(), ${{ parameters.condition }})
 - powershell: |
-    if ("${{ eq(variables['System.TeamProject'], 'public') }}" -eq "False") {
+    if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}") {
       $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
     } 
     if ($env:REPOTESTARGS) {
@@ -25,7 +26,7 @@ steps:
 - powershell: Get-ChildItem -Path tests -r | Where {$_.Extension -match "trx"} | Remove-Item
   displayName: Cleanup Old Test Results
   condition: and(succeeded(), ${{ parameters.condition }})
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
   - template: ../steps/download-build-artifact.yml
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
@@ -37,7 +38,7 @@ steps:
     $(optionalTestArgs)
   displayName: Test Images
   condition: and(succeeded(), ${{ parameters.condition }})
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
   - script: docker logout $(acr.server)
     displayName: Docker logout
     condition: and(always(), ${{ parameters.condition }})
@@ -52,7 +53,7 @@ steps:
     mergeTestResults: true
     publishRunAttachments: true
     testRunTitle: $(productVersion) $(osVariant) amd64
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
   - template: cleanup-docker-windows.yml
     parameters:
       condition: ${{ parameters.condition }}

--- a/eng/common/templates/steps/validate-branch.yml
+++ b/eng/common/templates/steps/validate-branch.yml
@@ -1,8 +1,11 @@
+parameters:
+  internalProjectName: null
+
 steps:
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
   - script: |
       if [[ "$OFFICIALBRANCHES" != *\'$SOURCEBRANCH\'* && \
-            "$PUBLISHREPOPREFIX" == "public/" && \
+            "$PUBLISHREPOPREFIX" == "$OFFICIALREPOPREFIX" && \
             "$OVERRIDEOFFICIALBRANCHVALIDATION" != "true" ]]; then
           echo "##vso[task.logissue type=error]Official builds must be done from an official branch: $OFFICIALBRANCHES"
           exit 1

--- a/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
@@ -8,7 +8,7 @@ steps:
     $(runImageBuilderCmd) waitForMcrDocIngestion
     '${{ parameters.commitDigest }}'
     '$(mcrStatus.servicePrincipalName)'
-    '$(app-DotnetDockerMcrStatusApi-client-secret)'
+    '$(mcrStatus.servicePrincipalPassword)'
     '$(mcrStatus.servicePrincipalTenant)'
     --timeout '$(mcrDocIngestionTimeout)'
     ${{ parameters.dryRunArg }}

--- a/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
@@ -9,7 +9,7 @@ steps:
     $(runImageBuilderCmd) waitForMcrImageIngestion
     '${{ parameters.imageInfoPath }}'
     '$(mcrStatus.servicePrincipalName)'
-    '$(app-DotnetDockerMcrStatusApi-client-secret)'
+    '$(mcrStatus.servicePrincipalPassword)'
     '$(mcrStatus.servicePrincipalTenant)'
     --manifest '$(manifest)'
     --min-queue-time '${{ parameters.minQueueTime }}'

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -19,8 +19,6 @@ variables:
   value: true
 - name: manifestVariables
   value: ""
-- name: defaultLinuxAmd64PoolImage
-  value: ubuntu-latest
 - name: mcrImageIngestionTimeout
   value: "00:20:00"
 - name: mcrDocIngestionTimeout
@@ -32,3 +30,20 @@ variables:
   value: 'mirror/'
 - name: cgBuildGrepArgs
   value: "''"
+
+- name: defaultLinuxAmd64PoolImage
+  value: ubuntu-latest
+- name: defaultLinuxArm32PoolImage
+  value: null
+- name: defaultLinuxArm64PoolImage
+  value: null
+- name: defaultWindows2016PoolImage
+  value: vs2017-win2016
+- name: defaultWindows1809PoolImage
+  value: windows-2019
+- name: defaultWindows2004PoolImage
+  value: null
+- name: defaultWindows20H2PoolImage
+  value: null
+- name: defaultWindows2022PoolImage
+  value: windows-2022

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1383683
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1442784
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -1,0 +1,57 @@
+# Common variables for building/testing/publishing in the .NET team's pipelines
+
+variables:
+- template: common.yml
+
+- name: commonVersionsImageInfoPath
+  value: build-info/docker
+- name: publicGitRepoUri
+  value: https://github.com/dotnet/dotnet-docker
+- name: testScriptPath
+  value: ./tests/run-tests.ps1
+- name: testResultsDirectory
+  value: tests/Microsoft.DotNet.Docker.Tests/TestResults/
+- name: officialRepoPrefix
+  value: public/
+
+- name: mcrDocsRepoInfo.accessToken
+  value: $(BotAccount-dotnet-docker-bot-PAT)
+- name: mcrDocsRepoInfo.userName
+  value: $(dotnetDockerBot.userName)
+- name: mcrDocsRepoInfo.email
+  value: $(dotnetDockerBot.email)
+
+- name: gitHubVersionsRepoInfo.org
+  value: dotnet
+- name: gitHubVersionsRepoInfo.repo
+  value: versions
+- name: gitHubVersionsRepoInfo.branch
+  value: main
+- name: gitHubVersionsRepoInfo.path
+  value: ${{ variables.commonVersionsImageInfoPath }}
+- name: gitHubVersionsRepoInfo.accessToken
+  value: $(BotAccount-dotnet-docker-bot-PAT)
+- name: gitHubVersionsRepoInfo.userName
+  value: $(dotnetDockerBot.userName)
+- name: gitHubVersionsRepoInfo.email
+  value: $(dotnetDockerBot.email)
+
+- name: azdoVersionsRepoInfo.org
+  value: dnceng
+- name: azdoVersionsRepoInfo.project
+  value: ${{ variables.internalProjectName }}
+- name: azdoVersionsRepoInfo.repo
+  value: dotnet-versions
+- name: azdoVersionsRepoInfo.branch
+  value: main
+- name: azdoVersionsRepoInfo.path
+  value: ${{ variables.commonVersionsImageInfoPath }}
+- name: azdoVersionsRepoInfo.accessToken
+  value: $(dn-bot-devdiv-dnceng-rw-code-pat)
+
+- name: kusto.servicePrincipalPassword
+  value: $(app-DotnetDockerTelemetryIngestion-client-secret)
+- name: mcrStatus.servicePrincipalPassword
+  value: $(app-DotnetDockerMcrStatusApi-client-secret)
+- name: acr.password
+  value: $(BotAccount-dotnet-docker-acr-bot-password)

--- a/eng/common/templates/variables/dotnet/common.yml
+++ b/eng/common/templates/variables/dotnet/common.yml
@@ -1,0 +1,14 @@
+variables:
+- template: ../common.yml
+- name: publicProjectName
+  value: public
+- name: internalProjectName
+  value: internal
+- name: mirrorRegistryCreds
+  value: --registry-creds 'docker.io=$(dotnetDockerHubBot.userName);$(BotAccount-dotnet-dockerhub-bot-PAT)'
+- name: acr.servicePrincipalPassword
+  value: $(app-dotnetdockerbuild-client-secret)
+
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - group: DotNet-Docker-Common
+  - group: DotNet-Docker-Secrets

--- a/eng/pipeline/go-docker-pr-pipeline.yml
+++ b/eng/pipeline/go-docker-pr-pipeline.yml
@@ -3,13 +3,13 @@ pr:
   branches:
     include:
       - microsoft/*
+      - dev/official/*
 
 variables:
   - template: variables/common.yml
 
 stages:
-  - template: ../common/templates/stages/build-test-publish-repo.yml
+  - template: stages/build-test-publish-repo.yml
     parameters:
-      buildMatrixType: platformVersionedOs
-      buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group build
-      noCache: true
+      extraParameters:
+        buildMatrixType: platformVersionedOs

--- a/eng/pipeline/go-docker-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline.yml
@@ -3,13 +3,11 @@ trigger:
   branches:
     include:
       - microsoft/*
+      - dev/official/*
 pr: none
 
 variables:
   - template: variables/common.yml
 
 stages:
-  - template: ../common/templates/stages/build-test-publish-repo.yml
-    parameters:
-      buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group build
-      noCache: true
+  - template: stages/build-test-publish-repo.yml

--- a/eng/pipeline/stages/build-test-publish-repo.yml
+++ b/eng/pipeline/stages/build-test-publish-repo.yml
@@ -1,0 +1,25 @@
+# Create Go Docker image build and publish stages.
+parameters:
+  extraParameters: []
+
+stages:
+  - template: ../../common/templates/stages/build-test-publish-repo.yml
+    parameters:
+      buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group build
+      noCache: true
+      internalProjectName: ${{ variables.internalProjectName }}
+      publicProjectName: ${{ variables.publicProjectName }}
+      # Template paths must be relative to the YAML job that executes them
+      customBuildInitSteps:
+        - template: ../../../pipeline/steps/set-public-source-branch-var.yml
+      customPublishInitSteps:
+        - template: ../../../pipeline/steps/set-public-source-branch-var.yml
+      # On Windows, 'docker login' is incompatible with 'manifest-tool' unless we use these pools.
+      # https://github.com/dotnet/docker-tools/issues/905
+      windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
+      windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
+      windows2004Pool: Docker-2004-${{ variables['System.TeamProject'] }}
+      windows20H2Pool: Docker-20H2-${{ variables['System.TeamProject'] }}
+      windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}
+      ${{ each pair in parameters.extraParameters }}:
+        ${{ pair.key }}: ${{ pair.value }}

--- a/eng/pipeline/steps/set-public-source-branch-var.yml
+++ b/eng/pipeline/steps/set-public-source-branch-var.yml
@@ -1,0 +1,34 @@
+# The "publicSourceBranch" variable is used by .NET Docker infra templates as part of the image info
+# filename in dotnet/versions. This is used to cache metadata about the results of previous builds
+# to allow features like skipping builds of unchanged images. So, simplify "microsoft/main" to
+# "main" and "microsoft/nightly" to "nightly". For PRs, use "main" as the image info source unless
+# the PR is merging into "nightly". Also handle dev branch targets.
+#
+# See https://github.com/dotnet/dotnet-docker/blob/480e62a/eng/pipelines/steps/set-public-source-branch-var.yml
+steps:
+- powershell: |
+    # Make simple string vars for source branch and PR branch (or empty string if not a PR).
+    $s = "$(sourceBranch)"
+    $pr = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
+    if (-not $pr) {
+        $pr = ""
+    }
+
+    if ($pr.StartsWith("dev/official/")) {
+        $publicSourceBranch = $pr
+    }
+    elseif ($s.StartsWith("dev/official/")) {
+        $publicSourceBranch = $s
+    }
+    elseif ($s -eq "microsoft/nightly" -or $pr -eq "microsoft/nightly") {
+        $publicSourceBranch = "nightly"
+    }
+    else {
+        $publicSourceBranch = "main"
+    }
+
+    # Make branch usable as filename. E.g. change "dev/official/feature" to "dev-official-feature".
+    $publicSourceBranch = $publicSourceBranch -replace "/","-"
+
+    echo "##vso[task.setvariable variable=publicSourceBranch]$publicSourceBranch"
+  displayName: Set Public Source Branch Var

--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -1,7 +1,18 @@
 variables:
 - template: ../../common/templates/variables/common.yml
+
+- name: publicProjectName
+  value: public
+- name: internalProjectName
+  value: internal
+
+- name: commonVersionsImageInfoPath
+  value: build-info/docker
 - name: publicGitRepoUri
   value: https://github.com/microsoft/go
+- name: officialRepoPrefix
+  value: public/
+
 - name: publishReadme
   value: false
 # https://github.com/microsoft/go/issues/157 tracks enabling publishImageInfo.
@@ -10,21 +21,27 @@ variables:
 # https://github.com/microsoft/go/issues/192 tracks enabling ingestKustoImageInfo.
 - name: ingestKustoImageInfo
   value: false
-- name: productVersionComponents
-  value: 2
+
 - name: officialBranches
   # list multiple branches as "'branch1', 'branch2', etc."
   value: "'microsoft/main'"
+
 - name: manifest
   value: manifest.json
+
+# dotnet/versions repo path info is used in shared templates. Even though we aren't publishing
+# there, it needs to be specified to avoid pipeline errors when the variable is referenced in tasks.
+- name: gitHubVersionsRepoInfo.path
+  value: ${{ variables.commonVersionsImageInfoPath }}
+- name: azdoVersionsRepoInfo.path
+  value: ${{ variables.commonVersionsImageInfoPath }}
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: go-docker-common
   - group: go-docker-secrets
   - group: go-docker-shared-DotNet-Docker-Secrets
 
-# Map go-docker secrets onto the dotnet-docker secret names that the templates assume we're using.
-- name: BotAccount-dotnet-docker-acr-bot-password
+- name: acr.password
   value: $(BotAccount-golang-docker-acr-bot-password)
-- name: app-dotnetdockerbuild-client-secret
+- name: acr.servicePrincipalPassword
   value: $(GolangDockerBuild)


### PR DESCRIPTION
Updating the tooling to match up with https://github.com/dotnet/dotnet-docker/commit/480e62a makes the templates less hard-coded, which should let us build `dev/official/*` branches and handle our `microsoft/` prefix better. It's also good, generally speaking, to keep up to date in case we need to take infra fixes quickly.

* In the short term, helps with https://github.com/microsoft/go/issues/268
* Later, helps with https://github.com/microsoft/go/issues/179

---

The first commit is a pure copy and doesn't require review. All my work is in the second commit.