### PR TITLE
[nightly] Add internal build and PR validation to nightly branch

### DIFF
--- a/eng/pipeline/go-docker-nightly-pr-pipeline.yml
+++ b/eng/pipeline/go-docker-nightly-pr-pipeline.yml
@@ -2,10 +2,13 @@ trigger: none
 pr:
   branches:
     include:
-      - microsoft/main
+      - microsoft/nightly
+      - dev/official/*
 
 variables:
   - template: variables/common.yml
+    parameters:
+      nightly: true
 
 stages:
   - template: stages/build-test-publish-repo.yml

--- a/eng/pipeline/go-docker-nightly-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-nightly-rolling-internal-pipeline.yml
@@ -1,11 +1,15 @@
-trigger: none
-pr:
+trigger:
+  batch: true
   branches:
     include:
-      - microsoft/main
+      - microsoft/nightly
+      - dev/official/*
+pr: none
 
 variables:
   - template: variables/common.yml
+    parameters:
+      nightly: true
 
 stages:
   - template: stages/build-test-publish-repo.yml
@@ -15,4 +19,3 @@ stages:
         # stage template, it returns an empty string. So, evaluate it here and pass it through.
         internalProjectName: ${{ variables.internalProjectName }}
         publicProjectName: ${{ variables.publicProjectName }}
-        buildMatrixType: platformVersionedOs

--- a/eng/pipeline/go-docker-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline.yml
@@ -1,9 +1,4 @@
-trigger:
-  batch: true
-  branches:
-    include:
-      - microsoft/*
-      - dev/official/*
+trigger: none
 pr: none
 
 variables:

--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -1,3 +1,6 @@
+parameters:
+  nightly: false
+
 variables:
 - template: ../../common/templates/variables/common.yml
 
@@ -11,7 +14,12 @@ variables:
 - name: publicGitRepoUri
   value: https://github.com/microsoft/go
 - name: officialRepoPrefix
-  value: public/
+  ${{ if eq(parameters.nightly, false) }}:
+    # Publish to "public/", which will be detected by MCR trigger.
+    value: public/
+  ${{ if eq(parameters.nightly, true) }}:
+    # In the nightly branch, publish to ACR only. The prefix doesn't need to match MCR expectations.
+    value: nightly/
 
 - name: publishReadme
   value: false
@@ -24,7 +32,10 @@ variables:
 
 - name: officialBranches
   # list multiple branches as "'branch1', 'branch2', etc."
-  value: "'microsoft/main'"
+  ${{ if eq(parameters.nightly, false) }}:
+    value: "'microsoft/main'"
+  ${{ if eq(parameters.nightly, true) }}:
+    value: "'nightly'"
 
 - name: manifest
   value: manifest.json
@@ -37,7 +48,10 @@ variables:
   value: ${{ variables.commonVersionsImageInfoPath }}
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - group: go-docker-common
+  - ${{ if eq(parameters.nightly, false) }}:
+    - group: go-docker-common
+  - ${{ if eq(parameters.nightly, true) }}:
+    - group: go-docker-common-nightly
   - group: go-docker-secrets
   - group: go-docker-shared-DotNet-Docker-Secrets
 

--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -56,6 +56,9 @@ variables:
   - group: go-docker-shared-DotNet-Docker-Secrets
 
 - name: acr.password
-  value: $(BotAccount-golang-docker-acr-bot-password)
+  ${{ if eq(parameters.nightly, false) }}:
+    value: $(BotAccount-golang-docker-acr-bot-password)
+  ${{ if eq(parameters.nightly, true) }}:
+    value: $(BotAccount-golang-docker-acr-public-bot-password)
 - name: acr.servicePrincipalPassword
   value: $(GolangDockerBuild)

--- a/manifest.json
+++ b/manifest.json
@@ -379,21 +379,21 @@
           "productVersion": "1.17",
           "sharedTags": {
             "1-fips": {},
-            "1-fips-cbl-mariner1.0.20211027": {},
+            "1-fips-cbl-mariner1.0": {},
             "1.17-fips": {},
-            "1.17-fips-cbl-mariner1.0.20211027": {},
+            "1.17-fips-cbl-mariner1.0": {},
             "1.17.6-1-fips": {},
-            "1.17.6-1-fips-cbl-mariner1.0.20211027": {},
+            "1.17.6-1-fips-cbl-mariner1.0": {},
             "1.17.6-fips": {},
-            "1.17.6-fips-cbl-mariner1.0.20211027": {}
+            "1.17.6-fips-cbl-mariner1.0": {}
           },
           "platforms": [
             {
-              "dockerfile": "src/microsoft/1.17-fips/cbl-mariner1.0.20211027",
+              "dockerfile": "src/microsoft/1.17-fips/cbl-mariner1.0",
               "os": "linux",
-              "osVersion": "cbl-mariner1.0.20211027",
+              "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.17.6-1-fips-cbl-mariner1.0.20211027-amd64": {}
+                "1.17.6-1-fips-cbl-mariner1.0-amd64": {}
               }
             }
           ]

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM cblmariner.azurecr.io/base/core:1.0.20211027
+FROM cblmariner.azurecr.io/base/core:1.0
 
 RUN tdnf install -y \
 		binutils \

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -113,12 +113,12 @@
       }
     },
     "variants": [
-      "cbl-mariner1.0.20211027"
+      "cbl-mariner1.0"
     ],
     "version": "1.17.6",
     "revision": "1",
     "preferredMinor": true,
-    "preferredVariant": "cbl-mariner1.0.20211027",
+    "preferredVariant": "cbl-mariner1.0",
     "branchSuffix": "-fips"
   }
 }


### PR DESCRIPTION
Follow the .NET Docker approach: one set of pipeline YAML files for main, another for nightly. This makes it so we can keep both `microsoft/main` and `microsoft/nightly` exactly the same as each other, and still have independent behaviors.
https://github.com/dotnet/dotnet-docker/tree/nightly/eng/pipelines

The `microsoft/main` build has no triggers. It is only manually triggered for intentional release events, to reduce unnecessary churn. These builds publish to an internal ACR that is configured for tag uptake into MCR.

The `microsoft/nightly` branch triggers per commit (rolling). It receives auto-updates for each new Microsoft Go build, and builds them once they merge. E.g. this contains Go servicing fixes before they're included in an official Go release. These builds publish to an anonymously accessible ACR: they are easy to access to try out locally, but not easy to browse, and do not have any guarantees (such as MCR's service quality and tag availability).

I added a new variable group that points to the anonymously accessible ACR:
https://dev.azure.com/dnceng/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=146&path=go-docker-common-nightly
I also added that ACR's credentials to the key vault.

This lets us remove the "alpha" part of the MCR Docker repository name `public/oss/go/microsoft/alpha/golang`, because our experimental and high-churn builds have a better place to live.