### PR TITLE
Merge nightly into main

### DIFF
--- a/1.16/alpine3.14/Dockerfile
+++ b/1.16/alpine3.14/Dockerfile
@@ -15,7 +15,7 @@ RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.16.13
+ENV GOLANG_VERSION 1.16.14
 
 RUN set -eux; \
 	apk add --no-cache --virtual .fetch-deps gnupg; \
@@ -49,8 +49,8 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://dl.google.com/go/go1.16.13.src.tar.gz'; \
-		sha256='b0926654eaeb01ef43816638f42d7b1681f2d3f41b9559f07735522b7afad41a'; \
+		url='https://dl.google.com/go/go1.16.14.src.tar.gz'; \
+		sha256='467898cd3a216de54dcb9014f541efe77e9b79a7154dbc1fd2dd778b0c63fb56'; \
 # the precompiled binaries published by Go upstream are not compatible with Alpine, so we always build from source here 😅
 	fi; \
 	\

--- a/1.16/alpine3.15/Dockerfile
+++ b/1.16/alpine3.15/Dockerfile
@@ -15,7 +15,7 @@ RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.16.13
+ENV GOLANG_VERSION 1.16.14
 
 RUN set -eux; \
 	apk add --no-cache --virtual .fetch-deps gnupg; \
@@ -49,8 +49,8 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://dl.google.com/go/go1.16.13.src.tar.gz'; \
-		sha256='b0926654eaeb01ef43816638f42d7b1681f2d3f41b9559f07735522b7afad41a'; \
+		url='https://dl.google.com/go/go1.16.14.src.tar.gz'; \
+		sha256='467898cd3a216de54dcb9014f541efe77e9b79a7154dbc1fd2dd778b0c63fb56'; \
 # the precompiled binaries published by Go upstream are not compatible with Alpine, so we always build from source here 😅
 	fi; \
 	\

--- a/1.16/bullseye/Dockerfile
+++ b/1.16/bullseye/Dockerfile
@@ -20,41 +20,41 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.16.13
+ENV GOLANG_VERSION 1.16.14
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dl.google.com/go/go1.16.13.linux-amd64.tar.gz'; \
-			sha256='275fc03c90c13b0bbff13125a43f1f7a9f9c00a0d5a9f2d5b16dbc2fa2c6e12a'; \
+			url='https://dl.google.com/go/go1.16.14.linux-amd64.tar.gz'; \
+			sha256='f4f5f02eb6809ac5bf19b5ad517b23504fd5fc036f6487651968ad36aa7a20e0'; \
 			;; \
 		'armel') \
 			export GOARCH='arm' GOARM='5' GOOS='linux'; \
 			;; \
 		'armhf') \
-			url='https://dl.google.com/go/go1.16.13.linux-armv6l.tar.gz'; \
-			sha256='cc68d35ee9d301cf4ad3f8844feeef5ae102102ea17dd2eb3b1f406f3df6ceba'; \
+			url='https://dl.google.com/go/go1.16.14.linux-armv6l.tar.gz'; \
+			sha256='ed313a1a79ecba23b0d12a12b05003bf3ad55dfa76e611804d0295f641d68ec9'; \
 			;; \
 		'arm64') \
-			url='https://dl.google.com/go/go1.16.13.linux-arm64.tar.gz'; \
-			sha256='3dd8e14837105cbfedf7124c7f8c524ce492748c370036c7316ef99e18d116d7'; \
+			url='https://dl.google.com/go/go1.16.14.linux-arm64.tar.gz'; \
+			sha256='5e59056e36704acb25809bcdb27191f27593cb7aba4d716b523008135a1e764a'; \
 			;; \
 		'i386') \
-			url='https://dl.google.com/go/go1.16.13.linux-386.tar.gz'; \
-			sha256='5b1b9d10df8ccac44a32eccd3136b28f570a8ab580e6dad43d307d4d66ab6cd3'; \
+			url='https://dl.google.com/go/go1.16.14.linux-386.tar.gz'; \
+			sha256='b4cd4602267f60db851fc420b53524ab4449d4a4c52c33cdb87bb74abc870ebf'; \
 			;; \
 		'mips64el') \
 			export GOARCH='mips64le' GOOS='linux'; \
 			;; \
 		'ppc64el') \
-			url='https://dl.google.com/go/go1.16.13.linux-ppc64le.tar.gz'; \
-			sha256='f1a6a3e99e8d202f838f7780ac996bd03d691bdb097869938362ec001a226372'; \
+			url='https://dl.google.com/go/go1.16.14.linux-ppc64le.tar.gz'; \
+			sha256='b1dc70128e51dfff8fba3053e90b8c2754294f62feb96ab2e7b6e30ab164b4b1'; \
 			;; \
 		's390x') \
-			url='https://dl.google.com/go/go1.16.13.linux-s390x.tar.gz'; \
-			sha256='f88eda38ba5f079f8af72c7f598bdbf1c13470336f8e677ff35548e24c3d53d6'; \
+			url='https://dl.google.com/go/go1.16.14.linux-s390x.tar.gz'; \
+			sha256='75ee0aee5fb0c22a047eb289e70c50c8e7088ddfc4f3a921c586d878ec1a88d8'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
@@ -62,8 +62,8 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://dl.google.com/go/go1.16.13.src.tar.gz'; \
-		sha256='b0926654eaeb01ef43816638f42d7b1681f2d3f41b9559f07735522b7afad41a'; \
+		url='https://dl.google.com/go/go1.16.14.src.tar.gz'; \
+		sha256='467898cd3a216de54dcb9014f541efe77e9b79a7154dbc1fd2dd778b0c63fb56'; \
 		echo >&2; \
 		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
 		echo >&2; \

