### PR TITLE
Add Mariner image that uses the OpenSSL/FIPS build of Go

### DIFF
--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -4,6 +4,16 @@
 	;
 	def alpine_version:
 		env.variant | ltrimstr("alpine")
+	;
+	def is_cbl_mariner:
+		env.variant | startswith("cbl-mariner")
+	;
+	def cbl_mariner_version:
+		env.variant | ltrimstr("cbl-mariner")
+	;
+
+	def is_fips:
+		(.tagPrefix // "") | contains("fips")
 -}}
 {{ if is_alpine then ( -}}
 FROM alpine:{{ alpine_version }}
@@ -14,6 +24,27 @@ RUN apk add --no-cache ca-certificates
 # - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+{{ ) elif is_cbl_mariner then ( -}}
+FROM cblmariner.azurecr.io/base/core:{{ cbl_mariner_version }}
+
+RUN tdnf install -y \
+		binutils \
+		gcc \
+		glibc \
+		glibc-devel \
+		kernel-headers \
+		iana-etc \
+{{
+	if is_fips then (
+-}}
+		# Install OpenSSL for headers when building a FIPS-compatible app with Go.
+		openssl-devel \
+{{
+	) else "" end
+-}}
+	; \
+	tdnf clean all
+
 {{ ) else ( -}}
 FROM buildpack-deps:{{ env.variant }}-scm
 
@@ -26,6 +57,14 @@ RUN set -eux; \
 		libc6-dev \
 		make \
 		pkg-config \
+{{
+	if is_fips then (
+-}}
+		# Install OpenSSL for headers when building a FIPS-compatible app with Go.
+		libssl-dev \
+{{
+	) else "" end
+-}}
 	; \
 	rm -rf /var/lib/apt/lists/*
 {{ ) end -}}
@@ -46,6 +85,10 @@ ENV GOLANG_VERSION {{ .version }}
 				ppc64le: "ppc64le",
 				s390x: "s390x",
 			}
+		elif is_cbl_mariner then
+			{
+				amd64: "x86_64",
+			}
 		else
 			{
 				amd64: "amd64",
@@ -63,6 +106,8 @@ RUN set -eux; \
 {{ if is_alpine then ( -}}
 	apk add --no-cache --virtual .fetch-deps gnupg; \
 	arch="$(apk --print-arch)"; \
+{{ ) elif is_cbl_mariner then ( -}}
+	arch="$(uname -m)"; \
 {{ ) else ( -}}
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 {{ ) end -}}
@@ -178,6 +223,17 @@ RUN set -eux; \
 		; \
 	fi; \
 	\
+{{ if is_fips then ( -}}
+	# We downloaded a FIPS/OpenSSL version of Go that may have been built with a different version
+	# of OpenSSL than we have installed in this image. That makes them incompatible and Go will fail
+	# to load OpenSSL. To fix this, recompile the boring/OpenSSL package on the current system. Also
+	# recompile commands so "go run", "go build" and other commands work under FIPS mode.
+	#
+	# Note that in microsoft/go-images, we always download a prebuilt copy of Go, so we don't need
+	# to worry about checking "$build" here to avoid unnecessary work.
+	/usr/local/go/bin/go install -a crypto/internal/boring cmd; \
+	\
+{{ ) else "" end -}}
 {{ if is_alpine then ( -}}
 	apk del --no-network .fetch-deps; \
 	\

--- a/manifest.json
+++ b/manifest.json
@@ -374,6 +374,29 @@
               }
             }
           ]
+        },
+        {
+          "productVersion": "1.17",
+          "sharedTags": {
+            "1-fips": {},
+            "1-fips-cbl-mariner1.0.20211027": {},
+            "1.17-fips": {},
+            "1.17-fips-cbl-mariner1.0.20211027": {},
+            "1.17.6-1-fips": {},
+            "1.17.6-1-fips-cbl-mariner1.0.20211027": {},
+            "1.17.6-fips": {},
+            "1.17.6-fips-cbl-mariner1.0.20211027": {}
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.17-fips/cbl-mariner1.0.20211027",
+              "os": "linux",
+              "osVersion": "cbl-mariner1.0.20211027",
+              "tags": {
+                "1.17.6-1-fips-cbl-mariner1.0.20211027-amd64": {}
+              }
+            }
+          ]
         }
       ]
     }

--- a/src/microsoft/1.17-fips/cbl-mariner1.0.20211027/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0.20211027/Dockerfile
@@ -1,31 +1,10 @@
-{{
-	def is_alpine:
-		env.variant | startswith("alpine")
-	;
-	def alpine_version:
-		env.variant | ltrimstr("alpine")
-	;
-	def is_cbl_mariner:
-		env.variant | startswith("cbl-mariner")
-	;
-	def cbl_mariner_version:
-		env.variant | ltrimstr("cbl-mariner")
-	;
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
 
-	def is_fips:
-		(.branchSuffix // "") | contains("fips")
--}}
-{{ if is_alpine then ( -}}
-FROM alpine:{{ alpine_version }}
-
-RUN apk add --no-cache ca-certificates
-
-# set up nsswitch.conf for Go's "netgo" implementation
-# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
-# - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
-{{ ) elif is_cbl_mariner then ( -}}
-FROM cblmariner.azurecr.io/base/core:{{ cbl_mariner_version }}
+FROM cblmariner.azurecr.io/base/core:1.0.20211027
 
 RUN tdnf install -y \
 		binutils \
@@ -34,130 +13,41 @@ RUN tdnf install -y \
 		glibc-devel \
 		kernel-headers \
 		iana-etc \
-{{
-	if is_fips then (
--}}
 		# Install OpenSSL for headers when building a FIPS-compatible app with Go.
 		openssl-devel \
-{{
-	) else "" end
--}}
 	; \
 	tdnf clean all
 
-{{ ) else ( -}}
-FROM buildpack-deps:{{ env.variant }}-scm
-
-# install cgo-related dependencies
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		g++ \
-		gcc \
-		libc6-dev \
-		make \
-		pkg-config \
-{{
-	if is_fips then (
--}}
-		# Install OpenSSL for headers when building a FIPS-compatible app with Go.
-		libssl-dev \
-{{
-	) else "" end
--}}
-	; \
-	rm -rf /var/lib/apt/lists/*
-{{ ) end -}}
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION {{ .version }}
+ENV GOLANG_VERSION 1.17.6
 
-{{
-	def os_arches:
-		if is_alpine then
-			{
-				amd64: "x86_64",
-				arm32v6: "armhf",
-				arm32v7: "armv7",
-				arm64v8: "aarch64",
-				i386: "x86",
-				ppc64le: "ppc64le",
-				s390x: "s390x",
-			}
-		elif is_cbl_mariner then
-			{
-				amd64: "x86_64",
-			}
-		else
-			{
-				amd64: "amd64",
-				arm32v5: "armel",
-				arm32v7: "armhf",
-				arm64v8: "arm64",
-				i386: "i386",
-				mips64le: "mips64el",
-				ppc64le: "ppc64el",
-				s390x: "s390x",
-			}
-		end
--}}
 RUN set -eux; \
-{{ if is_alpine then ( -}}
-	apk add --no-cache --virtual .fetch-deps gnupg; \
-	arch="$(apk --print-arch)"; \
-{{ ) elif is_cbl_mariner then ( -}}
 	arch="$(uname -m)"; \
-{{ ) else ( -}}
-	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
-{{ ) end -}}
 	url=; \
 	case "$arch" in \
-{{
-	[
-		.arches | to_entries[]
-		| select(.value.supported)
-		| .key as $bashbrewArch
-		| (
-			os_arches
-			| .[$bashbrewArch] // empty
-		) as $osArch
-		| .value
-		| (
--}}
-		{{ $osArch | @sh }}) \
-{{ if .url and (is_alpine | not) then ( -}}
-			url={{ .url | @sh }}; \
-			sha256={{ .sha256 | @sh }}; \
-{{ ) else ( -}}
-			export {{ .env | to_entries | map(.key + "=" + (.value | @sh)) | join(" ") }}; \
-{{ ) end -}}
+		'x86_64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220131.4/go.20220131.4.linux-amd64.tar.gz'; \
+			sha256='7fb05af800e2af224bcf03e5bf9d89cece7ff486a26aea85a8fe198c14781aa0'; \
 			;; \
-{{
-		)
-	] | add
--}}
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
 	build=; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url={{ .arches.src.url | @sh }}; \
-		sha256={{ .arches.src.sha256 | @sh }}; \
-{{ if is_alpine then ( -}}
-# the precompiled binaries published by Go upstream are not compatible with Alpine, so we always build from source here 😅
-{{ ) else ( -}}
+		url=null; \
+		sha256=null; \
 		echo >&2; \
 		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
 		echo >&2; \
-{{ ) end -}}
 	fi; \
 	\
 # NO MICROSOFT_UPSTREAM: Change ".asc" to ".sig" to match the filename we publish. https://github.com/microsoft/go/issues/181
 	wget -O go.tgz.asc "$url.sig" --progress=dot:giga; \
 # END NO MICROSOFT_UPSTREAM
-	wget -O go.tgz "$url"{{ if is_alpine then "" else " --progress=dot:giga" end }}; \
+	wget -O go.tgz "$url" --progress=dot:giga; \
 	echo "$sha256 *go.tgz" | sha256sum -c -; \
 	\
 # https://github.com/golang/go/issues/14739#issuecomment-324767697
@@ -178,18 +68,9 @@ RUN set -eux; \
 	rm go.tgz; \
 	\
 	if [ -n "$build" ]; then \
-{{ if is_alpine then ( -}}
-		apk add --no-cache --virtual .build-deps \
-			bash \
-			gcc \
-			go \
-			musl-dev \
-		; \
-{{ ) else ( -}}
 		savedAptMark="$(apt-mark showmanual)"; \
 		apt-get update; \
 		apt-get install -y --no-install-recommends golang-go; \
-{{ ) end -}}
 		\
 		( \
 			cd /usr/local/go/src; \
@@ -198,14 +79,10 @@ RUN set -eux; \
 			./make.bash; \
 		); \
 		\
-{{ if is_alpine then ( -}}
-		apk del --no-network .build-deps; \
-{{ ) else ( -}}
 		apt-mark auto '.*' > /dev/null; \
 		apt-mark manual $savedAptMark > /dev/null; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
-{{ ) end -}}
 		\
 # pre-compile the standard library, just like the official binary release tarballs do
 		go install std; \
@@ -223,10 +100,6 @@ RUN set -eux; \
 		; \
 	fi; \
 	\
-{{ if is_alpine then ( -}}
-	apk del --no-network .fetch-deps; \
-	\
-{{ ) else "" end -}}
 	go version
 
 ENV GOPATH /go

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -99,5 +99,26 @@
     "preferredMajor": true,
     "preferredMinor": true,
     "preferredVariant": "bullseye"
+  },
+  "1.17-fips": {
+    "arches": {
+      "amd64": {
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "linux"
+        },
+        "sha256": "7fb05af800e2af224bcf03e5bf9d89cece7ff486a26aea85a8fe198c14781aa0",
+        "supported": true,
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220131.4/go.20220131.4.linux-amd64.tar.gz"
+      }
+    },
+    "variants": [
+      "cbl-mariner1.0.20211027"
+    ],
+    "version": "1.17.6",
+    "revision": "1",
+    "preferredMinor": true,
+    "preferredVariant": "cbl-mariner1.0.20211027",
+    "branchSuffix": "-fips"
   }
 }


### PR DESCRIPTION
Add an image built on Mariner that uses a build of Go from the boring/FIPS branch. This is based on the dev branch (https://github.com/microsoft/go-images/tree/dev/official/go1.17-openssl-fips), with modifications to the `versions.json` file to support maintaining both "normal" release branches plus boring release branches in the same go-images branch.

* For the auto-update side, see: https://github.com/microsoft/go-infra/pull/23 

The dev branch has steps to reinstall the Go crypto libraries to rebuild them on the Mariner image to re-link it with the correct OpenSSL version. This shouldn't be necessary anymore since we do a portable build, so I didn't include that part of the Dockerfile template. (Look at 398f414 specifically to see my changes vs. the dev branch copy.)