### PR TITLE
Update to 1.17.8-1 FIPS

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -285,10 +285,10 @@
             "1-fips-cbl-mariner1.0": {},
             "1.17-fips": {},
             "1.17-fips-cbl-mariner1.0": {},
-            "1.17.7-1-fips": {},
-            "1.17.7-1-fips-cbl-mariner1.0": {},
-            "1.17.7-fips": {},
-            "1.17.7-fips-cbl-mariner1.0": {}
+            "1.17.8-1-fips": {},
+            "1.17.8-1-fips-cbl-mariner1.0": {},
+            "1.17.8-fips": {},
+            "1.17.8-fips-cbl-mariner1.0": {}
           },
           "platforms": [
             {
@@ -296,7 +296,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.17.7-1-fips-cbl-mariner1.0-amd64": {}
+                "1.17.8-1-fips-cbl-mariner1.0-amd64": {}
               }
             }
           ]

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -21,7 +21,7 @@ RUN tdnf install -y \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.7
+ENV GOLANG_VERSION 1.17.8
 
 RUN set -eux; \
 	arch="$(uname -m)"; \

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -28,8 +28,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220216.3/go.20220216.3.linux-amd64.tar.gz'; \
-			sha256='416eb5c5b81d5802a6f5baeec8c3abcacae438da81a026d00129d72852a6760f'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.3/go.20220307.3.linux-amd64.tar.gz'; \
+			sha256='6877d8a8f0a640b239ab3193e1327a18d38e557a896ac66d21c1f8ef56cff763'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -91,7 +91,7 @@
     "variants": [
       "cbl-mariner1.0"
     ],
-    "version": "1.17.7",
+    "version": "1.17.8",
     "revision": "1",
     "preferredMinor": true,
     "preferredVariant": "cbl-mariner1.0",

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -75,17 +75,17 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "416eb5c5b81d5802a6f5baeec8c3abcacae438da81a026d00129d72852a6760f",
+        "sha256": "6877d8a8f0a640b239ab3193e1327a18d38e557a896ac66d21c1f8ef56cff763",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220216.3/go.20220216.3.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.3/go.20220307.3.linux-amd64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "c1e850744b25fc167df1e3f0b8408e24ece5f7d4cff037624ee1e6597399d85c",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220216.3/go.20220216.3.windows-amd64.zip"
+        "sha256": "a5aba99ca5fc6cf8bdef0d61ca0b916ed663e03bfca15177549bf404b4315909",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.3/go.20220307.3.windows-amd64.zip"
       }
     },
     "variants": [


### PR DESCRIPTION
* https://github.com/microsoft/go/issues/458

The first commit is an auto-update from the 1.17.8-1 FIPS build asset JSON. In the second commit, I updated 1.17.7 -> 1.17.8 in `src/microsoft/versions.json` and ran `dockerupdate` again to propagate the version number change. (Because the upstream boring branch doesn't have a `VERSION` file to use to do this automatically.)