--- a/1.16/buster/Dockerfile
+++ b/1.16/buster/Dockerfile
@@ -20,41 +20,41 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.16.13
+ENV GOLANG_VERSION 1.16.14
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dl.google.com/go/go1.16.13.linux-amd64.tar.gz'; \
-			sha256='275fc03c90c13b0bbff13125a43f1f7a9f9c00a0d5a9f2d5b16dbc2fa2c6e12a'; \
+			url='https://dl.google.com/go/go1.16.14.linux-amd64.tar.gz'; \
+			sha256='f4f5f02eb6809ac5bf19b5ad517b23504fd5fc036f6487651968ad36aa7a20e0'; \
 			;; \
 		'armel') \
 			export GOARCH='arm' GOARM='5' GOOS='linux'; \
 			;; \
 		'armhf') \
-			url='https://dl.google.com/go/go1.16.13.linux-armv6l.tar.gz'; \
-			sha256='cc68d35ee9d301cf4ad3f8844feeef5ae102102ea17dd2eb3b1f406f3df6ceba'; \
+			url='https://dl.google.com/go/go1.16.14.linux-armv6l.tar.gz'; \
+			sha256='ed313a1a79ecba23b0d12a12b05003bf3ad55dfa76e611804d0295f641d68ec9'; \
 			;; \
 		'arm64') \
-			url='https://dl.google.com/go/go1.16.13.linux-arm64.tar.gz'; \
-			sha256='3dd8e14837105cbfedf7124c7f8c524ce492748c370036c7316ef99e18d116d7'; \
+			url='https://dl.google.com/go/go1.16.14.linux-arm64.tar.gz'; \
+			sha256='5e59056e36704acb25809bcdb27191f27593cb7aba4d716b523008135a1e764a'; \
 			;; \
 		'i386') \
-			url='https://dl.google.com/go/go1.16.13.linux-386.tar.gz'; \
-			sha256='5b1b9d10df8ccac44a32eccd3136b28f570a8ab580e6dad43d307d4d66ab6cd3'; \
+			url='https://dl.google.com/go/go1.16.14.linux-386.tar.gz'; \
+			sha256='b4cd4602267f60db851fc420b53524ab4449d4a4c52c33cdb87bb74abc870ebf'; \
 			;; \
 		'mips64el') \
 			export GOARCH='mips64le' GOOS='linux'; \
 			;; \
 		'ppc64el') \
-			url='https://dl.google.com/go/go1.16.13.linux-ppc64le.tar.gz'; \
-			sha256='f1a6a3e99e8d202f838f7780ac996bd03d691bdb097869938362ec001a226372'; \
+			url='https://dl.google.com/go/go1.16.14.linux-ppc64le.tar.gz'; \
+			sha256='b1dc70128e51dfff8fba3053e90b8c2754294f62feb96ab2e7b6e30ab164b4b1'; \
 			;; \
 		's390x') \
-			url='https://dl.google.com/go/go1.16.13.linux-s390x.tar.gz'; \
-			sha256='f88eda38ba5f079f8af72c7f598bdbf1c13470336f8e677ff35548e24c3d53d6'; \
+			url='https://dl.google.com/go/go1.16.14.linux-s390x.tar.gz'; \
+			sha256='75ee0aee5fb0c22a047eb289e70c50c8e7088ddfc4f3a921c586d878ec1a88d8'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
@@ -62,8 +62,8 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://dl.google.com/go/go1.16.13.src.tar.gz'; \
-		sha256='b0926654eaeb01ef43816638f42d7b1681f2d3f41b9559f07735522b7afad41a'; \
+		url='https://dl.google.com/go/go1.16.14.src.tar.gz'; \
+		sha256='467898cd3a216de54dcb9014f541efe77e9b79a7154dbc1fd2dd778b0c63fb56'; \
 		echo >&2; \
 		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
 		echo >&2; \

--- a/1.16/stretch/Dockerfile
+++ b/1.16/stretch/Dockerfile
@@ -20,41 +20,41 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.16.13
+ENV GOLANG_VERSION 1.16.14
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dl.google.com/go/go1.16.13.linux-amd64.tar.gz'; \
-			sha256='275fc03c90c13b0bbff13125a43f1f7a9f9c00a0d5a9f2d5b16dbc2fa2c6e12a'; \
+			url='https://dl.google.com/go/go1.16.14.linux-amd64.tar.gz'; \
+			sha256='f4f5f02eb6809ac5bf19b5ad517b23504fd5fc036f6487651968ad36aa7a20e0'; \
 			;; \
 		'armel') \
 			export GOARCH='arm' GOARM='5' GOOS='linux'; \
 			;; \
 		'armhf') \
-			url='https://dl.google.com/go/go1.16.13.linux-armv6l.tar.gz'; \
-			sha256='cc68d35ee9d301cf4ad3f8844feeef5ae102102ea17dd2eb3b1f406f3df6ceba'; \
+			url='https://dl.google.com/go/go1.16.14.linux-armv6l.tar.gz'; \
+			sha256='ed313a1a79ecba23b0d12a12b05003bf3ad55dfa76e611804d0295f641d68ec9'; \
 			;; \
 		'arm64') \
-			url='https://dl.google.com/go/go1.16.13.linux-arm64.tar.gz'; \
-			sha256='3dd8e14837105cbfedf7124c7f8c524ce492748c370036c7316ef99e18d116d7'; \
+			url='https://dl.google.com/go/go1.16.14.linux-arm64.tar.gz'; \
+			sha256='5e59056e36704acb25809bcdb27191f27593cb7aba4d716b523008135a1e764a'; \
 			;; \
 		'i386') \
-			url='https://dl.google.com/go/go1.16.13.linux-386.tar.gz'; \
-			sha256='5b1b9d10df8ccac44a32eccd3136b28f570a8ab580e6dad43d307d4d66ab6cd3'; \
+			url='https://dl.google.com/go/go1.16.14.linux-386.tar.gz'; \
+			sha256='b4cd4602267f60db851fc420b53524ab4449d4a4c52c33cdb87bb74abc870ebf'; \
 			;; \
 		'mips64el') \
 			export GOARCH='mips64le' GOOS='linux'; \
 			;; \
 		'ppc64el') \
-			url='https://dl.google.com/go/go1.16.13.linux-ppc64le.tar.gz'; \
-			sha256='f1a6a3e99e8d202f838f7780ac996bd03d691bdb097869938362ec001a226372'; \
+			url='https://dl.google.com/go/go1.16.14.linux-ppc64le.tar.gz'; \
+			sha256='b1dc70128e51dfff8fba3053e90b8c2754294f62feb96ab2e7b6e30ab164b4b1'; \
 			;; \
 		's390x') \
