### PR TITLE
Add linux-arm64 images and infrastructure

### DIFF
--- a/eng/pipeline/stages/build-test-publish-repo.yml
+++ b/eng/pipeline/stages/build-test-publish-repo.yml
@@ -12,6 +12,12 @@ stages:
         - template: ../../../pipeline/steps/set-public-source-branch-var.yml
       customPublishInitSteps:
         - template: ../../../pipeline/steps/set-public-source-branch-var.yml
+      # Specific pools for arm builds.
+      linuxArm64Pool:
+        ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
+          name: DotNetCore-Docker-Public
+        ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
+          name: Docker-Linux-Arm-Internal
       # On Windows, 'docker login' is incompatible with 'manifest-tool' unless we use these pools.
       # https://github.com/dotnet/docker-tools/issues/905
       windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}

--- a/manifest.json
+++ b/manifest.json
@@ -20,11 +20,22 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/bullseye",
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
                 "1.17.8-1-bullseye-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.17/bullseye",
+              "os": "linux",
+              "osVersion": "bullseye",
+              "tags": {
+                "1.17.8-1-bullseye-arm64v8": {}
               }
             }
           ]
@@ -38,11 +49,22 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/buster",
               "os": "linux",
               "osVersion": "buster",
               "tags": {
                 "1.17.8-1-buster-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.17/buster",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "1.17.8-1-buster-arm64v8": {}
               }
             }
           ]
@@ -56,11 +78,22 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/stretch",
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
                 "1.17.8-1-stretch-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.17/stretch",
+              "os": "linux",
+              "osVersion": "stretch",
+              "tags": {
+                "1.17.8-1-stretch-arm64v8": {}
               }
             }
           ]
@@ -74,6 +107,7 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/windows/windowsservercore-ltsc2022",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2022",
@@ -92,6 +126,7 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/windows/windowsservercore-1809",
               "os": "windows",
               "osVersion": "windowsservercore-1809",
@@ -110,6 +145,7 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/windows/windowsservercore-ltsc2016",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
@@ -132,6 +168,7 @@
                 "DOWNLOADER_TAG": "1.17.8-1-windowsservercore-ltsc2022-amd64",
                 "REPO": "$(Repo:golang)"
               },
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/windows/nanoserver-ltsc2022",
               "os": "windows",
               "osVersion": "nanoserver-ltsc2022",
@@ -154,6 +191,7 @@
                 "DOWNLOADER_TAG": "1.17.8-1-windowsservercore-1809-amd64",
                 "REPO": "$(Repo:golang)"
               },
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/windows/nanoserver-1809",
               "os": "windows",
               "osVersion": "nanoserver-1809",
@@ -175,11 +213,21 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17-fips/cbl-mariner1.0",
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
                 "1.17.8-2-fips-cbl-mariner1.0-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/microsoft/1.17-fips/cbl-mariner1.0",
+              "os": "linux",
+              "osVersion": "cbl-mariner1.0",
+              "tags": {
+                "1.17.8-2-fips-cbl-mariner1.0-arm64": {}
               }
             }
           ]
@@ -200,11 +248,22 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/bullseye",
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
                 "1.18.0-1-bullseye-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.18/bullseye",
+              "os": "linux",
+              "osVersion": "bullseye",
+              "tags": {
+                "1.18.0-1-bullseye-arm64v8": {}
               }
             }
           ]
@@ -220,11 +279,22 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/buster",
               "os": "linux",
               "osVersion": "buster",
               "tags": {
                 "1.18.0-1-buster-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.18/buster",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "1.18.0-1-buster-arm64v8": {}
               }
             }
           ]
@@ -240,11 +310,22 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/stretch",
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
                 "1.18.0-1-stretch-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.18/stretch",
+              "os": "linux",
+              "osVersion": "stretch",
+              "tags": {
+                "1.18.0-1-stretch-arm64v8": {}
               }
             }
           ]
@@ -260,6 +341,7 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/windows/windowsservercore-ltsc2022",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2022",
@@ -280,6 +362,7 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/windows/windowsservercore-1809",
               "os": "windows",
               "osVersion": "windowsservercore-1809",
@@ -300,6 +383,7 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/windows/windowsservercore-ltsc2016",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
@@ -324,6 +408,7 @@
                 "DOWNLOADER_TAG": "1.18.0-1-windowsservercore-ltsc2022-amd64",
                 "REPO": "$(Repo:golang)"
               },
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/windows/nanoserver-ltsc2022",
               "os": "windows",
               "osVersion": "nanoserver-ltsc2022",
