### PR TITLE
Install iana-etc in cbl-mariner image

### DIFF
--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -33,6 +33,7 @@ RUN tdnf install -y \
 		glibc \
 		glibc-devel \
 		kernel-headers \
+		iana-etc \
 {{
 	if is_fips then (
 -}}

--- a/src/microsoft/1.17/cbl-mariner1.0.20211027/Dockerfile
+++ b/src/microsoft/1.17/cbl-mariner1.0.20211027/Dockerfile
@@ -12,6 +12,7 @@ RUN tdnf install -y \
 		glibc \
 		glibc-devel \
 		kernel-headers \
+		iana-etc \
 		# Install OpenSSL for headers when building a FIPS-compatible app with Go.
 		openssl-devel \
 	; \


### PR DESCRIPTION
Some `net` tests require `/etc/services` to exist and contain meaningful data, else they fail.

CBL-Mariner does not come with that file pre-installed, but we can get it from  the `iana-etc` package.

Example of failing tests due to this issue:

```sh
root [ /usr/local/src/go/src ]# go test net
--- FAIL: TestCgoLookupPort (0.00s)
    cgo_unix_test.go:50: lookup tcp/smtp: Servname not supported for ai_socktype
--- FAIL: TestCgoLookupPortWithCancel (0.00s)
    cgo_unix_test.go:63: lookup tcp/smtp: Servname not supported for ai_socktype
--- FAIL: TestReadLine (0.00s)
    parse_test.go:24: open /etc/services: no such file or directory
FAIL
FAIL    net     45.867s
FAIL
```