-			url='https://dl.google.com/go/go1.16.13.linux-s390x.tar.gz'; \
-			sha256='f88eda38ba5f079f8af72c7f598bdbf1c13470336f8e677ff35548e24c3d53d6'; \
+			url='https://dl.google.com/go/go1.16.14.linux-s390x.tar.gz'; \
+			sha256='75ee0aee5fb0c22a047eb289e70c50c8e7088ddfc4f3a921c586d878ec1a88d8'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
@@ -62,8 +62,8 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://dl.google.com/go/go1.16.13.src.tar.gz'; \
-		sha256='b0926654eaeb01ef43816638f42d7b1681f2d3f41b9559f07735522b7afad41a'; \
+		url='https://dl.google.com/go/go1.16.14.src.tar.gz'; \
+		sha256='467898cd3a216de54dcb9014f541efe77e9b79a7154dbc1fd2dd778b0c63fb56'; \
 		echo >&2; \
 		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
 		echo >&2; \

--- a/1.16/windows/nanoserver-1809/Dockerfile
+++ b/1.16/windows/nanoserver-1809/Dockerfile
@@ -21,10 +21,10 @@ RUN setx /m PATH "%GOPATH%\bin;C:\go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.16.13
+ENV GOLANG_VERSION 1.16.14
 
 # Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
-COPY --from=golang:1.16.13-windowsservercore-1809 ["C:\\\\go","C:\\\\go"]
+COPY --from=golang:1.16.14-windowsservercore-1809 ["C:\\\\go","C:\\\\go"]
 RUN go version
 
 WORKDIR $GOPATH

--- a/1.16/windows/nanoserver-ltsc2022/Dockerfile
+++ b/1.16/windows/nanoserver-ltsc2022/Dockerfile
@@ -21,10 +21,10 @@ RUN setx /m PATH "%GOPATH%\bin;C:\go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.16.13
+ENV GOLANG_VERSION 1.16.14
 
 # Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
-COPY --from=golang:1.16.13-windowsservercore-ltsc2022 ["C:\\\\go","C:\\\\go"]
+COPY --from=golang:1.16.14-windowsservercore-ltsc2022 ["C:\\\\go","C:\\\\go"]
 RUN go version
 
 WORKDIR $GOPATH

--- a/1.16/windows/windowsservercore-1809/Dockerfile
+++ b/1.16/windows/windowsservercore-1809/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.16.13
+ENV GOLANG_VERSION 1.16.14
 
-RUN $url = 'https://dl.google.com/go/go1.16.13.windows-amd64.zip'; \
+RUN $url = 'https://dl.google.com/go/go1.16.14.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '76c938058444093bb6d95c5ee05db07c2b970f07d450d3b6d3cdea60edeb2765'; \
+	$sha256 = 'df3760d564477e5fc5ffb79496ca4b6667f7dd6d30f1baae9be83f7cc726a071'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/1.16/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/1.16/windows/windowsservercore-ltsc2022/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.16.13
+ENV GOLANG_VERSION 1.16.14
 
-RUN $url = 'https://dl.google.com/go/go1.16.13.windows-amd64.zip'; \
+RUN $url = 'https://dl.google.com/go/go1.16.14.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '76c938058444093bb6d95c5ee05db07c2b970f07d450d3b6d3cdea60edeb2765'; \
+	$sha256 = 'df3760d564477e5fc5ffb79496ca4b6667f7dd6d30f1baae9be83f7cc726a071'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/1.17/alpine3.14/Dockerfile
+++ b/1.17/alpine3.14/Dockerfile
@@ -15,7 +15,7 @@ RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.17.7
 
 RUN set -eux; \
 	apk add --no-cache --virtual .fetch-deps gnupg; \
@@ -49,8 +49,8 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://dl.google.com/go/go1.17.6.src.tar.gz'; \
-		sha256='4dc1bbf3ff61f0c1ff2b19355e6d88151a70126268a47c761477686ef94748c8'; \
+		url='https://dl.google.com/go/go1.17.7.src.tar.gz'; \
+		sha256='c108cd33b73b1911a02b697741df3dea43e01a5c4e08e409e8b3a0e3745d2b4d'; \
 # the precompiled binaries published by Go upstream are not compatible with Alpine, so we always build from source here 😅
 	fi; \
 	\

--- a/1.17/alpine3.15/Dockerfile
+++ b/1.17/alpine3.15/Dockerfile
@@ -15,7 +15,7 @@ RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.17.7
 
 RUN set -eux; \
 	apk add --no-cache --virtual .fetch-deps gnupg; \
@@ -49,8 +49,8 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://dl.google.com/go/go1.17.6.src.tar.gz'; \
-		sha256='4dc1bbf3ff61f0c1ff2b19355e6d88151a70126268a47c761477686ef94748c8'; \
+		url='https://dl.google.com/go/go1.17.7.src.tar.gz'; \
+		sha256='c108cd33b73b1911a02b697741df3dea43e01a5c4e08e409e8b3a0e3745d2b4d'; \
 # the precompiled binaries published by Go upstream are not compatible with Alpine, so we always build from source here 😅
 	fi; \
 	\

--- a/1.17/bullseye/Dockerfile
+++ b/1.17/bullseye/Dockerfile
@@ -20,41 +20,41 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.17.7
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dl.google.com/go/go1.17.6.linux-amd64.tar.gz'; \
-			sha256='231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2'; \
+			url='https://dl.google.com/go/go1.17.7.linux-amd64.tar.gz'; \
+			sha256='02b111284bedbfa35a7e5b74a06082d18632eff824fd144312f6063943d49259'; \
 			;; \
 		'armel') \
 			export GOARCH='arm' GOARM='5' GOOS='linux'; \
 			;; \
 		'armhf') \
