### PR TITLE
Add tag listing instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Microsoft build of Go produced by the
 
 See [eng/README.md](eng/README.md) for information about the infrastructure.
 
+To view the list of available tags:
+
+* Microsoft Container Registry API: https://mcr.microsoft.com/v2/oss/go/microsoft/alpha/golang/tags/list
+  * The full tag URL is `mcr.microsoft.com/{name}:{tag}`
+* AZCU Indexer (Microsoft auth required): https://azcuindexer.azurewebsites.net/repositories/oss/go/microsoft/alpha/golang
+  * Click on a tag name to copy the full tag URL to your clipboard
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a


### PR DESCRIPTION
Add links to locations to list our alpha tags, and briefly describe how to turn the public MCR API response into a full tag URL you can put in a Docker command.

Once we have non-alpha tags, the main readme can switch over to just the "release" tags, or release + nightly.