### PR TITLE
[nightly] Update microsoft/nightly fips to 1.17.7

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -285,10 +285,10 @@
             "1-fips-cbl-mariner1.0": {},
             "1.17-fips": {},
             "1.17-fips-cbl-mariner1.0": {},
-            "1.17.6-1-fips": {},
-            "1.17.6-1-fips-cbl-mariner1.0": {},
-            "1.17.6-fips": {},
-            "1.17.6-fips-cbl-mariner1.0": {}
+            "1.17.7-1-fips": {},
+            "1.17.7-1-fips-cbl-mariner1.0": {},
+            "1.17.7-fips": {},
+            "1.17.7-fips-cbl-mariner1.0": {}
           },
           "platforms": [
             {
@@ -296,7 +296,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.17.6-1-fips-cbl-mariner1.0-amd64": {}
+                "1.17.7-1-fips-cbl-mariner1.0-amd64": {}
               }
             }
           ]

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -21,15 +21,15 @@ RUN tdnf install -y \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.17.7
 
 RUN set -eux; \
 	arch="$(uname -m)"; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220131.4/go.20220131.4.linux-amd64.tar.gz'; \
-			sha256='7fb05af800e2af224bcf03e5bf9d89cece7ff486a26aea85a8fe198c14781aa0'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220211.4/go.20220211.4.linux-amd64.tar.gz'; \
+			sha256='750881935e8304f1ecc84d76ecc356c25d6756bc396a4c61420df8f105e59a67'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -75,15 +75,23 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "7fb05af800e2af224bcf03e5bf9d89cece7ff486a26aea85a8fe198c14781aa0",
+        "sha256": "750881935e8304f1ecc84d76ecc356c25d6756bc396a4c61420df8f105e59a67",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220131.4/go.20220131.4.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220211.4/go.20220211.4.linux-amd64.tar.gz"
+      },
+      "windows-amd64": {
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "windows"
+        },
+        "sha256": "774a317b35681b6e71f8693d1027eaf87ffd01f19beaeb4e9acb7123354274b3",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220211.4/go.20220211.4.windows-amd64.zip"
       }
     },
     "variants": [
       "cbl-mariner1.0"
     ],
-    "version": "1.17.6",
+    "version": "1.17.7",
     "revision": "1",
     "preferredMinor": true,
     "preferredVariant": "cbl-mariner1.0",


### PR DESCRIPTION
Auto-update from boring branches isn't working right now (https://github.com/microsoft/go/pull/429), so I modified the 1.17.7 boring build's build asset JSON file locally and re-ran the update command.