-			url='https://dl.google.com/go/go1.17.6.linux-armv6l.tar.gz'; \
-			sha256='9ac723e6b41cb7c3651099a09332a8a778b69aa63a5e6baaa47caf0d818e2d6d'; \
+			url='https://dl.google.com/go/go1.17.7.linux-armv6l.tar.gz'; \
+			sha256='874774f078b182fa21ffcb3878467eb5cb7e78bbffa6343ea5f0fbe47983433b'; \
 			;; \
 		'arm64') \
-			url='https://dl.google.com/go/go1.17.6.linux-arm64.tar.gz'; \
-			sha256='82c1a033cce9bc1b47073fd6285233133040f0378439f3c4659fe77cc534622a'; \
+			url='https://dl.google.com/go/go1.17.7.linux-arm64.tar.gz'; \
+			sha256='a5aa1ed17d45ee1d58b4a4099b12f8942acbd1dd09b2e9a6abb1c4898043c5f5'; \
 			;; \
 		'i386') \
-			url='https://dl.google.com/go/go1.17.6.linux-386.tar.gz'; \
-			sha256='06c50fb0d44bb03dd4ea8795f9448379c5825d2765307b51f66905084c3ba541'; \
+			url='https://dl.google.com/go/go1.17.7.linux-386.tar.gz'; \
+			sha256='5d5472672a2e0252fe31f4ec30583d9f2b320f9b9296eda430f03cbc848400ce'; \
 			;; \
 		'mips64el') \
 			export GOARCH='mips64le' GOOS='linux'; \
 			;; \
 		'ppc64el') \
-			url='https://dl.google.com/go/go1.17.6.linux-ppc64le.tar.gz'; \
-			sha256='adc35c920b8c0253d4dd001f8979e0db4c6111a60cd5e0785a8bee95dba1fcaa'; \
+			url='https://dl.google.com/go/go1.17.7.linux-ppc64le.tar.gz'; \
+			sha256='2262fdee9147eb61fd1e719cfd19b9c035009c14890de02b5a77071b0a577405'; \
 			;; \
 		's390x') \
-			url='https://dl.google.com/go/go1.17.6.linux-s390x.tar.gz'; \
-			sha256='ccb2d4509db846be7055d1105b28154e72cd43162c4ef79c38a936a3e6f26e1d'; \
+			url='https://dl.google.com/go/go1.17.7.linux-s390x.tar.gz'; \
+			sha256='24dd117581d592f52b4cf45d75ae68a6a1e42691a8671a2d3c2ddd739894a1e4'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
@@ -62,8 +62,8 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://dl.google.com/go/go1.17.6.src.tar.gz'; \
-		sha256='4dc1bbf3ff61f0c1ff2b19355e6d88151a70126268a47c761477686ef94748c8'; \
+		url='https://dl.google.com/go/go1.17.7.src.tar.gz'; \
+		sha256='c108cd33b73b1911a02b697741df3dea43e01a5c4e08e409e8b3a0e3745d2b4d'; \
 		echo >&2; \
 		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
 		echo >&2; \

--- a/1.17/buster/Dockerfile
+++ b/1.17/buster/Dockerfile
@@ -20,41 +20,41 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.17.7
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dl.google.com/go/go1.17.6.linux-amd64.tar.gz'; \
-			sha256='231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2'; \
+			url='https://dl.google.com/go/go1.17.7.linux-amd64.tar.gz'; \
+			sha256='02b111284bedbfa35a7e5b74a06082d18632eff824fd144312f6063943d49259'; \
 			;; \
 		'armel') \
 			export GOARCH='arm' GOARM='5' GOOS='linux'; \
 			;; \
 		'armhf') \
-			url='https://dl.google.com/go/go1.17.6.linux-armv6l.tar.gz'; \
-			sha256='9ac723e6b41cb7c3651099a09332a8a778b69aa63a5e6baaa47caf0d818e2d6d'; \
+			url='https://dl.google.com/go/go1.17.7.linux-armv6l.tar.gz'; \
+			sha256='874774f078b182fa21ffcb3878467eb5cb7e78bbffa6343ea5f0fbe47983433b'; \
 			;; \
 		'arm64') \
-			url='https://dl.google.com/go/go1.17.6.linux-arm64.tar.gz'; \
-			sha256='82c1a033cce9bc1b47073fd6285233133040f0378439f3c4659fe77cc534622a'; \
+			url='https://dl.google.com/go/go1.17.7.linux-arm64.tar.gz'; \
+			sha256='a5aa1ed17d45ee1d58b4a4099b12f8942acbd1dd09b2e9a6abb1c4898043c5f5'; \
 			;; \
 		'i386') \
-			url='https://dl.google.com/go/go1.17.6.linux-386.tar.gz'; \
-			sha256='06c50fb0d44bb03dd4ea8795f9448379c5825d2765307b51f66905084c3ba541'; \
+			url='https://dl.google.com/go/go1.17.7.linux-386.tar.gz'; \
+			sha256='5d5472672a2e0252fe31f4ec30583d9f2b320f9b9296eda430f03cbc848400ce'; \
 			;; \
 		'mips64el') \
 			export GOARCH='mips64le' GOOS='linux'; \
 			;; \
 		'ppc64el') \
-			url='https://dl.google.com/go/go1.17.6.linux-ppc64le.tar.gz'; \
-			sha256='adc35c920b8c0253d4dd001f8979e0db4c6111a60cd5e0785a8bee95dba1fcaa'; \
+			url='https://dl.google.com/go/go1.17.7.linux-ppc64le.tar.gz'; \
+			sha256='2262fdee9147eb61fd1e719cfd19b9c035009c14890de02b5a77071b0a577405'; \
 			;; \
 		's390x') \
-			url='https://dl.google.com/go/go1.17.6.linux-s390x.tar.gz'; \
-			sha256='ccb2d4509db846be7055d1105b28154e72cd43162c4ef79c38a936a3e6f26e1d'; \
+			url='https://dl.google.com/go/go1.17.7.linux-s390x.tar.gz'; \
+			sha256='24dd117581d592f52b4cf45d75ae68a6a1e42691a8671a2d3c2ddd739894a1e4'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
@@ -62,8 +62,8 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://dl.google.com/go/go1.17.6.src.tar.gz'; \
-		sha256='4dc1bbf3ff61f0c1ff2b19355e6d88151a70126268a47c761477686ef94748c8'; \
+		url='https://dl.google.com/go/go1.17.7.src.tar.gz'; \
+		sha256='c108cd33b73b1911a02b697741df3dea43e01a5c4e08e409e8b3a0e3745d2b4d'; \
 		echo >&2; \
 		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
 		echo >&2; \

