### PR TITLE
Fix microsoft/nightly official branch status

### DIFF
--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -35,7 +35,7 @@ variables:
   ${{ if eq(parameters.nightly, false) }}:
     value: "'microsoft/main'"
   ${{ if eq(parameters.nightly, true) }}:
-    value: "'nightly'"
+    value: "'microsoft/nightly'"
 
 - name: manifest
   value: manifest.json


### PR DESCRIPTION
Fix https://dev.azure.com/dnceng/internal/_build?definitionId=1101&_a=summary. The .NET Docker repository uses `main` and `nightly` as its branches, and we use `microsoft/main` and `microsoft/nightly`. I got some wires crossed and used `nightly` here rather than `microsoft/nightly`. This causes the nightly branch builds to fail, because some infra protection kicks in to make sure we don't accidentally publish dev branch builds as if they're official.

I'll queue a merge on one approval--this is a very simple infra fix.