### PR TITLE
Add tag doc, add more detail to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,37 @@
 # Docker images containing the Microsoft build of Go
 
-This repository creates Docker images that contain the Microsoft build of Go
-produced by the [microsoft/go](https://github.com/microsoft/go) repository. The
-tags are published on the Microsoft Container Registry (MCR) in the
-`oss/go/microsoft/golang` repository.
+This repository creates Docker images that contain the Microsoft build of Go produced by the [microsoft/go](https://github.com/microsoft/go) repository. The tags are published on the Microsoft Container Registry (MCR) in the `oss/go/microsoft/golang` repository.
 
-The submodule named `go` contains the source code for the official Golang image
-repository, https://github.com/docker-library/golang. The submodule contains
-templates that this repository uses to create the Dockerfiles that contain the
-Microsoft build of Go.
+In general, the microsoft/go-images tag names match those available for the [Docker Hub golang official image](https://hub.docker.com/_/golang). To switch from the official image to one on MCR, it may be possible to simply prepend `mcr.microsoft.com/oss/go/microsoft/` to the official image you would normally use.
 
-See [eng/README.md](eng/README.md) for information about the infrastructure.
+This tag is recommended for general build scenarios:
 
-To view the list of available tags:
+```
+mcr.microsoft.com/oss/go/microsoft/golang:1.17-bullseye
+```
 
-* Microsoft Container Registry API: https://mcr.microsoft.com/v2/oss/go/microsoft/golang/tags/list
+If you need to build a FIPS-compatible app, use a `fips` tag, such as:
+
+```
+mcr.microsoft.com/oss/go/microsoft/golang:1.17-fips-cbl-mariner1.0
+```
+
+For more information about building FIPS-compatible Go apps with the Microsoft Go tools, visit [the FIPS readme](https://github.com/microsoft/go/tree/microsoft/dev.boringcrypto.go1.17/eng/doc/fips) and [user guide](https://github.com/microsoft/go/blob/microsoft/dev.boringcrypto.go1.17/eng/doc/fips/UserGuide.md) in the microsoft/go repository.
+
+To view the full list of available Go tags in MCR:
+
+* Use the [Microsoft Container Registry API](https://mcr.microsoft.com/v2/oss/go/microsoft/golang/tags/list)
   * The full tag URL is `mcr.microsoft.com/{name}:{tag}`
-* AZCU Indexer (Microsoft auth required): https://azcuindexer.azurewebsites.net/repositories/oss/go/microsoft/golang
+* Visit the [AZCU Indexer](https://azcuindexer.azurewebsites.net/repositories/oss/go/microsoft/golang) (*Microsoft internal auth required*)
   * Click on a tag name to copy the full tag URL to your clipboard
+
+See [Tags of microsoft/go-images](docs/tags.md) for more information about tag names and support.
+
+## Is this repository a fork?
+
+We think it's accurate to call this repository a fork of the official Golang image repository, [docker-library/golang](https://github.com/docker-library/golang). See [microsoft/go#is-this-repository-a-fork](https://github.com/microsoft/go#is-this-repository-a-fork) for more details why.
+
+The submodule named `go` contains the official image source code. The templates in `go` are used to create the Dockerfiles in this repo, at [`src/microsoft`](src/microsoft). See the [eng README file](eng) for more information about this repository's infrastructure.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [Tags of microsoft/go-images](docs/tags.md) for more information about tag n
 
 ## Is this repository a fork?
 
-We think it's accurate to call this repository a fork of the official Golang image repository, [docker-library/golang](https://github.com/docker-library/golang). See [microsoft/go#is-this-repository-a-fork](https://github.com/microsoft/go#is-this-repository-a-fork) for more details why.
+We think it's accurate to call this repository a fork of the official Golang image repository, [docker-library/golang](https://github.com/docker-library/golang). The branches here do not share Git ancestry with docker-library/golang. However, the repository serves the same purpose as a Git fork: maintaining a modified version of the Go source code over time.
 
 The submodule named `go` contains the official image source code. The templates in `go` are used to create the Dockerfiles in this repo, at [`src/microsoft`](src/microsoft). See the [eng README file](eng) for more information about this repository's infrastructure.
 

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,62 @@
+# Tags of microsoft/go-images
+
+This repository's build infrastructure is based on the .NET Docker tooling. The Microsoft Go tagging practices are largely the same as .NET Docker's, and we both strive to align with the official Docker image tagging practices.
+
+See [.NET Supported Tags](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md) for .NET Docker's description of this tagging strategy. This document is based on .NET's, but describes the Microsoft Go tags.
+
+# Simple tags
+
+In go-images, a *simple tag* references the image for a specific version of Go, on a specific OS, on a specific platform. The only way to be more specific about a Go image is to use a digest instead of a tag.
+
+In general, these shouldn't be used in Dockerfile `FROM` statements. It would prevent auto-update to the latest, patched, images. It also prevents the Dockerfile from working on multiple architectures (`amd64`/`arm64`) when it otherwise might.
+
+Examples:
+
+* `1.17.7-1-bullseye-amd64`
+* `1.17.7-1-fips-cbl-mariner1.0-amd64`
+
+> This document uses `1.17.7-1` as a placeholder for *the most recent release of Microsoft Go*. Check MCR for the actual latest tag versions and available OS/Distros.
+
+# Shared tags
+
+A *shared tag* references images for multiple platforms. The Go shared tags have these characteristics:
+
+* Include all architectures that are available in microsoft/go-images.
+* When no OS/Distro is specified in the tag, use the most recent Debian distribution.
+* When a part of the version number is omitted, the most recent matching version is used.
+
+Examples:
+
+* `1.17-bullseye`
+* `1.17-fips-cbl-mariner1.0`
+* `1`
+
+# Tag parts
+
+* `1.{major}.{minor}-{revision}{extra}-{os/distro}-{architecture}`
+  * `major` and `minor` describe the version of the official Go source code that was used. This is not semver: we use upstream Go's definition of `major` and `minor` versions.
+  * `revision` is the Microsoft revision of Go.
+    * This is incremented when Microsoft needs to release a new microsoft/go build but upstream hasn't released a new version yet.
+    * This is *not* incremented when there are Dockerfile-specific changes, base images change, or when platforms are added and removed.
+  * `extra` specifies that the image is specialized for a particular scenario.
+    * `-fips` is a only `extra` as of writing. It indicates the image is capable of building FIPS-compatible Go apps.
+  * `os/distro` is the OS or Linux distribution of the base image.
+  * `architecture` is the platform architecture of the image, e.g. `amd64`.
+
+# Tag lifecycle
+
+The Go versions supported by this repo follow the support lifecycle of [microsoft/go](https://github.com/microsoft/go), which generates the Go binaries used in this repository. OS versions are supported until the OS is EOL. When a tag's Go support or OS support ends, the tag is no longer supported.
+
+The microsoft/go-images repository has two active branches:
+
+* `microsoft/main`
+  * This branch is updated when there is a new, stable release of microsoft/go, the underlying OS has a change that is important to users of the Microsoft Go images, or the Dockerfile itself is updated.
+  * Tags produced by this branch are published to MCR. 
+* `microsoft/nightly`
+  * This branch is frequently updated to new non-production-quality builds of Go. For example, the branch may contain bugfixes that have been committed to a Go release branch, even though the commits aren't part of any release yet. 
+  * Actual rate of updates varies: not necessarily nightly. `nightly` is just terminology borrowed from .NET, used to indicate this is not the stable branch.
+  * The tags produced by this branch are not published to MCR.
+
+## Policy Changes
+
+In the event that a change is needed to the tagging patterns we use, all tags for the previous pattern will continue to be supported for their original lifetime.


### PR DESCRIPTION
Adds detail to the readme, and adds a doc that describes our tagging strategy based on a similar .NET Docker doc.

Rendered view: https://github.com/dagood/go-images/tree/dev/dagood/tag-docs#readme