### PR TITLE
Move "variables.[...]ProjectName" template expressions to pipeline yml

### DIFF
--- a/eng/pipeline/go-docker-pr-pipeline.yml
+++ b/eng/pipeline/go-docker-pr-pipeline.yml
@@ -12,4 +12,7 @@ stages:
   - template: stages/build-test-publish-repo.yml
     parameters:
       extraParameters:
+        # "variables.x" syntax only gets correct values in pipeline file and need to be passed down.
+        internalProjectName: ${{ variables.internalProjectName }}
+        publicProjectName: ${{ variables.publicProjectName }}
         buildMatrixType: platformVersionedOs

--- a/eng/pipeline/go-docker-pr-pipeline.yml
+++ b/eng/pipeline/go-docker-pr-pipeline.yml
@@ -12,7 +12,8 @@ stages:
   - template: stages/build-test-publish-repo.yml
     parameters:
       extraParameters:
-        # "variables.x" syntax only gets correct values in pipeline file and need to be passed down.
+        # "variables.x" template expression only gets the correct value in this pipeline file. In a
+        # stage template, it returns an empty string. So, evaluate it here and pass it through.
         internalProjectName: ${{ variables.internalProjectName }}
         publicProjectName: ${{ variables.publicProjectName }}
         buildMatrixType: platformVersionedOs

--- a/eng/pipeline/go-docker-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline.yml
@@ -11,3 +11,8 @@ variables:
 
 stages:
   - template: stages/build-test-publish-repo.yml
+    parameters:
+      extraParameters:
+        # "variables.x" syntax only gets correct values in pipeline file and need to be passed down.
+        internalProjectName: ${{ variables.internalProjectName }}
+        publicProjectName: ${{ variables.publicProjectName }}

--- a/eng/pipeline/go-docker-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline.yml
@@ -13,6 +13,7 @@ stages:
   - template: stages/build-test-publish-repo.yml
     parameters:
       extraParameters:
-        # "variables.x" syntax only gets correct values in pipeline file and need to be passed down.
+        # "variables.x" template expression only gets the correct value in this pipeline file. In a
+        # stage template, it returns an empty string. So, evaluate it here and pass it through.
         internalProjectName: ${{ variables.internalProjectName }}
         publicProjectName: ${{ variables.publicProjectName }}

--- a/eng/pipeline/stages/build-test-publish-repo.yml
+++ b/eng/pipeline/stages/build-test-publish-repo.yml
@@ -1,14 +1,12 @@
 # Create Go Docker image build and publish stages.
 parameters:
-  extraParameters: []
+  extraParameters: {}
 
 stages:
   - template: ../../common/templates/stages/build-test-publish-repo.yml
     parameters:
       buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group build
       noCache: true
-      internalProjectName: ${{ variables.internalProjectName }}
-      publicProjectName: ${{ variables.publicProjectName }}
       # Template paths must be relative to the YAML job that executes them
       customBuildInitSteps:
         - template: ../../../pipeline/steps/set-public-source-branch-var.yml


### PR DESCRIPTION
* Fixes https://github.com/microsoft/go/issues/282

I looked at the differences between our pipeline and https://github.com/dotnet/dotnet-docker/blob/main/eng/pipelines/dotnet-core-nightly.yml, and found this.

I moved our `${{ variables.publicProjectName }}` from our stage template file to the pipeline yml, which seems absurd to me, but it fixed a test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1477194&view=results. 