### PR TITLE
Merge nightly into main

### DIFF
--- a/1.16/alpine3.14/Dockerfile
+++ b/1.16/alpine3.14/Dockerfile
@@ -88,11 +88,6 @@ RUN set -eux; \
 		\
 		apk del --no-network .build-deps; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.16/alpine3.15/Dockerfile
+++ b/1.16/alpine3.15/Dockerfile
@@ -88,11 +88,6 @@ RUN set -eux; \
 		\
 		apk del --no-network .build-deps; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.16/bullseye/Dockerfile
+++ b/1.16/bullseye/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.16/buster/Dockerfile
+++ b/1.16/buster/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.16/stretch/Dockerfile
+++ b/1.16/stretch/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.17/alpine3.14/Dockerfile
+++ b/1.17/alpine3.14/Dockerfile
@@ -88,11 +88,6 @@ RUN set -eux; \
 		\
 		apk del --no-network .build-deps; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.17/alpine3.15/Dockerfile
+++ b/1.17/alpine3.15/Dockerfile
@@ -88,11 +88,6 @@ RUN set -eux; \
 		\
 		apk del --no-network .build-deps; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.17/bullseye/Dockerfile
+++ b/1.17/bullseye/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.17/buster/Dockerfile
+++ b/1.17/buster/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.17/stretch/Dockerfile
+++ b/1.17/stretch/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.18-rc/alpine3.14/Dockerfile
+++ b/1.18-rc/alpine3.14/Dockerfile
@@ -88,11 +88,6 @@ RUN set -eux; \
 		\
 		apk del --no-network .build-deps; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.18-rc/alpine3.15/Dockerfile
+++ b/1.18-rc/alpine3.15/Dockerfile
@@ -88,11 +88,6 @@ RUN set -eux; \
 		\
 		apk del --no-network .build-deps; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.18-rc/bullseye/Dockerfile