--- a/1.17/stretch/Dockerfile
+++ b/1.17/stretch/Dockerfile
@@ -20,41 +20,41 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.17.7
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dl.google.com/go/go1.17.6.linux-amd64.tar.gz'; \
-			sha256='231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2'; \
+			url='https://dl.google.com/go/go1.17.7.linux-amd64.tar.gz'; \
+			sha256='02b111284bedbfa35a7e5b74a06082d18632eff824fd144312f6063943d49259'; \
 			;; \
 		'armel') \
 			export GOARCH='arm' GOARM='5' GOOS='linux'; \
 			;; \
 		'armhf') \
-			url='https://dl.google.com/go/go1.17.6.linux-armv6l.tar.gz'; \
-			sha256='9ac723e6b41cb7c3651099a09332a8a778b69aa63a5e6baaa47caf0d818e2d6d'; \
+			url='https://dl.google.com/go/go1.17.7.linux-armv6l.tar.gz'; \
+			sha256='874774f078b182fa21ffcb3878467eb5cb7e78bbffa6343ea5f0fbe47983433b'; \
 			;; \
 		'arm64') \
-			url='https://dl.google.com/go/go1.17.6.linux-arm64.tar.gz'; \
-			sha256='82c1a033cce9bc1b47073fd6285233133040f0378439f3c4659fe77cc534622a'; \
+			url='https://dl.google.com/go/go1.17.7.linux-arm64.tar.gz'; \
+			sha256='a5aa1ed17d45ee1d58b4a4099b12f8942acbd1dd09b2e9a6abb1c4898043c5f5'; \
 			;; \
 		'i386') \
-			url='https://dl.google.com/go/go1.17.6.linux-386.tar.gz'; \
-			sha256='06c50fb0d44bb03dd4ea8795f9448379c5825d2765307b51f66905084c3ba541'; \
+			url='https://dl.google.com/go/go1.17.7.linux-386.tar.gz'; \
+			sha256='5d5472672a2e0252fe31f4ec30583d9f2b320f9b9296eda430f03cbc848400ce'; \
 			;; \
 		'mips64el') \
 			export GOARCH='mips64le' GOOS='linux'; \
 			;; \
 		'ppc64el') \
-			url='https://dl.google.com/go/go1.17.6.linux-ppc64le.tar.gz'; \
-			sha256='adc35c920b8c0253d4dd001f8979e0db4c6111a60cd5e0785a8bee95dba1fcaa'; \
+			url='https://dl.google.com/go/go1.17.7.linux-ppc64le.tar.gz'; \
+			sha256='2262fdee9147eb61fd1e719cfd19b9c035009c14890de02b5a77071b0a577405'; \
 			;; \
 		's390x') \
-			url='https://dl.google.com/go/go1.17.6.linux-s390x.tar.gz'; \
-			sha256='ccb2d4509db846be7055d1105b28154e72cd43162c4ef79c38a936a3e6f26e1d'; \
+			url='https://dl.google.com/go/go1.17.7.linux-s390x.tar.gz'; \
+			sha256='24dd117581d592f52b4cf45d75ae68a6a1e42691a8671a2d3c2ddd739894a1e4'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
@@ -62,8 +62,8 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://dl.google.com/go/go1.17.6.src.tar.gz'; \
-		sha256='4dc1bbf3ff61f0c1ff2b19355e6d88151a70126268a47c761477686ef94748c8'; \
+		url='https://dl.google.com/go/go1.17.7.src.tar.gz'; \
+		sha256='c108cd33b73b1911a02b697741df3dea43e01a5c4e08e409e8b3a0e3745d2b4d'; \
 		echo >&2; \
 		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
 		echo >&2; \

--- a/1.17/windows/nanoserver-1809/Dockerfile
+++ b/1.17/windows/nanoserver-1809/Dockerfile
@@ -21,10 +21,10 @@ RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.17.7
 
 # Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
-COPY --from=golang:1.17.6-windowsservercore-1809 ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]
+COPY --from=golang:1.17.7-windowsservercore-1809 ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]
 RUN go version
 
 WORKDIR $GOPATH

--- a/1.17/windows/nanoserver-ltsc2022/Dockerfile
+++ b/1.17/windows/nanoserver-ltsc2022/Dockerfile
@@ -21,10 +21,10 @@ RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.17.7
 
 # Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
-COPY --from=golang:1.17.6-windowsservercore-ltsc2022 ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]
+COPY --from=golang:1.17.7-windowsservercore-ltsc2022 ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]
 RUN go version
 
 WORKDIR $GOPATH

--- a/1.17/windows/windowsservercore-1809/Dockerfile
+++ b/1.17/windows/windowsservercore-1809/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.17.7
 
-RUN $url = 'https://dl.google.com/go/go1.17.6.windows-amd64.zip'; \
+RUN $url = 'https://dl.google.com/go/go1.17.7.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '5bf8f87aec7edfc08e6bc845f1c30dba6de32b863f89ae46553ff4bbcc1d4954'; \
+	$sha256 = '1b648165d62a2f5399f3c42c7e59de9f4aa457212c4ea763e1b650546fac72e2'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/1.17/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/1.17/windows/windowsservercore-ltsc2022/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.17.7
 
-RUN $url = 'https://dl.google.com/go/go1.17.6.windows-amd64.zip'; \
+RUN $url = 'https://dl.google.com/go/go1.17.7.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '5bf8f87aec7edfc08e6bc845f1c30dba6de32b863f89ae46553ff4bbcc1d4954'; \
+	$sha256 = '1b648165d62a2f5399f3c42c7e59de9f4aa457212c4ea763e1b650546fac72e2'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -35,7 +35,7 @@ variables:
   ${{ if eq(parameters.nightly, false) }}:
     value: "'microsoft/main'"
   ${{ if eq(parameters.nightly, true) }}:
