### PR TITLE
Add dev/official/go1.17-openssl-fips as official branch

### DIFF
--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -24,7 +24,7 @@ variables:
 
 - name: officialBranches
   # list multiple branches as "'branch1', 'branch2', etc."
-  value: "'microsoft/main'"
+  value: "'microsoft/main','dev/official/go1.17-openssl-fips'"
 
 - name: manifest
   value: manifest.json


### PR DESCRIPTION
This allows the `dev/official/go1.17-openssl-fips` to run an official build and publish to MCR. The branch name is matched up to this value here:

https://github.com/microsoft/go-images/blob/44ceed11f2bda2cc74f303fba72baf735302ead4/eng/common/templates/steps/validate-branch.yml#L7-L10

---

We can propose a change to this .NET Docker infra template to let us make it allow `dev/official/*`. Or, we can inject some more conditions via the AzDO variable because it's evaluated before the script runs. For now, keep it simple and add the current branch. It won't harm anything if we forget about it and merge it into `microsoft/main` later.

We have an issue tracking this kind of issue more broadly:
* https://github.com/microsoft/go/issues/195