### PR TITLE
Update to 1.17.8-2-fips, 1.18.0-2-fips

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -168,8 +168,8 @@
           "sharedTags": {
             "1.17-fips": {},
             "1.17-fips-cbl-mariner1.0": {},
-            "1.17.8-1-fips": {},
-            "1.17.8-1-fips-cbl-mariner1.0": {},
+            "1.17.8-2-fips": {},
+            "1.17.8-2-fips-cbl-mariner1.0": {},
             "1.17.8-fips": {},
             "1.17.8-fips-cbl-mariner1.0": {}
           },
@@ -179,7 +179,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.17.8-1-fips-cbl-mariner1.0-amd64": {}
+                "1.17.8-2-fips-cbl-mariner1.0-amd64": {}
               }
             }
           ]
@@ -364,8 +364,8 @@
             "1-fips-cbl-mariner1.0": {},
             "1.18-fips": {},
             "1.18-fips-cbl-mariner1.0": {},
-            "1.18.0-1-fips": {},
-            "1.18.0-1-fips-cbl-mariner1.0": {},
+            "1.18.0-2-fips": {},
+            "1.18.0-2-fips-cbl-mariner1.0": {},
             "1.18.0-fips": {},
             "1.18.0-fips-cbl-mariner1.0": {}
           },
@@ -375,7 +375,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.18.0-1-fips-cbl-mariner1.0-amd64": {}
+                "1.18.0-2-fips-cbl-mariner1.0-amd64": {}
               }
             }
           ]

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -28,8 +28,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.3/go.20220307.3.linux-amd64.tar.gz'; \
-			sha256='6877d8a8f0a640b239ab3193e1327a18d38e557a896ac66d21c1f8ef56cff763'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.6/go.20220329.6.linux-amd64.tar.gz'; \
+			sha256='661b1d3d3d2b1a2d8d151a85c6972c0995ce18098639b8f72668f6b587834ad4'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
@@ -28,8 +28,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.linux-amd64.tar.gz'; \
-			sha256='5a9074b309dbaa30faff98f1fcffd4488c39e4cb1398832908bbd4b57ef92873'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220329.7/go.20220329.7.linux-amd64.tar.gz'; \
+			sha256='3ea93d412f30297866d60bc728278197ea9c9ee8671167f1b207782af9e9e7f6'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -41,24 +41,24 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "6877d8a8f0a640b239ab3193e1327a18d38e557a896ac66d21c1f8ef56cff763",
+        "sha256": "661b1d3d3d2b1a2d8d151a85c6972c0995ce18098639b8f72668f6b587834ad4",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.3/go.20220307.3.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.6/go.20220329.6.linux-amd64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "a5aba99ca5fc6cf8bdef0d61ca0b916ed663e03bfca15177549bf404b4315909",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.3/go.20220307.3.windows-amd64.zip"
+        "sha256": "d873b137e5778faffb967cfe92ec7e9ab30dfb283ed3211d097e46273753eec4",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.6/go.20220329.6.windows-amd64.zip"
       }
     },
     "variants": [
       "cbl-mariner1.0"
     ],
     "version": "1.17.8",
-    "revision": "1",
+    "revision": "2",
     "preferredVariant": "cbl-mariner1.0",
     "branchSuffix": "-fips"
   },
@@ -106,24 +106,24 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "5a9074b309dbaa30faff98f1fcffd4488c39e4cb1398832908bbd4b57ef92873",
+        "sha256": "3ea93d412f30297866d60bc728278197ea9c9ee8671167f1b207782af9e9e7f6",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220329.7/go.20220329.7.linux-amd64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "b07dac951f9dd4fbf9677e92d9ac320bf1486f313d49f16bcef5fd1696ab91c2",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.windows-amd64.zip"
+        "sha256": "1c2f4bb1abe9eccf7b33589abd3f114d549c2f35fb8643d5526b74a4c0394c1a",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220329.7/go.20220329.7.windows-amd64.zip"
       }
     },
     "variants": [
       "cbl-mariner1.0"
     ],
     "version": "1.18.0",
-    "revision": "1",
+    "revision": "2",
     "preferredMinor": true,
     "preferredVariant": "cbl-mariner1.0",
     "branchSuffix": "-fips"


### PR DESCRIPTION
This is the result of running `dockerupdate` on each build's build asset JSON file, no other modifications. (Enabling automerge to merge with one approval.)

* Fixes this issue that shows up in our images if the user sets `CGO_ENABLED=0`:  
  https://github.com/microsoft/go/issues/492

Once this PR goes through, I'll queue the builds to get this onto MCR.