-    value: "'nightly'"
+    value: "'microsoft/nightly'"
 
 - name: manifest
   value: manifest.json

--- a/manifest.json
+++ b/manifest.json
@@ -285,10 +285,10 @@
             "1-fips-cbl-mariner1.0": {},
             "1.17-fips": {},
             "1.17-fips-cbl-mariner1.0": {},
-            "1.17.6-1-fips": {},
-            "1.17.6-1-fips-cbl-mariner1.0": {},
-            "1.17.6-fips": {},
-            "1.17.6-fips-cbl-mariner1.0": {}
+            "1.17.7-1-fips": {},
+            "1.17.7-1-fips-cbl-mariner1.0": {},
+            "1.17.7-fips": {},
+            "1.17.7-fips-cbl-mariner1.0": {}
           },
           "platforms": [
             {
@@ -296,7 +296,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.17.6-1-fips-cbl-mariner1.0-amd64": {}
+                "1.17.7-1-fips-cbl-mariner1.0-amd64": {}
               }
             }
           ]

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -21,15 +21,15 @@ RUN tdnf install -y \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.17.7
 
 RUN set -eux; \
 	arch="$(uname -m)"; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220131.4/go.20220131.4.linux-amd64.tar.gz'; \
-			sha256='7fb05af800e2af224bcf03e5bf9d89cece7ff486a26aea85a8fe198c14781aa0'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220211.4/go.20220211.4.linux-amd64.tar.gz'; \
+			sha256='750881935e8304f1ecc84d76ecc356c25d6756bc396a4c61420df8f105e59a67'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -75,15 +75,23 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "7fb05af800e2af224bcf03e5bf9d89cece7ff486a26aea85a8fe198c14781aa0",
+        "sha256": "750881935e8304f1ecc84d76ecc356c25d6756bc396a4c61420df8f105e59a67",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220131.4/go.20220131.4.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220211.4/go.20220211.4.linux-amd64.tar.gz"
+      },
+      "windows-amd64": {
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "windows"
+        },
+        "sha256": "774a317b35681b6e71f8693d1027eaf87ffd01f19beaeb4e9acb7123354274b3",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220211.4/go.20220211.4.windows-amd64.zip"
       }
     },
     "variants": [
       "cbl-mariner1.0"
     ],
-    "version": "1.17.6",
+    "version": "1.17.7",
     "revision": "1",
     "preferredMinor": true,
     "preferredVariant": "cbl-mariner1.0",

--- a/versions.json
+++ b/versions.json
@@ -6,9 +6,9 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "275fc03c90c13b0bbff13125a43f1f7a9f9c00a0d5a9f2d5b16dbc2fa2c6e12a",
+        "sha256": "f4f5f02eb6809ac5bf19b5ad517b23504fd5fc036f6487651968ad36aa7a20e0",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.16.13.linux-amd64.tar.gz"
+        "url": "https://dl.google.com/go/go1.16.14.linux-amd64.tar.gz"
       },
       "arm32v5": {
         "env": {
@@ -24,9 +24,9 @@
           "GOARM": "6",
           "GOOS": "linux"
         },
-        "sha256": "cc68d35ee9d301cf4ad3f8844feeef5ae102102ea17dd2eb3b1f406f3df6ceba",
+        "sha256": "ed313a1a79ecba23b0d12a12b05003bf3ad55dfa76e611804d0295f641d68ec9",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.16.13.linux-armv6l.tar.gz"
+        "url": "https://dl.google.com/go/go1.16.14.linux-armv6l.tar.gz"
       },
       "arm32v7": {
         "env": {
@@ -34,54 +34,54 @@
           "GOARM": "7",
           "GOOS": "linux"
         },
-        "sha256": "cc68d35ee9d301cf4ad3f8844feeef5ae102102ea17dd2eb3b1f406f3df6ceba",
+        "sha256": "ed313a1a79ecba23b0d12a12b05003bf3ad55dfa76e611804d0295f641d68ec9",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.16.13.linux-armv6l.tar.gz"
+        "url": "https://dl.google.com/go/go1.16.14.linux-armv6l.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "3dd8e14837105cbfedf7124c7f8c524ce492748c370036c7316ef99e18d116d7",
+        "sha256": "5e59056e36704acb25809bcdb27191f27593cb7aba4d716b523008135a1e764a",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.16.13.linux-arm64.tar.gz"
+        "url": "https://dl.google.com/go/go1.16.14.linux-arm64.tar.gz"
       },
       "darwin-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "darwin"
         },
-        "sha256": "74cffa0c9b4bc4f358a66bfd6bc61d63b5c3cbabd35729b4953ec69c61376378",
+        "sha256": "671fc0673394b16747cc9fd4fe7f33de6a62610fd8c13b2cfad190a7280ec7ab",
         "supported": false,
-        "url": "https://dl.google.com/go/go1.16.13.darwin-amd64.tar.gz"
+        "url": "https://dl.google.com/go/go1.16.14.darwin-amd64.tar.gz"
       },
       "darwin-arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "darwin"
         },
-        "sha256": "545205b9a635e6196a59c5b6726aabb2cf3af25508bc8715934f12e8338c1f1a",
+        "sha256": "c97f02a5c93dcda5f0e25bc49a31761b31e9cb30de1e30f94033f5ddb9138133",
         "supported": false,
-        "url": "https://dl.google.com/go/go1.16.13.darwin-arm64.tar.gz"
+        "url": "https://dl.google.com/go/go1.16.14.darwin-arm64.tar.gz"
       },
       "freebsd-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "freebsd"
         },
-        "sha256": "643cb7252f16169c05db789ce3bfacdb34d04de1ac30896d7e4775f5b132248b",
+        "sha256": "aa5bc52c8839b0979e1c2fe8f847efc44a8725e191e9b457c8ce80b99870007b",
         "supported": false,