@@ -348,6 +433,7 @@
                 "DOWNLOADER_TAG": "1.18.0-1-windowsservercore-1809-amd64",
                 "REPO": "$(Repo:golang)"
               },
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/windows/nanoserver-1809",
               "os": "windows",
               "osVersion": "nanoserver-1809",
@@ -371,11 +457,21 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18-fips/cbl-mariner1.0",
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
                 "1.18.0-2-fips-cbl-mariner1.0-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/microsoft/1.18-fips/cbl-mariner1.0",
+              "os": "linux",
+              "osVersion": "cbl-mariner1.0",
+              "tags": {
+                "1.18.0-2-fips-cbl-mariner1.0-arm64": {}
               }
             }
           ]

--- a/patches/0002-Add-Mariner-support-with-FIPS-dependency-flag.patch
+++ b/patches/0002-Add-Mariner-support-with-FIPS-dependency-flag.patch
@@ -4,11 +4,11 @@ Date: Fri, 11 Feb 2022 18:07:18 -0600
 Subject: [PATCH] Add Mariner support with FIPS dependency flag
 
 ---
- Dockerfile-linux.template | 45 +++++++++++++++++++++++++++++++++++++++
- 1 file changed, 45 insertions(+)
+ Dockerfile-linux.template | 48 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 48 insertions(+)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index c300098..ee0c959 100644
+index a79ec02..106f1d0 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
 @@ -4,6 +4,16 @@