+++ b/1.18-rc/bullseye/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.18-rc/buster/Dockerfile
+++ b/1.18-rc/buster/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.18-rc/stretch/Dockerfile
+++ b/1.18-rc/stretch/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -156,11 +156,6 @@ RUN set -eux; \
 		rm -rf /var/lib/apt/lists/*; \
 {{ ) end -}}
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -7,6 +7,7 @@ jqt='.jq-template.awk'
 if [ -n "${BASHBREW_SCRIPTS:-}" ]; then
 	jqt="$BASHBREW_SCRIPTS/jq-template.awk"
 elif [ "$BASH_SOURCE" -nt "$jqt" ]; then
+	# https://github.com/docker-library/bashbrew/blob/master/scripts/jq-template.awk
 	wget -qO "$jqt" 'https://github.com/docker-library/bashbrew/raw/1da7341a79651d28fbcc3d14b9176593c4231942/scripts/jq-template.awk'
 fi
 

--- a/src/microsoft/1.16/buster/Dockerfile
+++ b/src/microsoft/1.16/buster/Dockerfile
@@ -27,8 +27,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.16/20220209.9/go.20220209.9.linux-amd64.tar.gz'; \
-			sha256='190381cc3dff2453d3f7eddf74a8fae49b30317d840b78b0086b394a4f5f28fc'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.16/20220215.1/go.20220215.1.linux-amd64.tar.gz'; \
+			sha256='dbb155d91f44638c81d36b2565aede1605deedf01740a1c4b10fd275d61a0673'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.16/buster/Dockerfile
+++ b/src/microsoft/1.16/buster/Dockerfile
@@ -83,11 +83,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/src/microsoft/1.16/stretch/Dockerfile
+++ b/src/microsoft/1.16/stretch/Dockerfile
@@ -27,8 +27,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.16/20220209.9/go.20220209.9.linux-amd64.tar.gz'; \
-			sha256='190381cc3dff2453d3f7eddf74a8fae49b30317d840b78b0086b394a4f5f28fc'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.16/20220215.1/go.20220215.1.linux-amd64.tar.gz'; \
+			sha256='dbb155d91f44638c81d36b2565aede1605deedf01740a1c4b10fd275d61a0673'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.16/stretch/Dockerfile
+++ b/src/microsoft/1.16/stretch/Dockerfile
@@ -83,11 +83,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/src/microsoft/1.16/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.16/windows/windowsservercore-1809/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 
 ENV GOLANG_VERSION 1.16.14
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.16/20220209.9/go.20220209.9.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.16/20220215.1/go.20220215.1.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '1ae66e1ad62a1dbed3ee83dbdc1e4628cc4524a22865f5883ebb4feb3a62e01f'; \
+	$sha256 = '695b1d62403d85e25dcecd0a42b73afd1bf516301084ea54e843b66aa9f93a19'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.16/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/1.16/windows/windowsservercore-ltsc2016/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 
 ENV GOLANG_VERSION 1.16.14
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.16/20220209.9/go.20220209.9.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.16/20220215.1/go.20220215.1.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '1ae66e1ad62a1dbed3ee83dbdc1e4628cc4524a22865f5883ebb4feb3a62e01f'; \
+	$sha256 = '695b1d62403d85e25dcecd0a42b73afd1bf516301084ea54e843b66aa9f93a19'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -28,8 +28,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220211.4/go.20220211.4.linux-amd64.tar.gz'; \
-			sha256='750881935e8304f1ecc84d76ecc356c25d6756bc396a4c61420df8f105e59a67'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220216.3/go.20220216.3.linux-amd64.tar.gz'; \
+			sha256='416eb5c5b81d5802a6f5baeec8c3abcacae438da81a026d00129d72852a6760f'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
@@ -83,11 +83,6 @@ RUN set -eux; \
 		apt-mark manual $savedAptMark > /dev/null; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
-		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
 		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \

--- a/src/microsoft/1.17/bullseye/Dockerfile
+++ b/src/microsoft/1.17/bullseye/Dockerfile
@@ -83,11 +83,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/src/microsoft/1.17/bullseye/Dockerfile
+++ b/src/microsoft/1.17/bullseye/Dockerfile
@@ -27,8 +27,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220210.1/go.20220210.1.linux-amd64.tar.gz'; \
-			sha256='3e8fc2d4e412f927fae92feb6077c94e223732bd627b8d0919f9bdb67dd0f012'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220215.2/go.20220215.2.linux-amd64.tar.gz'; \
+			sha256='f6b229872daf22e6eb1e5ad44612b04f331e007d643ec7c79f57dd378a7f495e'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/buster/Dockerfile
+++ b/src/microsoft/1.17/buster/Dockerfile
@@ -83,11 +83,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/src/microsoft/1.17/buster/Dockerfile
+++ b/src/microsoft/1.17/buster/Dockerfile
@@ -27,8 +27,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220210.1/go.20220210.1.linux-amd64.tar.gz'; \
-			sha256='3e8fc2d4e412f927fae92feb6077c94e223732bd627b8d0919f9bdb67dd0f012'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220215.2/go.20220215.2.linux-amd64.tar.gz'; \
+			sha256='f6b229872daf22e6eb1e5ad44612b04f331e007d643ec7c79f57dd378a7f495e'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/stretch/Dockerfile
+++ b/src/microsoft/1.17/stretch/Dockerfile
@@ -83,11 +83,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/src/microsoft/1.17/stretch/Dockerfile
+++ b/src/microsoft/1.17/stretch/Dockerfile
@@ -27,8 +27,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220210.1/go.20220210.1.linux-amd64.tar.gz'; \
-			sha256='3e8fc2d4e412f927fae92feb6077c94e223732bd627b8d0919f9bdb67dd0f012'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220215.2/go.20220215.2.linux-amd64.tar.gz'; \
+			sha256='f6b229872daf22e6eb1e5ad44612b04f331e007d643ec7c79f57dd378a7f495e'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-1809/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.17.7
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220210.1/go.20220210.1.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220215.2/go.20220215.2.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '68a1224869c8840787fe59f9b7a96aa05fba284a218f7380209c7d979c0a2bc9'; \
+	$sha256 = 'ad1e3a2bbbaa0235ed5d99fffd43d5d0be06ae16bfb4704f8f53330c80d84eab'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-ltsc2016/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.17.7
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220210.1/go.20220210.1.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220215.2/go.20220215.2.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '68a1224869c8840787fe59f9b7a96aa05fba284a218f7380209c7d979c0a2bc9'; \
+	$sha256 = 'ad1e3a2bbbaa0235ed5d99fffd43d5d0be06ae16bfb4704f8f53330c80d84eab'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-ltsc2022/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.17.7
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220210.1/go.20220210.1.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220215.2/go.20220215.2.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '68a1224869c8840787fe59f9b7a96aa05fba284a218f7380209c7d979c0a2bc9'; \
+	$sha256 = 'ad1e3a2bbbaa0235ed5d99fffd43d5d0be06ae16bfb4704f8f53330c80d84eab'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -38,18 +38,18 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "3e8fc2d4e412f927fae92feb6077c94e223732bd627b8d0919f9bdb67dd0f012",
+        "sha256": "f6b229872daf22e6eb1e5ad44612b04f331e007d643ec7c79f57dd378a7f495e",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220210.1/go.20220210.1.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220215.2/go.20220215.2.linux-amd64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "68a1224869c8840787fe59f9b7a96aa05fba284a218f7380209c7d979c0a2bc9",
+        "sha256": "ad1e3a2bbbaa0235ed5d99fffd43d5d0be06ae16bfb4704f8f53330c80d84eab",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220210.1/go.20220210.1.windows-amd64.zip"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220215.2/go.20220215.2.windows-amd64.zip"
       }
     },
     "variants": [

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -6,18 +6,18 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "190381cc3dff2453d3f7eddf74a8fae49b30317d840b78b0086b394a4f5f28fc",
+        "sha256": "dbb155d91f44638c81d36b2565aede1605deedf01740a1c4b10fd275d61a0673",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.16/20220209.9/go.20220209.9.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.16/20220215.1/go.20220215.1.linux-amd64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "1ae66e1ad62a1dbed3ee83dbdc1e4628cc4524a22865f5883ebb4feb3a62e01f",
+        "sha256": "695b1d62403d85e25dcecd0a42b73afd1bf516301084ea54e843b66aa9f93a19",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.16/20220209.9/go.20220209.9.windows-amd64.zip"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.16/20220215.1/go.20220215.1.windows-amd64.zip"
       }
     },
     "variants": [

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -75,17 +75,17 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "750881935e8304f1ecc84d76ecc356c25d6756bc396a4c61420df8f105e59a67",
+        "sha256": "416eb5c5b81d5802a6f5baeec8c3abcacae438da81a026d00129d72852a6760f",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220211.4/go.20220211.4.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220216.3/go.20220216.3.linux-amd64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "774a317b35681b6e71f8693d1027eaf87ffd01f19beaeb4e9acb7123354274b3",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220211.4/go.20220211.4.windows-amd64.zip"
+        "sha256": "c1e850744b25fc167df1e3f0b8408e24ece5f7d4cff037624ee1e6597399d85c",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220216.3/go.20220216.3.windows-amd64.zip"
       }
     },
     "variants": [


### PR DESCRIPTION
The important thing this brings in is the 1.17-fips update--I only plan to trigger a build for these tags. This is a clean merge commit.

This also brings in updates to the other branches, and a merge from upstream that doesn't affect our images.

It *would* be at least a little better to keep out the non-1.17-fips updates so `microsoft/main` represents the latest we've pushed to MCR, but it's difficult to piece together, in part because we're still on the Git fork model rather than isolating our changes from upstream with a submodule.

Once we're on submodules, we can more easily follow the .NET Docker model, where changes to individual tags are ported over individually to keep `microsoft/main` stable and in sync with the latest on MCR. (.NET Docker actually has a much more deliberate process that doesn't involve copying--it's more like replaying the changes and using merge commits to keep track of what's going on: https://github.com/dotnet/dotnet-docker/blob/main/.github/ISSUE_TEMPLATE/releases/dotnet-release.md.)