### PR TITLE
[nightly] Update SUPPORT.md

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,25 +1,18 @@
-# TODO: The maintainer of this repo has not yet edited this file
-
-**REPO OWNER**: Do you want Customer Service & Support (CSS) support for this product/project?
-
-- **No CSS support:** Fill out this template with information about how to file issues and get help.
-- **Yes CSS support:** Fill out an intake form at [aka.ms/spot](https://aka.ms/spot). CSS will work with/help you to determine next steps. More details also available at [aka.ms/onboardsupport](https://aka.ms/onboardsupport).
-- **Not sure?** Fill out a SPOT intake as though the answer were "Yes". CSS will help you decide.
-
-*Then remove this first heading from this SUPPORT.MD file before publishing your repo.*
-
 # Support
 
-## How to file issues and get help  
+For help and questions about the Go programming language and tools, visit the official website: <https://go.dev/>.
 
-This project uses GitHub Issues to track bugs and feature requests. Please search the existing 
-issues before filing new issues to avoid duplicates.  For new issues, file your bug or 
-feature request as a new Issue.
+## How to file issues and get help
 
-For help and questions about using this project, please **REPO MAINTAINER: INSERT INSTRUCTIONS HERE 
-FOR HOW TO ENGAGE REPO OWNERS OR COMMUNITY FOR HELP. COULD BE A STACK OVERFLOW TAG OR OTHER
-CHANNEL. WHERE WILL YOU HELP PEOPLE?**.
+This project uses GitHub Issues in the [microsoft/go repository][microsoft/go] to track bugs and feature requests.
+Please search the existing issues before filing new issues to avoid duplicates.
+For new issues, [file your bug or feature request as a new Issue in microsoft/go][file].
 
-## Microsoft Support Policy  
+For help and questions about the microsoft/go-images project, please [file an issue in microsoft/go][file].
 
-Support for this **PROJECT or PRODUCT** is limited to the resources listed above.
+## Microsoft Support Policy
+
+Support for this project is limited to the resources listed above.
+
+[microsoft/go]: https://github.com/microsoft/go
+[file]: https://github.com/microsoft/go/issues/new/choose


### PR DESCRIPTION
Rendered: https://github.com/dagood/go-images/blob/dev/dagood/supportmd/SUPPORT.md

Copy from https://github.com/microsoft/go/blob/microsoft/main/SUPPORT.md, but direct people to the microsoft/go repo for centralized issue tracking.