@@ -71,18 +71,21 @@ index c300098..ee0c959 100644
  	; \
  	rm -rf /var/lib/apt/lists/*
  {{ ) end -}}
-@@ -46,6 +85,10 @@ ENV GOLANG_VERSION {{ .version }}
+@@ -46,6 +85,13 @@ ENV GOLANG_VERSION {{ .version }}
  				ppc64le: "ppc64le",
  				s390x: "s390x",
  			}
 +		elif is_cbl_mariner then
 +			{
 +				amd64: "x86_64",
++				arm32v6: "armhf",
++				arm32v7: "armv7",
++				arm64v8: "aarch64",
 +			}
  		else
  			{
  				amd64: "amd64",
-@@ -63,6 +106,8 @@ RUN set -eux; \
+@@ -63,6 +109,8 @@ RUN set -eux; \
  {{ if is_alpine then ( -}}
  	apk add --no-cache --virtual .fetch-deps gnupg; \
  	arch="$(apk --print-arch)"; \

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -28,8 +28,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.6/go.20220329.6.linux-amd64.tar.gz'; \
-			sha256='661b1d3d3d2b1a2d8d151a85c6972c0995ce18098639b8f72668f6b587834ad4'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220401.1/go.20220401.1.linux-amd64.tar.gz'; \
+			sha256='9fe4c70c8ec15ca406aab68e9efed871b16d5db27f69bfb74fe87f099dcaa41e'; \
+			;; \
+		'aarch64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220401.1/go.20220401.1.linux-arm64.tar.gz'; \
+			sha256='b7e54d90fcaccd2bec45bd75ad78628a923715063fb7f985ded2836a35a63f9e'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/bullseye/Dockerfile
+++ b/src/microsoft/1.17/bullseye/Dockerfile
@@ -27,8 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.linux-amd64.tar.gz'; \
-			sha256='fa8a829cf00f9370ba2032335700e3d65e1c58b0ff5bea1cd72145d2d1a51631'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-amd64.tar.gz'; \
+			sha256='5014d7ce47db6c70a1d18340deb33e45c802746ba7e7498f42dfbd8a310fb8c8'; \
+			;; \
+		'arm64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-arm64.tar.gz'; \
+			sha256='0df2e76bfc2f61e44daf05d9ba8171fb46c6ee8ebb088593b6a4cd408c151e9b'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/buster/Dockerfile
+++ b/src/microsoft/1.17/buster/Dockerfile
@@ -27,8 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.linux-amd64.tar.gz'; \
-			sha256='fa8a829cf00f9370ba2032335700e3d65e1c58b0ff5bea1cd72145d2d1a51631'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-amd64.tar.gz'; \
+			sha256='5014d7ce47db6c70a1d18340deb33e45c802746ba7e7498f42dfbd8a310fb8c8'; \
+			;; \
+		'arm64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-arm64.tar.gz'; \
+			sha256='0df2e76bfc2f61e44daf05d9ba8171fb46c6ee8ebb088593b6a4cd408c151e9b'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/stretch/Dockerfile
+++ b/src/microsoft/1.17/stretch/Dockerfile
@@ -27,8 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.linux-amd64.tar.gz'; \
-			sha256='fa8a829cf00f9370ba2032335700e3d65e1c58b0ff5bea1cd72145d2d1a51631'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-amd64.tar.gz'; \
+			sha256='5014d7ce47db6c70a1d18340deb33e45c802746ba7e7498f42dfbd8a310fb8c8'; \
+			;; \
+		'arm64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-arm64.tar.gz'; \
+			sha256='0df2e76bfc2f61e44daf05d9ba8171fb46c6ee8ebb088593b6a4cd408c151e9b'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-1809/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.17.8
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '3f376538245436da78193101863751c502da489e29317acaf18bdb0d2852d654'; \
+	$sha256 = '68c32ee9f6460035915a16f318eb6e03dfc4428d2ec9f5251c427b429ad44a44'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-ltsc2016/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.17.8
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '3f376538245436da78193101863751c502da489e29317acaf18bdb0d2852d654'; \
+	$sha256 = '68c32ee9f6460035915a16f318eb6e03dfc4428d2ec9f5251c427b429ad44a44'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-ltsc2022/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.17.8
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '3f376538245436da78193101863751c502da489e29317acaf18bdb0d2852d654'; \
+	$sha256 = '68c32ee9f6460035915a16f318eb6e03dfc4428d2ec9f5251c427b429ad44a44'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
@@ -28,8 +28,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220329.7/go.20220329.7.linux-amd64.tar.gz'; \
-			sha256='3ea93d412f30297866d60bc728278197ea9c9ee8671167f1b207782af9e9e7f6'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220401.2/go.20220401.2.linux-amd64.tar.gz'; \
+			sha256='dd80089e36c2e0219d4292bc06c4c468bb0d80766e3ef25b1cb8f0999c347f7e'; \
+			;; \
+		'aarch64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220401.2/go.20220401.2.linux-arm64.tar.gz'; \
+			sha256='d24bb3090c4fe81afebe74166c73091c178d63439177a1d4155c7d062ed2323e'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/bullseye/Dockerfile
+++ b/src/microsoft/1.18/bullseye/Dockerfile
@@ -27,8 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.linux-amd64.tar.gz'; \
-			sha256='b5ed9d893fb12934daf41edea40b15c4b43533761665d8c61a00d666c8d341ef'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-amd64.tar.gz'; \
+			sha256='ecd5cdd9a3c8ec2d57170c8c4daa7c55309c96e4f186aa79709ccb5aab4a2f40'; \
+			;; \
+		'arm64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-arm64.tar.gz'; \
+			sha256='e640c8cc2eddc11d6d7b8bd7936797f62641eacee57c1e3f7e90381bcb4b33eb'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/buster/Dockerfile
+++ b/src/microsoft/1.18/buster/Dockerfile
@@ -27,8 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.linux-amd64.tar.gz'; \
-			sha256='b5ed9d893fb12934daf41edea40b15c4b43533761665d8c61a00d666c8d341ef'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-amd64.tar.gz'; \
+			sha256='ecd5cdd9a3c8ec2d57170c8c4daa7c55309c96e4f186aa79709ccb5aab4a2f40'; \
+			;; \
+		'arm64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-arm64.tar.gz'; \
+			sha256='e640c8cc2eddc11d6d7b8bd7936797f62641eacee57c1e3f7e90381bcb4b33eb'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/stretch/Dockerfile
+++ b/src/microsoft/1.18/stretch/Dockerfile
@@ -27,8 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.linux-amd64.tar.gz'; \
-			sha256='b5ed9d893fb12934daf41edea40b15c4b43533761665d8c61a00d666c8d341ef'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-amd64.tar.gz'; \
+			sha256='ecd5cdd9a3c8ec2d57170c8c4daa7c55309c96e4f186aa79709ccb5aab4a2f40'; \
+			;; \
+		'arm64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-arm64.tar.gz'; \
+			sha256='e640c8cc2eddc11d6d7b8bd7936797f62641eacee57c1e3f7e90381bcb4b33eb'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.18/windows/windowsservercore-1809/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.18.0
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '5100de35f79dcb259aa01121b75b4d019869aebc9bc959a8c8873f8865f1ff59'; \
+	$sha256 = '13fe9c56edf90884b963b95f12dd9019fbf77e051ee96cd73943ad67c141e652'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.18/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/1.18/windows/windowsservercore-ltsc2016/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.18.0
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '5100de35f79dcb259aa01121b75b4d019869aebc9bc959a8c8873f8865f1ff59'; \
+	$sha256 = '13fe9c56edf90884b963b95f12dd9019fbf77e051ee96cd73943ad67c141e652'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.18/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.18/windows/windowsservercore-ltsc2022/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.18.0
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '5100de35f79dcb259aa01121b75b4d019869aebc9bc959a8c8873f8865f1ff59'; \
+	$sha256 = '13fe9c56edf90884b963b95f12dd9019fbf77e051ee96cd73943ad67c141e652'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -6,18 +6,27 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "fa8a829cf00f9370ba2032335700e3d65e1c58b0ff5bea1cd72145d2d1a51631",
+        "sha256": "5014d7ce47db6c70a1d18340deb33e45c802746ba7e7498f42dfbd8a310fb8c8",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-amd64.tar.gz"
+      },
+      "arm64v8": {
+        "env": {
+          "GOARCH": "arm64",
+          "GOOS": "linux"
+        },
+        "sha256": "0df2e76bfc2f61e44daf05d9ba8171fb46c6ee8ebb088593b6a4cd408c151e9b",
+        "supported": true,
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "3f376538245436da78193101863751c502da489e29317acaf18bdb0d2852d654",
+        "sha256": "68c32ee9f6460035915a16f318eb6e03dfc4428d2ec9f5251c427b429ad44a44",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.windows-amd64.zip"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.windows-amd64.zip"
       }
     },
     "variants": [
@@ -41,17 +50,26 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "661b1d3d3d2b1a2d8d151a85c6972c0995ce18098639b8f72668f6b587834ad4",
+        "sha256": "9fe4c70c8ec15ca406aab68e9efed871b16d5db27f69bfb74fe87f099dcaa41e",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.6/go.20220329.6.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220401.1/go.20220401.1.linux-amd64.tar.gz"
+      },
+      "arm64v8": {
+        "env": {
+          "GOARCH": "arm64",
+          "GOOS": "linux"
+        },
+        "sha256": "b7e54d90fcaccd2bec45bd75ad78628a923715063fb7f985ded2836a35a63f9e",
+        "supported": true,
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220401.1/go.20220401.1.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "d873b137e5778faffb967cfe92ec7e9ab30dfb283ed3211d097e46273753eec4",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.6/go.20220329.6.windows-amd64.zip"
+        "sha256": "5241ef99d1b53a6309660fbcda7ad563e1bbe634ac2047bf3d8469aff8616853",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220401.1/go.20220401.1.windows-amd64.zip"
       }
     },
     "variants": [
@@ -69,18 +87,27 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "b5ed9d893fb12934daf41edea40b15c4b43533761665d8c61a00d666c8d341ef",
+        "sha256": "ecd5cdd9a3c8ec2d57170c8c4daa7c55309c96e4f186aa79709ccb5aab4a2f40",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-amd64.tar.gz"
+      },
+      "arm64v8": {
+        "env": {
+          "GOARCH": "arm64",
+          "GOOS": "linux"
+        },
+        "sha256": "e640c8cc2eddc11d6d7b8bd7936797f62641eacee57c1e3f7e90381bcb4b33eb",
+        "supported": true,
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "5100de35f79dcb259aa01121b75b4d019869aebc9bc959a8c8873f8865f1ff59",
+        "sha256": "13fe9c56edf90884b963b95f12dd9019fbf77e051ee96cd73943ad67c141e652",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.windows-amd64.zip"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.windows-amd64.zip"
       }
     },
     "variants": [
@@ -106,17 +133,26 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "3ea93d412f30297866d60bc728278197ea9c9ee8671167f1b207782af9e9e7f6",
+        "sha256": "dd80089e36c2e0219d4292bc06c4c468bb0d80766e3ef25b1cb8f0999c347f7e",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220329.7/go.20220329.7.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220401.2/go.20220401.2.linux-amd64.tar.gz"
+      },
+      "arm64v8": {
+        "env": {
+          "GOARCH": "arm64",
+          "GOOS": "linux"
+        },
+        "sha256": "d24bb3090c4fe81afebe74166c73091c178d63439177a1d4155c7d062ed2323e",
+        "supported": true,
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220401.2/go.20220401.2.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "1c2f4bb1abe9eccf7b33589abd3f114d549c2f35fb8643d5526b74a4c0394c1a",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220329.7/go.20220329.7.windows-amd64.zip"
+        "sha256": "83c1eee6dee98fb656cb5330424e8e8d3a971229cd9a7a8b8d6d0252934364ff",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220401.2/go.20220401.2.windows-amd64.zip"
       }
     },
     "variants": [


### PR DESCRIPTION
* https://github.com/microsoft/go/issues/173
* Uses `dockerupdate` support being added in https://github.com/microsoft/go-infra/pull/36

https://dev.azure.com/dnceng/internal/_build/results?buildId=1703886&view=results