-        "url": "https://dl.google.com/go/go1.16.13.freebsd-amd64.tar.gz"
+        "url": "https://dl.google.com/go/go1.16.14.freebsd-amd64.tar.gz"
       },
       "freebsd-i386": {
         "env": {
           "GOARCH": "386",
           "GOOS": "freebsd"
         },
-        "sha256": "2c3734417843590b3a23a47312287f4663adbd9bb62510e11c89f6014509d7da",
+        "sha256": "c3e50940f3b773191a144141f1c3b00e997bde6421e4ff7315bec351aaa73538",
         "supported": false,
-        "url": "https://dl.google.com/go/go1.16.13.freebsd-386.tar.gz"
+        "url": "https://dl.google.com/go/go1.16.14.freebsd-386.tar.gz"
       },
       "i386": {
         "env": {
@@ -89,9 +89,9 @@
           "GOARCH": "386",
           "GOOS": "linux"
         },
-        "sha256": "5b1b9d10df8ccac44a32eccd3136b28f570a8ab580e6dad43d307d4d66ab6cd3",
+        "sha256": "b4cd4602267f60db851fc420b53524ab4449d4a4c52c33cdb87bb74abc870ebf",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.16.13.linux-386.tar.gz"
+        "url": "https://dl.google.com/go/go1.16.14.linux-386.tar.gz"
       },
       "mips64le": {
         "env": {
@@ -105,41 +105,41 @@
           "GOARCH": "ppc64le",
           "GOOS": "linux"
         },
-        "sha256": "f1a6a3e99e8d202f838f7780ac996bd03d691bdb097869938362ec001a226372",
+        "sha256": "b1dc70128e51dfff8fba3053e90b8c2754294f62feb96ab2e7b6e30ab164b4b1",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.16.13.linux-ppc64le.tar.gz"
+        "url": "https://dl.google.com/go/go1.16.14.linux-ppc64le.tar.gz"
       },
       "s390x": {
         "env": {
           "GOARCH": "s390x",
           "GOOS": "linux"
         },
-        "sha256": "f88eda38ba5f079f8af72c7f598bdbf1c13470336f8e677ff35548e24c3d53d6",
+        "sha256": "75ee0aee5fb0c22a047eb289e70c50c8e7088ddfc4f3a921c586d878ec1a88d8",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.16.13.linux-s390x.tar.gz"
+        "url": "https://dl.google.com/go/go1.16.14.linux-s390x.tar.gz"
       },
       "src": {
-        "sha256": "b0926654eaeb01ef43816638f42d7b1681f2d3f41b9559f07735522b7afad41a",
+        "sha256": "467898cd3a216de54dcb9014f541efe77e9b79a7154dbc1fd2dd778b0c63fb56",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.16.13.src.tar.gz"
+        "url": "https://dl.google.com/go/go1.16.14.src.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "76c938058444093bb6d95c5ee05db07c2b970f07d450d3b6d3cdea60edeb2765",
+        "sha256": "df3760d564477e5fc5ffb79496ca4b6667f7dd6d30f1baae9be83f7cc726a071",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.16.13.windows-amd64.zip"
+        "url": "https://dl.google.com/go/go1.16.14.windows-amd64.zip"
       },
       "windows-i386": {
         "env": {
           "GOARCH": "386",
           "GOOS": "windows"
         },
-        "sha256": "665698d8ef1c260d9f77d4127e947b1a29d044b999013f4da9c2f5a19a50de67",
+        "sha256": "420d90f09258c907bfef0e1e54b77b1c814c17b4f0b8ac74092909f3a8ab536a",
         "supported": false,
-        "url": "https://dl.google.com/go/go1.16.13.windows-386.zip"
+        "url": "https://dl.google.com/go/go1.16.14.windows-386.zip"
       }
     },
     "variants": [
@@ -153,7 +153,7 @@
       "windows/nanoserver-ltsc2022",
       "windows/nanoserver-1809"
     ],
-    "version": "1.16.13"
+    "version": "1.16.14"
   },
   "1.17": {
     "arches": {

--- a/versions.json
+++ b/versions.json
@@ -162,9 +162,9 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2",
+        "sha256": "02b111284bedbfa35a7e5b74a06082d18632eff824fd144312f6063943d49259",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.17.6.linux-amd64.tar.gz"
+        "url": "https://dl.google.com/go/go1.17.7.linux-amd64.tar.gz"
       },
       "arm32v5": {
         "env": {
@@ -180,9 +180,9 @@
           "GOARM": "6",
           "GOOS": "linux"
         },
-        "sha256": "9ac723e6b41cb7c3651099a09332a8a778b69aa63a5e6baaa47caf0d818e2d6d",
+        "sha256": "874774f078b182fa21ffcb3878467eb5cb7e78bbffa6343ea5f0fbe47983433b",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.17.6.linux-armv6l.tar.gz"
+        "url": "https://dl.google.com/go/go1.17.7.linux-armv6l.tar.gz"
       },
       "arm32v7": {
         "env": {
@@ -190,54 +190,54 @@
           "GOARM": "7",
           "GOOS": "linux"
         },
-        "sha256": "9ac723e6b41cb7c3651099a09332a8a778b69aa63a5e6baaa47caf0d818e2d6d",
+        "sha256": "874774f078b182fa21ffcb3878467eb5cb7e78bbffa6343ea5f0fbe47983433b",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.17.6.linux-armv6l.tar.gz"
+        "url": "https://dl.google.com/go/go1.17.7.linux-armv6l.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "82c1a033cce9bc1b47073fd6285233133040f0378439f3c4659fe77cc534622a",
+        "sha256": "a5aa1ed17d45ee1d58b4a4099b12f8942acbd1dd09b2e9a6abb1c4898043c5f5",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.17.6.linux-arm64.tar.gz"
+        "url": "https://dl.google.com/go/go1.17.7.linux-arm64.tar.gz"
       },
       "darwin-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "darwin"
         },
-        "sha256": "874bc6f95e07697380069a394a21e05576a18d60f4ba178646e1ebed8f8b1f89",
+        "sha256": "7c3d9cc70ee592515d92a44385c0cba5503fd0a9950f78d76a4587916c67a84d",
         "supported": false,
