### PR TITLE
[nightly] Update eng/common to dotnet-docker@54cdf56af

### DIFF
--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -33,22 +33,27 @@ else {
     $DotnetInstallScript = "dotnet-install.ps1"
 }
 
-if (!(Test-Path $DotnetInstallScript)) {
+$DotnetInstallScriptPath = Join-Path -Path $InstallPath -ChildPath $DotnetInstallScript
+
+if (!(Test-Path $DotnetInstallScriptPath)) {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
-    & "$PSScriptRoot/Invoke-WithRetry.ps1" "Invoke-WebRequest 'https://dot.net/v1/$DotnetInstallScript' -OutFile $InstallPath/$DotnetInstallScript"
+    & "$PSScriptRoot/Invoke-WithRetry.ps1" "Invoke-WebRequest 'https://dot.net/v1/$DotnetInstallScript' -OutFile $DotnetInstallScriptPath"
 }
 
-$DotnetChannel = "5.0"
+$DotnetChannel = "Current"
 
 $InstallFailed = $false
 if ($IsRunningOnUnix) {
-    & chmod +x $InstallPath/$DotnetInstallScript
-    & $InstallPath/$DotnetInstallScript --channel $DotnetChannel --version "latest" --install-dir $InstallPath
+    & chmod +x $DotnetInstallScriptPath
+    & $DotnetInstallScriptPath --channel $DotnetChannel --version "latest" --install-dir $InstallPath
     $InstallFailed = ($LASTEXITCODE -ne 0)
 }
 else {
-    & $InstallPath/$DotnetInstallScript -Channel $DotnetChannel -Version "latest" -InstallDir $InstallPath
+    & $DotnetInstallScriptPath -Channel $DotnetChannel -Version "latest" -InstallDir $InstallPath
     $InstallFailed = (-not $?)
 }
+
+# See https://github.com/NuGet/NuGet.Client/pull/4259
+$Env:NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY = "3,1000"
 
 if ($InstallFailed) { throw "Failed to install the .NET Core SDK" }

--- a/eng/common/Retain-Build.ps1
+++ b/eng/common/Retain-Build.ps1
@@ -1,0 +1,43 @@
+# Adapted from https://github.com/dotnet/arcade/blob/main/eng/common/retain-build.ps1
+Param(
+    [Parameter(Mandatory = $true)][int] $BuildId,
+    [Parameter(Mandatory = $true)][string] $AzdoOrgUri, 
+    [Parameter(Mandatory = $true)][string] $AzdoProject,
+    [Parameter(Mandatory = $true)][string] $Token
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+function Get-AzDOHeaders(
+    [string] $Token) {
+    $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":${Token}"))
+    $headers = @{"Authorization" = "Basic $base64AuthInfo" }
+    return $headers
+}
+
+function Update-BuildRetention(
+    [string] $AzdoOrgUri,
+    [string] $AzdoProject,
+    [int] $BuildId,
+    [string] $Token) {
+    $headers = Get-AzDOHeaders -Token $Token
+    $requestBody = "{
+        `"keepForever`": `"true`"
+    }"
+
+    $requestUri = "${AzdoOrgUri}/${AzdoProject}/_apis/build/builds/${BuildId}?api-version=6.0"
+    Write-Host "Attempting to retain build using the following URI: ${requestUri} ..."
+
+    try {
+        Invoke-RestMethod -Uri $requestUri -Method Patch -Body $requestBody -Header $headers -contentType "application/json"
+        Write-Host "Updated retention settings for build ${BuildId}."
+    }
+    catch {
+        Write-Host "##[error] Failed to update retention settings for build: $($_.Exception.Response.StatusDescription)"
+        exit 1
+    }
+}
+
+Update-BuildRetention -AzdoOrgUri $AzdoOrgUri -AzdoProject $AzdoProject -BuildId $BuildId -Token $Token
+exit 0

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -50,23 +50,23 @@ try {
     $args = $OptionalImageBuilderArgs
 
     if ($Version) {
-        $args += " --version " + ($Version -join " --version ")
+        $args += ($Version | foreach { ' --version "{0}"' -f $_ })
     }
 
     if ($OS) {
-        $args += " --os-version " + ($OS -join " --os-version ")
+        $args += ($OS | foreach { ' --os-version "{0}"' -f $_ })
     }
 
     if ($Architecture) {
-        $args += " --architecture $Architecture"
+        $args += ' --architecture "{0}"' -f $Architecture
     }
 
     if ($Paths) {
-        $args += " --path " + ($Paths -join " --path ")
+        $args += ($Paths | foreach { ' --path "{0}"' -f $_ })
     }
 
     if ($Manifest) {
-        $args += " --manifest $Manifest"
+        $args += ' --manifest "{0}"' -f $Manifest
     }
 
     ./eng/common/Invoke-ImageBuilder.ps1 "build $args"

--- a/eng/common/package-scripts/Dockerfile.scripts
+++ b/eng/common/package-scripts/Dockerfile.scripts
@@ -1,0 +1,3 @@
+ARG BASETAG
+FROM $BASETAG
+COPY . /scripts

--- a/eng/common/package-scripts/get-installed-packages.container.sh
+++ b/eng/common/package-scripts/get-installed-packages.container.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env sh
+
+pkgManagerArgs="$PKG_MANAGER_ARGS"
+
+# If package manager is apt
+if type apt > /dev/null 2>/dev/null; then
+    # Extract the package name and version out of the list of installed packages.
+    # Example output of "apt list":
+    #   zlib1g/now 1:1.2.11.dfsg-1 amd64 [installed,local]
+    # Regex consists of two capture groups:
+    #   1: Package name: all chars up until the first '/' character
+    #   2: Package version: substring after the first whitespace occurrence and before the next whitespace
+    # Output is the format of "DEB,<pkg-name>=<pkg-version>"
+    apt list --installed $pkgManagerArgs 2>/dev/null | grep installed | sed -n 's/^\([^/]*\)\S*\s\(\S*\).*/DEB,\1=\2/p' | sort
+    exit 0
+fi
+
+# If package manager is apk
+if type apk > /dev/null 2>/dev/null; then
+    # Extract the package name and version out of the list of installed packages.
+    # This uses the output of the "apk info" command to build a regex to find the version from the "apk list"
+    # command. The reason the "apk info -v" or "apk list --installed" commands (which provide both the package name and version)
+    # aren't used just by itself is because of the ambiguity between what characters are part of the package name and which are 
+    # part of the version. For example, the output for something like "libssl1.1-1.1.1k-r0" can be ambiguous because of the dash 
+    # separator. In this case, the package name is "libssl1.1" and the version is "1.1.1k-r0". You can't necessarily assume that 
+    # the first '-' character indicates a version separator because some package names also contain a '-' character.  What the 
+    # command below does is to first get the list of package names (w/o any versions) and then feed each package name into another
+    # command to lookup that package name with the "apk list" command to get the version details.
+    # Example of the output of "apk info -d musl":
+    #   musl-1.2.2-r3 description:
+    #   the musl c library (libc) implementation
+    # Output is the format of "APK,<pkg-name>=<pkg-version>"
+    apk info $pkgManagerArgs 2>/dev/null | xargs -I {} sh -c "apk list 2>/dev/null {} | grep '\[installed\]' 2>/dev/null | sed -n 's/\({}\)-\(\S*\)\s.*/APK,\1=\2/p'" | sort
+    exit 0
+fi
+
+formatRpmPackagesOutput() {
+    # Extract the RPM package name and version out of the list of installed packages.
+    # Example output:
+    #   zstd-libs.x86_64   1.4.4-1.cm1   @System
+    # Because some package names can be very long, the output can be split across multiple lines if not formatted
+    # properly. To do this, the columns are piped with xargs to be formatted by the column command.
+    # Regex consists of two capture groups:
+    #   1: Package name: all chars up until the last '.' character of the first column
+    #   2: Package version: substring after the remaining arch text/whitespace and before the next whitespace
+    # Output is the format of "RPM,<pkg-name>=<pkg-version>"
+    tail -n +2 | xargs -n3 | column -t | sed -n 's/^\(\S*\)\.\S*\s*\(\S*\)\s*.*/RPM,\1=\2/p'
+}
+commonRpmBasedPkgManagerArgs="list installed $pkgManagerArgs --quiet"
+
+# If package manager is dnf
+if type dnf > /dev/null 2>/dev/null; then
+    dnf $commonRpmBasedPkgManagerArgs | formatRpmPackagesOutput
+    exit 0
+fi
+
+# If package manager is tdnf
+if type tdnf > /dev/null 2>/dev/null; then
+    tdnf $commonRpmBasedPkgManagerArgs | formatRpmPackagesOutput
+    exit 0
+fi
+
+# If package manager is yum
+if type yum > /dev/null 2>/dev/null; then
+    yum $commonRpmBasedPkgManagerArgs | formatRpmPackagesOutput
+    exit 0
+fi
+
+# If package manager is zypper
+if type zypper > /dev/null 2>/dev/null; then
+    # Extract the package name and version out of the list of installed packages.
+    # Example output:
+    # i+ | glibc  | package | 2.26-lp152.26.9.1  | x86_64 | Main Update Repository
+    # Regex consists of two capture groups:
+    #   1: Package name: Skips the Status column and captures the characters surrounded by the vertical bars indicating the Name column.
+    #   2: Package version: The next column after the Type (package) column.
+    # Output is the format of "RPM,<pkg-name>=<pkg-version>"
+    zypper --quiet search --installed-only --type package --details 2>/dev/null | sed -n 's/^[^|]*|\s*\(\S*\)\s*|\s*package\s*|\s*\(\S*\).*/RPM,\1=\2/p' | sort
+    exit 0
+fi
+
+echo "Unsupported package manager. Current supported package managers: apt, apk, dnf, tdnf, yum, zypper" >&2
+exit 1

--- a/eng/common/package-scripts/get-installed-packages.sh
+++ b/eng/common/package-scripts/get-installed-packages.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env sh
+
+# This is the main script for retrieving the list of installed packages.
+
+usage() {
+    echo "Usage: $0 [<OPTIONS>...] IMAGETAG DOCKERFILEPATH"
+    echo
+    echo "Queries a container to determine which packages are installed"
+    echo 
+    echo "Options:"
+    echo "  -h: Print this help message"
+    echo "  -a: Additional package manager args"
+    echo "Arguments:"
+    echo "  IMAGETAG: The tag of the image to query"
+    echo "  DOCKERFILEPATH: The path to the image's Dockerfile"
+}
+
+while getopts "ha:o:" opt; do
+    case $opt in
+        h)
+            usage
+            exit 0
+            ;;
+        a)
+            pkgManagerArgs=$OPTARG
+            shift 2
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            exit 1
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+imageTag=$1
+dockerfilePath=$2
+scriptDir=$(dirname $(realpath $0))
+
+docker run \
+    --rm \
+    -i \
+    -e PKG_MANAGER_ARGS="$pkgManagerArgs" \
+    --entrypoint /bin/sh \
+    --user root \
+    $imageTag \
+    < $scriptDir/get-installed-packages.container.sh

--- a/eng/common/package-scripts/get-upgradable-packages.container.bash.sh
+++ b/eng/common/package-scripts/get-upgradable-packages.container.bash.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+
+# This is the Bash-based script for retrieving the list of upgradable packages
+
+printPackageInfo() {
+    echo $1
+    echo "- Current: $2"
+    echo "- Upgrade: $3"
+}
+
+writeError() {
+    echo "Error: $1" >>/dev/stderr
+    exit 1
+}
+
+addUpgradeablePackageVersion() {
+    local pkgName=$1
+    local currentVersion=$2
+    local upgradeVersion=$3
+
+    # If the package is not already in the list, add it
+    if [[ -z ${upgradablePackageVersions[$pkgName]} ]]; then
+        local versionData=$(echo "$currentVersion,$upgradeVersion")
+        upgradablePackageVersions[$pkgName]=$versionData
+
+        printPackageInfo "$pkgName" "$currentVersion" "$upgradeVersion"
+    fi
+}
+
+checkForUpgradableVersionWithApt() {
+    pkgName=$1
+    pkgVersion=$2
+
+    echo "Finding latest version of package $pkgName"
+    local pkgInfo=$(apt policy $pkgManagerArgs $pkgName 2>/dev/null)
+    if [[ $pkgInfo == "" ]]; then
+        writeError "Package '$pkgName' does not exist."
+    fi
+
+    # Get the candidate version of the package to be installed
+    local candidateVersion=$(echo "$pkgInfo" | sed -n 's/.*Candidate:\s*\(\S*\)/\1/p')
+
+    # If a newer version of the package is available
+    if [[ $candidateVersion != $pkgVersion ]]; then
+        # Check if the candidate package version comes from a security repository
+        apt-cache madison $pkgName | grep $candidateVersion | grep security 1>/dev/null
+
+        # If the candidate version comes from a security repository, add it to the list of upgradable packages
+        if [[ $? == 0 ]]; then
+            addUpgradeablePackageVersion "$pkgName" "$pkgVersion" "$candidateVersion"
+        fi
+    fi
+}
+
+checkForUpgradableVersionWithApk() {
+    pkgName=$1
+    pkgVersion=$2
+
+    echo "Finding latest version of package $pkgName"
+    availableVersion=$(apk list $pkgManagerArgs $pkgName | tac | sed -n "1 s/$pkgName-\(\S*\).*/\1/p")
+    if [[ $availableVersion == "" ]]; then
+        writeError "Package '$pkgName' does not exist."
+    fi
+
+    # If a newer version of the package is available
+    if [[ $availableVersion != $pkgVersion ]]; then
+        # If the package exists, add it to the list of upgradable packages
+        if [[ $availableVersion != "" ]]; then
+            addUpgradeablePackageVersion "$pkgName" "$pkgVersion" "$availableVersion"
+        fi
+    fi
+}
+
+checkForUpgradableVersionWithCommonRpmBasedPkgMgr() {
+    pkgName=$1
+    pkgVersion=$2
+    pkgManagerName=$3
+    headerLineCount=${4:-2}
+
+    echo "Finding latest version of package $pkgName"
+    $pkgManagerName install $pkgManagerArgs -y $pkgName 1>/dev/null 2>/dev/null
+
+    # If the package exists
+    if [[ $? == 0 ]]; then
+        local installedVersion=$($pkgManagerName list installed $pkgManagerArgs $pkgName | tail -n +$headerLineCount | sed -n 's/\S*\s*\(\S*\)\s*.*/\1/p')
+        # If a newer version of the package is available
+        if [[ $installedVersion != $pkgVersion ]]; then
+            addUpgradeablePackageVersion "$pkgName" "$pkgVersion" "$installedVersion"
+        fi
+    else
+        writeError "Package '$pkgName' does not exist."
+    fi
+}
+
+checkForUpgradableVersionWithDnf() {
+    pkgName=$1
+    pkgVersion=$2
+
+    checkForUpgradableVersionWithCommonRpmBasedPkgMgr "$pkgName" "$pkgVersion" "dnf"
+}
+
+checkForUpgradableVersionWithTdnf() {
+    pkgName=$1
+    pkgVersion=$2
+
+    checkForUpgradableVersionWithCommonRpmBasedPkgMgr "$pkgName" "$pkgVersion" "tdnf"
+}
+
+checkForUpgradableVersionWithYum() {
+    pkgName=$1
+    pkgVersion=$2
+
+    checkForUpgradableVersionWithCommonRpmBasedPkgMgr "$pkgName" "$pkgVersion" "yum" 3
+}
+
+checkForUpgradableVersionWithZypper() {
+    pkgName=$1
+    pkgVersion=$2
+
+    echo "Finding latest version of package $pkgName"
+    availableVersion=$(zypper info $pkgManagerArgs $pkgName | sed -n 's/^Version\s*:\s*\(\S*\).*/\1/p')
+    if [[ $availableVersion == "" ]]; then
+        writeError "Package '$pkgName' does not exist."
+    fi
+
+    # If a newer version of the package is available
+    if [[ $availableVersion != $pkgVersion ]]; then
+        # If the package exists, add it to the list of upgradable packages
+        if [[ $availableVersion != "" ]]; then
+            addUpgradeablePackageVersion "$pkgName" "$pkgVersion" "$availableVersion"
+        fi
+    fi
+}
+
+outputPackagesToUpgrade() {
+    echo
+    echo "Packages requiring an upgrade:"
+
+    local packagesToUpgrade=()
+    local pkg
+    # Lookup the provided package names to see if any are in the list of upgradable packages
+    for pkg in "${packages[@]}"
+    do
+        if [[ ! $pkg =~ $packageVersionRegex ]]; then
+            writeError "Unable to parse package version info. Value: $pkg"
+        fi
+
+        local pkgName=${BASH_REMATCH[1]}
+        versionData=${upgradablePackageVersions[$pkgName]}
+
+        if [ ! -z "$versionData" ]; then
+            # Split versionData by comma
+            local versionArray=( ${versionData//,/ } )
+            local currentVersion=${versionArray[0]}
+            local upgradeVersion=${versionArray[1]}
+            
+            packagesToUpgrade+=($(echo "$pkgName,$currentVersion,$upgradeVersion"))
+            printPackageInfo "$pkgName" "$currentVersion" "$upgradeVersion"
+        fi
+    done
+
+    local upgradeCount=${#packagesToUpgrade[@]}
+    if [ $upgradeCount = 0 ]; then
+        echo "<none>"
+    fi
+
+    local outputDir=$(dirname "$outputPath")
+    mkdir -p $outputDir
+
+    printf "%s\n" "${packagesToUpgrade[@]}" > $outputPath
+}
+
+updatePackageCacheWithApt() {
+    apt update 1>/dev/null 2>/dev/null
+}
+
+updatePackageCacheWithApk() {
+    apk update 1>/dev/null
+}
+
+updatePackageCacheWithCommonRpmBasedPkgMgr() {
+    pkgMgr=$1
+    $1 makecache 1>/dev/null
+}
+
+updatePackageCacheWithDnf() {
+    updatePackageCacheWithCommonRpmBasedPkgMgr dnf
+}
+
+updatePackageCacheWithTdnf() {
+    updatePackageCacheWithCommonRpmBasedPkgMgr tdnf
+}
+
+updatePackageCacheWithYum() {
+    updatePackageCacheWithCommonRpmBasedPkgMgr yum
+}
+
+updatePackageCacheWithZypper() {
+    zypper ref 1>/dev/null
+}
+
+
+
+outputPath="$1"
+pkgManagerArgs="$2"
+shift 2
+packages=( $@ )
+
+declare -A upgradablePackageVersions
+upgradablePackageVersions=()
+
+if type apt > /dev/null 2>/dev/null; then
+    pkgType="Apt"
+elif type apk > /dev/null 2>/dev/null; then
+    pkgType="Apk"
+elif type dnf > /dev/null 2>/dev/null; then
+    pkgType="Dnf"
+elif type tdnf > /dev/null 2>/dev/null; then
+    pkgType="Tdnf"
+elif type yum > /dev/null 2>/dev/null; then
+    pkgType="Yum"
+elif type zypper > /dev/null 2>/dev/null; then
+    pkgType="Zypper"
+else
+    writeError "Unsupported package manager. Current supported package managers: apt, apk, tdnf, yum, zypper"
+fi
+
+if [[ $(type -t updatePackageCacheWith$pkgType) != "function" ]]; then
+    writeError "Missing function named 'updatePackageCacheWith$pkgType'"
+fi
+
+if [[ $(type -t checkForUpgradableVersionWith$pkgType) != "function" ]]; then
+    writeError "Missing function named 'checkForUpgradableVersionWith$pkgType'"
+fi
+
+echo "Updating package cache..."
+updatePackageCacheWith$pkgType
+
+packageVersionRegex="(\S+)=(\S+)"
+for pkgName in "${packages[@]}"
+do
+    echo "Processing $pkgName"
+    if [[ ! $pkgName =~ $packageVersionRegex ]]; then
+        writeError "Package version info for '$pkgName' must be in the form of <pkg-name>=<pkg-version>"
+    fi
+
+    checkForUpgradableVersionWith$pkgType ${BASH_REMATCH[1]} ${BASH_REMATCH[2]}
+done
+outputPackagesToUpgrade

--- a/eng/common/package-scripts/get-upgradable-packages.container.sh
+++ b/eng/common/package-scripts/get-upgradable-packages.container.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env sh
+
+# This is just a wrapper around the Bash-based script. This ensures that Bash is installed and then runs the Bash script. 
+
+ensureBashInstalledForApt() {
+    echo "Ensuring bash is installed"
+    apt update 1>/dev/null 2>/dev/null
+    apt install -y bash 1>/dev/null 2>/dev/null
+}
+
+ensureBashInstalledForApk() {
+    echo "Ensuring bash is installed"
+    apk add bash 1>/dev/null
+}
+
+ensureBashInstalledForRpmBasedPkgMgr() {
+    echo "Ensuring bash is installed"
+    local pkgMgr=$1
+    $pkgMgr makecache 1>/dev/null
+    $pkgMgr install -y bash 1>/dev/null
+}
+
+ensureBashInstalledForZypper() {
+    echo "Ensuring bash is installed"
+    zypper ref 1>/dev/null
+    zypper install -y bash 1>/dev/null
+}
+
+
+scriptDir=$(dirname $0)
+
+outputPath="$1"
+pkgManagerArgs="$2"
+shift 2
+packages=$@
+
+if type apt > /dev/null 2>/dev/null; then
+    ensureBashInstalledForApt
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+if type apk > /dev/null 2>/dev/null; then
+    ensureBashInstalledForApk
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+if type dnf > /dev/null 2>/dev/null; then
+    ensureBashInstalledForRpmBasedPkgMgr dnf
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+if type tdnf > /dev/null 2>/dev/null; then
+    ensureBashInstalledForRpmBasedPkgMgr tdnf
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+if type yum > /dev/null 2>/dev/null; then
+    ensureBashInstalledForRpmBasedPkgMgr yum
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+if type zypper > /dev/null 2>/dev/null; then
+    ensureBashInstalledForZypper
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+echo "Unsupported package manager. Current supported package managers: apt, apk, tdnf, yum, zypper" >&2
+exit 1

--- a/eng/common/package-scripts/get-upgradable-packages.sh
+++ b/eng/common/package-scripts/get-upgradable-packages.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env sh
+
+# This is the main script for retrieving the list of upgradable packages.
+
+usage() {
+    echo "Usage: $0 [<OPTIONS>...] IMAGETAG DOCKERFILEPATH [PACKAGEVERSION...]"
+    echo
+    echo "Queries a container to determine which packages are upgradable"
+    echo 
+    echo "Options:"
+    echo "  -h: Print this help message"
+    echo "  -a: Additional package manager args"
+    echo "  -o: Output path for a formatted list of upgradable packages"
+    echo "Arguments:"
+    echo "  IMAGETAG: The tag of the image to query"
+    echo "  DOCKERFILEPATH: The path to the image's Dockerfile"
+    echo "  PACKAGEVERSION: A package version to check whether its upgradable (format: NAME=VERSION)"
+}
+
+while getopts "ha:o:" opt; do
+    case $opt in
+        h)
+            usage
+            exit 0
+            ;;
+        a)
+            pkgManagerArgs=$OPTARG
+            shift 2
+            ;;
+        o)
+            outputPath=$OPTARG
+            shift 2
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            exit 1
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+imageTag=$1
+dockerfilePath=$2
+shift 2
+packagelist=$@
+
+scriptDir="$(dirname $(realpath $0))"
+containerName="container$RANDOM"
+containerOutputPath="/$containerName.txt"
+
+scriptsWrapperImageTag="tag$RANDOM"
+docker build -t $scriptsWrapperImageTag -f $scriptDir/Dockerfile.scripts --build-arg BASETAG=$imageTag $scriptDir 1>/dev/null 2>/dev/null
+
+docker run \
+    --name $containerName \
+    --entrypoint /bin/sh \
+    --user root \
+    $scriptsWrapperImageTag \
+    -c "/scripts/get-upgradable-packages.container.sh $containerOutputPath \"$pkgManagerArgs\" $packagelist"
+
+if [ -n "$outputPath" ]; then
+    docker cp $containerName:$containerOutputPath $outputPath
+fi
+
+docker rm $containerName 1>/dev/null

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -13,7 +13,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  condition: and(${{ parameters.matrix }}, in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
+  condition: and(${{ parameters.matrix }}, not(canceled()), in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
   dependsOn:
   - PreBuildValidation
   - CopyBaseImages
@@ -25,6 +25,7 @@ jobs:
   variables:
     imageBuilderDockerRunExtraOptions: $(build.imageBuilderDockerRunExtraOptions)
     versionsRepoPath: versions
+    sbomDirectory: $(Build.ArtifactStagingDirectory)/sbom
     ${{ if eq(parameters.noCache, false) }}:
       versionsBasePath: $(versionsRepoPath)/
       pipelineDisabledCache: false
@@ -65,13 +66,25 @@ jobs:
         echo "##vso[task.setvariable variable=testScriptPath]$testScriptPath"
         echo "##vso[task.setvariable variable=testResultsDirectory]$testResultsDirectory"
       displayName: Override Common Paths
+  - powershell: |
+      if ("${{ parameters.noCache }}" -eq "false") {
+        $baseContainerRepoPath = "/repo/$(buildRepoName)"
+      }
+      else {
+        $baseContainerRepoPath = "/repo"
+      }
+      echo "##vso[task.setvariable variable=baseContainerRepoPath]$baseContainerRepoPath"
+    displayName: Set Base Container Repo Path
   - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}
   - ${{ parameters.customInitSteps }}
   - template: ../steps/set-image-info-path-var.yml
     parameters:
       publicSourceBranch: $(publicSourceBranch)
+  - powershell: echo "##vso[task.setvariable variable=imageBuilderBuildArgs]"
+    condition: eq(variables.imageBuilderBuildArgs, '')
+    displayName: Initialize Image Builder Build Args
   - powershell: |
-      $imageBuilderBuildArgs = "$(imageBuilder.queueArgs) --image-info-output-path $(artifactsPath)/$(legName)-image-info.json"
+      $imageBuilderBuildArgs = "$(imageBuilderBuildArgs) $(imageBuilder.queueArgs) --image-info-output-path $(artifactsPath)/$(legName)-image-info.json"
       if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.internalProjectName }}") {
         $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push --registry-creds ""$(acr.server)=$(acr.userName);$(acr.password)"""
       }
@@ -83,7 +96,7 @@ jobs:
 
       echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$imageBuilderBuildArgs"
     displayName: Set Image Builder Build Args
-  - script: >
+  - powershell: >
       $(runImageBuilderCmd) build
       --manifest $(manifest)
       $(imageBuilderPaths)
@@ -92,14 +105,55 @@ jobs:
       --architecture $(architecture)
       --retry
       --source-repo $(publicGitRepoUri)
+      --get-installed-pkgs-path $(baseContainerRepoPath)/$(engCommonRelativePath)/package-scripts/get-installed-packages.sh
+      --digests-out-var 'builtImages'
       $(manifestVariables)
       $(imageBuilderBuildArgs)
+    name: BuildImages
     displayName: Build Images
   - publish: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
     artifact: $(legName)-image-info-$(System.JobAttempt)
     displayName: Publish Image Info File Artifact
+  - ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+      # Define the task here to load it into the agent so that we can invoke the tool manually
+    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+      inputs:
+        BuildDropPath: $(Build.ArtifactStagingDirectory)
+      displayName: Load Manifest Generator
+      condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))
+    - powershell: |
+        $images = "$(BuildImages.builtImages)"
+        if (-not $images) { return 0 }
+        $taskDir = $(Get-ChildItem -Recurse -Directory -Filter "ManifestGeneratorTask*" -Path '$(Agent.WorkFolder)').FullName
+        $manifestToolDllPath = $(Get-ChildItem -Recurse -File -Filter "Microsoft.ManifestTool.dll" -Path $taskDir).FullName
+        $dotnetDir = $(Get-ChildItem -Recurse -Directory -Filter "dotnet-*" -Path $taskDir).FullName
+
+        # Call the manifest tool for each image to produce seperate SBOMs
+        # Manifest tool docs: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/custom-sbom-generation-workflows
+        $images -Split ',' | ForEach-Object {
+          echo "Generating SBOM for $_";
+          $formattedImageName = $_.Replace('$(acr.server)/$(stagingRepoPrefix)', "").Replace('/', '_').Replace(':', '_');
+          $sbomChildDir = "$(sbomDirectory)/$formattedImageName";
+          New-Item -Type Directory -Path $sbomChildDir > $null;
+          & "$dotnetDir/dotnet" "$manifestToolDllPath" `
+            Generate `
+            -BuildDropPath '$(Build.ArtifactStagingDirectory)' `
+            -BuildComponentPath '$(Agent.BuildDirectory)' `
+            -PackageName '.NET' `
+            -PackageVersion '$(Build.BuildNumber)' `
+            -ManifestDirPath $sbomChildDir `
+            -DockerImagesToScan $_ `
+            -Verbosity Information 
+        }
+      displayName: Generate SBOMs
+      condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))
   - ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
     - template: ${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}
       parameters:
         condition: ne(variables.testScriptPath, '')
   - template: ${{ format('../steps/cleanup-docker-{0}.yml', parameters.dockerClientOS) }}
+  - ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+    - publish: $(sbomDirectory)
+      artifact: $(legName)-sboms
+      displayName: Publish SBOM
+      condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))

--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -10,6 +10,7 @@ jobs:
 - job: ${{ parameters.name }}
   pool: ${{ parameters.pool }}
   steps:
+  - template: ../steps/retain-build.yml
   - template: ../steps/init-docker-linux.yml
   - template: ../steps/validate-branch.yml
     parameters:

--- a/eng/common/templates/jobs/generate-sbom.yml
+++ b/eng/common/templates/jobs/generate-sbom.yml
@@ -1,0 +1,47 @@
+parameters:
+  pool: {}
+
+jobs:
+- job: GenerateSBOM
+  pool: ${{ parameters.pool }}
+  strategy:
+    matrix:
+      amd64:
+        arch: amd64
+      arm32:
+        arch: arm
+      arm64:
+        arch: arm64
+  variables:
+    sbomDirectory: $(Build.ArtifactStagingDirectory)/sbom
+  steps:
+  - template: ../steps/init-docker-linux.yml
+  - template: ../steps/download-build-artifact.yml
+    parameters:
+      targetPath: $(Build.ArtifactStagingDirectory)
+      artifactName: image-info
+  - script: >
+      $(runImageBuilderCmd) trimUnchangedPlatforms
+      '$(artifactsPath)/image-info.json'
+    displayName: Trim Unchanged Images
+  - script: >
+      $(runImageBuilderCmd) pullImages
+      --architecture '$(arch)'
+      --manifest 'manifest.json'
+      --output-var 'pulledImages'
+      --image-info '$(artifactsPath)/image-info.json'
+    name: PullImages
+    displayName: Pull Images
+  - script: mkdir $(sbomDirectory)
+    displayName: Create SBOM Directory
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: Generate SBOM
+    inputs:
+      PackageName: ".NET"
+      PackageVersion: $(Build.BuildNumber)
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
+      ManifestDirPath: $(sbomDirectory)
+      dockerImagesToScan: $(PullImages.pulledImages)
+  - publish: $(sbomDirectory)
+    artifact: sbom_linux_$(arch)
+    displayName: Publish SBOM

--- a/eng/common/templates/jobs/post-build.yml
+++ b/eng/common/templates/jobs/post-build.yml
@@ -1,15 +1,34 @@
+parameters:
+  pool: {}
+
 jobs:
 - job: Build
-  pool:
-    vmImage: $(defaultLinuxAmd64PoolImage)
+  pool: ${{ parameters.pool }}
+  variables:
+    imageInfosSubDir: "/image-infos"
+    sbomSubDir: "/sbom"
   steps:
   - template: ../steps/init-docker-linux.yml
   - template: ../steps/download-build-artifact.yml
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
-  - pwsh: |
+  - powershell: |
+      # Move all image-info artifacts to their own directory
+      New-Item -ItemType Directory -Path $(Build.ArtifactStagingDirectory)$(imageInfosSubDir)
+      Get-ChildItem -Directory -Filter "*-image-info-*" $(Build.ArtifactStagingDirectory) |
+        Move-Item -Verbose -Destination $(Build.ArtifactStagingDirectory)$(imageInfosSubDir)
+    displayName: Collect Image Info Files
+  - powershell: |
+      # Move the contents of all the SBOM artifact directories to a single location
+      New-Item -ItemType Directory -Path $(Build.ArtifactStagingDirectory)$(sbomSubDir)
+      Get-ChildItem -Directory -Filter "*-sboms" $(Build.ArtifactStagingDirectory) |
+        ForEach-Object {
+          Get-ChildItem $_ -Directory | Move-Item -Verbose -Destination $(Build.ArtifactStagingDirectory)$(sbomSubDir)
+        }
+    displayName: Consolidate SBOMs to Single Directory
+  - powershell: |
       # Deletes the artifacts from all the unsuccessful jobs
-      Get-ChildItem $(Build.ArtifactStagingDirectory) -Directory |
+      Get-ChildItem $(Build.ArtifactStagingDirectory)$(imageInfosSubDir) -Directory |
           ForEach-Object {
               [pscustomobject]@{
                   # Parse the artifact name to separate the base of the name from the job attempt number 
@@ -30,10 +49,13 @@ jobs:
   - script: >
       $(runImageBuilderCmd) mergeImageInfo
       --manifest $(manifest)
-      $(artifactsPath)
-      $(artifactsPath)/image-info.json
+      $(artifactsPath)$(imageInfosSubDir)
+      $(artifactsPath)$(imageInfosSubDir)/image-info.json
       $(manifestVariables)
     displayName: Merge Image Info Files
-  - publish: $(Build.ArtifactStagingDirectory)/image-info.json
+  - publish: $(Build.ArtifactStagingDirectory)$(sbomSubDir)
+    artifact: sboms
+    displayName: Publish SBOM Artifact
+  - publish: $(Build.ArtifactStagingDirectory)$(imageInfosSubDir)/image-info.json
     artifact: image-info
     displayName: Publish Image Info File Artifact

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -14,9 +14,16 @@ jobs:
       --registry-override '$(acr.server)'
       $(manifestVariables)
       $(imageBuilder.queueArgs)
+  - name: publishNotificationRepoName
+    value: $(Build.Repository.Name)
   - ${{ parameters.customPublishVariables }}
   steps:
+  - template: ../steps/retain-build.yml
   - template: ../steps/init-docker-linux.yml
+  - pwsh: |
+      $azdoOrgName = Split-Path -Leaf $Env:SYSTEM_COLLECTIONURI
+      echo "##vso[task.setvariable variable=azdoOrgName]$azdoOrgName"
+    displayName: Set Publish Variables
   - ${{ parameters.customInitSteps }}
   - template: ../steps/validate-branch.yml
     parameters:
@@ -86,16 +93,10 @@ jobs:
       '$(gitHubVersionsRepoInfo.userName)'
       '$(gitHubVersionsRepoInfo.email)'
       '$(gitHubVersionsRepoInfo.accessToken)'
-      '$(azdoVersionsRepoInfo.accessToken)'
-      '$(azdoVersionsRepoInfo.org)'
-      '$(azdoVersionsRepoInfo.project)'
       --git-owner '$(gitHubVersionsRepoInfo.org)'
       --git-repo '$(gitHubVersionsRepoInfo.repo)'
       --git-branch '$(gitHubVersionsRepoInfo.branch)'
       --git-path '$(gitHubImageInfoVersionsPath)'
-      --azdo-repo '$(azdoVersionsRepoInfo.repo)'
-      --azdo-branch '$(azdoVersionsRepoInfo.branch)'
-      --azdo-path '$(azdoImageInfoVersionsPath)'
       $(dryRunArg)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Image Info
@@ -121,4 +122,27 @@ jobs:
       $(imageBuilder.commonCmdArgs)
     displayName: Ingest Kusto Image Info
     condition: and(succeeded(), eq(variables['ingestKustoImageInfo'], 'true'))
+  - script: >
+      $(runImageBuilderCmd) postPublishNotification
+      '$(publishNotificationRepoName)'
+      '$(Build.SourceBranchName)'
+      '$(artifactsPath)/image-info.json'
+      $(Build.BuildId)
+      '$(System.AccessToken)'
+      '$(azdoOrgName)'
+      '$(System.TeamProject)'
+      '$(gitHubNotificationsRepoInfo.accessToken)'
+      '$(gitHubNotificationsRepoInfo.org)'
+      '$(gitHubNotificationsRepoInfo.repo)'
+      --task "Copy Images"
+      --task "Publish Manifest"
+      --task "Wait for Image Ingestion"
+      --task "Publish Readmes"
+      --task "Wait for MCR Doc Ingestion"
+      --task "Publish Image Info"
+      --task "Ingest Kusto Image Info"
+      $(dryRunArg)
+      $(imageBuilder.commonCmdArgs)
+    displayName: Post Publish Notification
+    condition: and(always(), eq(variables['publishNotificationsEnabled'], 'true'))
   - template: ../steps/cleanup-docker-linux.yml

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -33,8 +33,6 @@ parameters:
     vmImage: $(defaultWindows2016PoolImage)
   windows1809Pool:
     vmImage: $(defaultWindows1809PoolImage)
-  windows2004Pool:
-    vmImage: $(defaultWindows2004PoolImage)
   windows20H2Pool:
     vmImage: $(defaultWindows20H2PoolImage)
   windows2022Pool:
@@ -85,9 +83,9 @@ stages:
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
   - template: ../jobs/build-images.yml
     parameters:
-      name: Linux_arm64v8
+      name: Linux_arm64
       pool: ${{ parameters.linuxArm64Pool }}
-      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm64v8']
+      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm64']
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
@@ -98,9 +96,9 @@ stages:
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
   - template: ../jobs/build-images.yml
     parameters:
-      name: Linux_arm32v7
+      name: Linux_arm32
       pool: ${{ parameters.linuxArm32Pool }}
-      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm32v7']
+      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm32']
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
@@ -114,19 +112,6 @@ stages:
       name: Windows1809_amd64
       pool: ${{ parameters.windows1809Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows1809Amd64']
-      dockerClientOS: windows
-      buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
-      customInitSteps: ${{ parameters.customBuildInitSteps }}
-      noCache: ${{ parameters.noCache }}
-      internalProjectName: ${{ parameters.internalProjectName }}
-      publicProjectName: ${{ parameters.publicProjectName }}
-      internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
-      publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
-    parameters:
-      name: Windows2004_amd64
-      pool: ${{ parameters.windows2004Pool }}
-      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows2004Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
@@ -183,6 +168,8 @@ stages:
   condition: and(succeeded(), contains(variables['stages'], 'build'))
   jobs:
   - template: ../jobs/post-build.yml
+    parameters:
+      pool: ${{ parameters.linuxAmd64Pool }}
 
 ################################################################################
 # Test Images
@@ -220,16 +207,16 @@ stages:
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-linux-client.yml
       parameters:
-        name: Linux_arm64v8
+        name: Linux_arm64
         pool: ${{ parameters.linuxArm64Pool }}
-        matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm64v8']
+        matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm64']
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-linux-client.yml
       parameters:
-        name: Linux_arm32v7
+        name: Linux_arm32
         pool: ${{ parameters.linuxArm32Pool }}
-        matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm32v7']
+        matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm32']
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-windows-client.yml
@@ -237,13 +224,6 @@ stages:
         name: Windows1809_amd64
         pool: ${{ parameters.windows1809Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1809Amd64']
-        testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
-        internalProjectName: ${{ parameters.internalProjectName }}
-    - template: ../jobs/test-images-windows-client.yml
-      parameters:
-        name: Windows2004_amd64
-        pool: ${{ parameters.windows2004Pool }}
-        matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows2004Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-windows-client.yml
@@ -278,31 +258,33 @@ stages:
     dependsOn: Post_Build
   condition: "
     and(
-      contains(variables['stages'], 'publish'),
-      or(
+      not(canceled()),
+      and(
+        contains(variables['stages'], 'publish'),
         or(
-          and(
-            and(
-              contains(variables['stages'], 'build'),
-              succeeded('Post_Build')),
-            and(
-              contains(variables['stages'], 'test'),
-              in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
           or(
             and(
-              not(contains(variables['stages'], 'build')),
+              and(
+                contains(variables['stages'], 'build'),
+                succeeded('Post_Build')),
               and(
                 contains(variables['stages'], 'test'),
                 in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
-            and(
-              not(contains(variables['stages'], 'test')),
+            or(
               and(
-                contains(variables['stages'], 'build'),
-                succeeded('Post_Build'))))),
-        not(
-          or(
-            contains(variables['stages'], 'build'),
-            contains(variables['stages'], 'test')))))"
+                not(contains(variables['stages'], 'build')),
+                and(
+                  contains(variables['stages'], 'test'),
+                  in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
+              and(
+                not(contains(variables['stages'], 'test')),
+                and(
+                  contains(variables['stages'], 'build'),
+                  succeeded('Post_Build'))))),
+          not(
+            or(
+              contains(variables['stages'], 'build'),
+              contains(variables['stages'], 'test'))))))"
   jobs:
   - template: ../jobs/publish.yml
     parameters:

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -6,13 +6,13 @@ parameters:
   internalProjectName: null
   publicProjectName: null
   buildMatrixCustomBuildLegGroupArgs: ""
+  testMatrixCustomBuildLegGroupArgs: ""
   customBuildInitSteps: []
   customPublishInitSteps: []
   windowsAmdBuildJobTimeout: 60
   windowsAmdTestJobTimeout: 60
   linuxAmdBuildJobTimeout: 60
-  linuxAmd64Pool:
-    vmImage: $(defaultLinuxAmd64PoolImage)
+  linuxAmd64Pool: ""
   buildMatrixType: platformDependencyGraph
   testMatrixType: platformVersionedOs
 
@@ -23,8 +23,27 @@ stages:
     internalProjectName: ${{ parameters.internalProjectName }}
     publicProjectName: ${{ parameters.publicProjectName }}
     buildMatrixCustomBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
+    testMatrixCustomBuildLegGroupArgs: ${{ parameters.testMatrixCustomBuildLegGroupArgs }}
     customBuildInitSteps: ${{ parameters.customBuildInitSteps }}
-    customPublishInitSteps: ${{ parameters.customPublishInitSteps }}
+    customPublishInitSteps:
+    - pwsh: |
+        # When reporting the repo name in the publish notification, we don't want to include
+        # the org part of the repo name (e.g. we want "dotnet-docker", not "dotnet-dotnet-docker").
+        # This also accounts for the different separators between AzDO and GitHub repo names.
+
+        $repoName = "$(Build.Repository.Name)"
+
+        $orgSeparatorIndex = $repoName.IndexOf("/")
+        if ($orgSeparatorIndex -eq -1) {
+          $orgSeparatorIndex = $repoName.IndexOf("-")
+        }
+
+        if ($orgSeparatorIndex -ge 0) {
+          $repoName = $repoName.Substring($orgSeparatorIndex + 1)
+        }
+        echo "##vso[task.setvariable variable=publishNotificationRepoName]$repoName"
+      displayName: "Set Custom Repo Name Var"
+    - ${{ parameters.customPublishInitSteps }}
     windowsAmdBuildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
     windowsAmdTestJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     linuxAmdBuildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
@@ -38,25 +57,26 @@ stages:
       customPublishVariables:
       - group: DotNet-AllOrgs-Darc-Pats
 
-    linuxAmd64Pool: ${{ parameters.linuxAmd64Pool }}
+    linuxAmd64Pool:
+      ${{ if ne(parameters.linuxAmd64Pool, '') }}:
+        ${{ parameters.linuxAmd64Pool }}
+      ${{ elseif eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+        vmImage: $(defaultLinuxAmd64PoolImage)
+      ${{ elseif eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+    
     linuxArm64Pool:
-        ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-          name: DotNetCore-Docker-Public
-        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-          name: DotNetCore-Docker
-        demands:
-        - Agent.OS -equals linux
-        - Agent.OSArchitecture -equals ARM64
+      ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+        name: DotNetCore-Docker-Public
+      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        name: Docker-Linux-Arm-Internal
     linuxArm32Pool:
-        ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-          name: DotNetCore-Docker-Public
-        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-          name: DotNetCore-Docker
-        demands:
-        - Agent.OS -equals linux
-        - Agent.OSArchitecture -equals ARM64
+      ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+        name: DotNetCore-Docker-Public
+      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        name: Docker-Linux-Arm-Internal
     windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
     windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
-    windows2004Pool: Docker-2004-${{ variables['System.TeamProject'] }}
     windows20H2Pool: Docker-20H2-${{ variables['System.TeamProject'] }}
     windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}

--- a/eng/common/templates/steps/retain-build.yml
+++ b/eng/common/templates/steps/retain-build.yml
@@ -1,0 +1,9 @@
+steps:
+- powershell: >
+    $(engCommonPath)/Retain-Build.ps1
+    -BuildId $(Build.BuildId)
+    -AzdoOrgUri '$(System.CollectionUri)'
+    -AzdoProject '$(System.TeamProject)'
+    -Token '$(System.AccessToken)'
+  displayName: Enable permanent build retention
+  condition: and(succeeded(), eq(variables.retainBuild, 'true'))

--- a/eng/common/templates/steps/set-image-info-path-var.yml
+++ b/eng/common/templates/steps/set-image-info-path-var.yml
@@ -3,12 +3,7 @@ parameters:
 
 steps:
 - powershell: |
-    if ("$(System.TeamProject)" -eq "$(publicProjectName)") {
-        $basePath = "$(gitHubVersionsRepoInfo.path)"
-    }
-    else {
-        $basePath= "$(azdoVersionsRepoInfo.path)"
-    }
+    $basePath = "$(gitHubVersionsRepoInfo.path)"
 
     $publicSourceBranch = "${{ parameters.publicSourceBranch }}"
 
@@ -21,5 +16,4 @@ steps:
 
     echo "##vso[task.setvariable variable=imageInfoVersionsPath]$basePath/$imageInfoName"
     echo "##vso[task.setvariable variable=gitHubImageInfoVersionsPath]$(gitHubVersionsRepoInfo.path)/$imageInfoName"
-    echo "##vso[task.setvariable variable=azdoImageInfoVersionsPath]$(azdoVersionsRepoInfo.path)/$imageInfoName"
   displayName: Set Image Info Path Vars

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -17,6 +17,8 @@ variables:
   value: ""
 - name: ingestKustoImageInfo
   value: true
+- name: publishNotificationsEnabled
+  value: false
 - name: manifestVariables
   value: ""
 - name: mcrImageIngestionTimeout
@@ -41,8 +43,6 @@ variables:
   value: vs2017-win2016
 - name: defaultWindows1809PoolImage
   value: windows-2019
-- name: defaultWindows2004PoolImage
-  value: null
 - name: defaultWindows20H2PoolImage
   value: null
 - name: defaultWindows2022PoolImage

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1442784
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1689405
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -21,6 +21,15 @@ variables:
 - name: mcrDocsRepoInfo.email
   value: $(dotnetDockerBot.email)
 
+- name: publishNotificationsEnabled
+  value: true
+- name: gitHubNotificationsRepoInfo.org
+  value: dotnet
+- name: gitHubNotificationsRepoInfo.repo
+  value: dotnet-docker-internal
+- name: gitHubNotificationsRepoInfo.accessToken
+  value: $(BotAccount-dotnet-docker-bot-PAT)
+
 - name: gitHubVersionsRepoInfo.org
   value: dotnet
 - name: gitHubVersionsRepoInfo.repo
@@ -35,19 +44,6 @@ variables:
   value: $(dotnetDockerBot.userName)
 - name: gitHubVersionsRepoInfo.email
   value: $(dotnetDockerBot.email)
-
-- name: azdoVersionsRepoInfo.org
-  value: dnceng
-- name: azdoVersionsRepoInfo.project
-  value: ${{ variables.internalProjectName }}
-- name: azdoVersionsRepoInfo.repo
-  value: dotnet-versions
-- name: azdoVersionsRepoInfo.branch
-  value: main
-- name: azdoVersionsRepoInfo.path
-  value: ${{ variables.commonVersionsImageInfoPath }}
-- name: azdoVersionsRepoInfo.accessToken
-  value: $(dn-bot-devdiv-dnceng-rw-code-pat)
 
 - name: kusto.servicePrincipalPassword
   value: $(app-DotnetDockerTelemetryIngestion-client-secret)


### PR DESCRIPTION
https://github.com/dotnet/dotnet-docker/tree/54cdf56af

This brings in arm-related updates, e.g. `eng/common/templates/stages/build-test-publish-repo.yml`:

* https://github.com/dotnet/docker-tools/pull/950 (https://github.com/dotnet/docker-tools/pull/953)

This particular situation shouldn't happen for us (we only have plans to build armv7 tags that contain armv6 binaries, no armv6 tags). But, it's good to be on the latest version regardless.