-        "url": "https://dl.google.com/go/go1.17.6.darwin-amd64.tar.gz"
+        "url": "https://dl.google.com/go/go1.17.7.darwin-amd64.tar.gz"
       },
       "darwin-arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "darwin"
         },
-        "sha256": "dc54f3f4099e2be9e9c33bf926a7dc3ad64f34717142f7abcaff9ae44bc03d0c",
+        "sha256": "e141bd85577b875cc771cfcc18604989c861e93bbef377ba6c80d29e18f9a338",
         "supported": false,
-        "url": "https://dl.google.com/go/go1.17.6.darwin-arm64.tar.gz"
+        "url": "https://dl.google.com/go/go1.17.7.darwin-arm64.tar.gz"
       },
       "freebsd-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "freebsd"
         },
-        "sha256": "2b759b0eb1fc25bc1da5612ac13f60c4bf4cd6f3c7e4f3fe3476f454d08de318",
+        "sha256": "41fcb0a94fe5f5000d871c50e076f8f1f769146b9767ae11d4c5296690d02677",
         "supported": false,
-        "url": "https://dl.google.com/go/go1.17.6.freebsd-amd64.tar.gz"
+        "url": "https://dl.google.com/go/go1.17.7.freebsd-amd64.tar.gz"
       },
       "freebsd-i386": {
         "env": {
           "GOARCH": "386",
           "GOOS": "freebsd"
         },
-        "sha256": "d5fbe0292fc0ae734041d54a5614712fa50337c76927df7bc749c27a543ed6a2",
+        "sha256": "20f8accd08087fa6d1aa7133b639f813b457a83af500fb550d9d9b2bb576f321",
         "supported": false,
-        "url": "https://dl.google.com/go/go1.17.6.freebsd-386.tar.gz"
+        "url": "https://dl.google.com/go/go1.17.7.freebsd-386.tar.gz"
       },
       "i386": {
         "env": {
@@ -245,9 +245,9 @@
           "GOARCH": "386",
           "GOOS": "linux"
         },
-        "sha256": "06c50fb0d44bb03dd4ea8795f9448379c5825d2765307b51f66905084c3ba541",
+        "sha256": "5d5472672a2e0252fe31f4ec30583d9f2b320f9b9296eda430f03cbc848400ce",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.17.6.linux-386.tar.gz"
+        "url": "https://dl.google.com/go/go1.17.7.linux-386.tar.gz"
       },
       "mips64le": {
         "env": {
@@ -261,50 +261,50 @@
           "GOARCH": "ppc64le",
           "GOOS": "linux"
         },
-        "sha256": "adc35c920b8c0253d4dd001f8979e0db4c6111a60cd5e0785a8bee95dba1fcaa",
+        "sha256": "2262fdee9147eb61fd1e719cfd19b9c035009c14890de02b5a77071b0a577405",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.17.6.linux-ppc64le.tar.gz"
+        "url": "https://dl.google.com/go/go1.17.7.linux-ppc64le.tar.gz"
       },
       "s390x": {
         "env": {
           "GOARCH": "s390x",
           "GOOS": "linux"
         },
-        "sha256": "ccb2d4509db846be7055d1105b28154e72cd43162c4ef79c38a936a3e6f26e1d",
+        "sha256": "24dd117581d592f52b4cf45d75ae68a6a1e42691a8671a2d3c2ddd739894a1e4",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.17.6.linux-s390x.tar.gz"
+        "url": "https://dl.google.com/go/go1.17.7.linux-s390x.tar.gz"
       },
       "src": {
-        "sha256": "4dc1bbf3ff61f0c1ff2b19355e6d88151a70126268a47c761477686ef94748c8",
+        "sha256": "c108cd33b73b1911a02b697741df3dea43e01a5c4e08e409e8b3a0e3745d2b4d",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.17.6.src.tar.gz"
+        "url": "https://dl.google.com/go/go1.17.7.src.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "5bf8f87aec7edfc08e6bc845f1c30dba6de32b863f89ae46553ff4bbcc1d4954",
+        "sha256": "1b648165d62a2f5399f3c42c7e59de9f4aa457212c4ea763e1b650546fac72e2",
         "supported": true,
-        "url": "https://dl.google.com/go/go1.17.6.windows-amd64.zip"
+        "url": "https://dl.google.com/go/go1.17.7.windows-amd64.zip"
       },
       "windows-arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "windows"
         },
-        "sha256": "c794af7c7fe32207df2c30a39cad1cca2e382c82a4e9493499fc2feab5967ca0",
+        "sha256": "acd6819e1d037551c091764a3ce3f86d8001c5756ebcfd304c4d7fbd38b0572b",
         "supported": false,
-        "url": "https://dl.google.com/go/go1.17.6.windows-arm64.zip"
+        "url": "https://dl.google.com/go/go1.17.7.windows-arm64.zip"
       },
       "windows-i386": {
         "env": {
           "GOARCH": "386",
           "GOOS": "windows"
         },
-        "sha256": "3809c4e40482ff047200c8b1e22a43a2c9c79b53ef540668d2b00f7228f093aa",
+        "sha256": "6be3a03549ee97de250a0dcc6658a5154e907540651a3fdec709e7b4df76038b",
         "supported": false,
-        "url": "https://dl.google.com/go/go1.17.6.windows-386.zip"
+        "url": "https://dl.google.com/go/go1.17.7.windows-386.zip"
       }
     },
     "variants": [
@@ -318,7 +318,7 @@
       "windows/nanoserver-ltsc2022",
       "windows/nanoserver-1809"
     ],
-    "version": "1.17.6"
+    "version": "1.17.7"
   },
   "1.18-rc": {
     "arches": {


### PR DESCRIPTION
Merge nightly into main to pick up an update to 1.17-fips. Also brings along an update from upstream (which doesn't affect our files) and an infra fix that doesn't affect `main`.

I plan to trigger a build that *only* builds the FIPS images (not the unchanged ones) and publishes them to MCR, after merging. (Using path args, like https://github.com/dotnet/dotnet-docker/blob/main/.github/ISSUE_TEMPLATE/releases/patch-tuesday-release.md.)