### PR TITLE
[main] Merge from nightly for 1.18.1-1, 1.17.9-1 with linux-arm64

### DIFF
--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -33,22 +33,27 @@ else {
     $DotnetInstallScript = "dotnet-install.ps1"
 }
 
-if (!(Test-Path $DotnetInstallScript)) {
+$DotnetInstallScriptPath = Join-Path -Path $InstallPath -ChildPath $DotnetInstallScript
+
+if (!(Test-Path $DotnetInstallScriptPath)) {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
-    & "$PSScriptRoot/Invoke-WithRetry.ps1" "Invoke-WebRequest 'https://dot.net/v1/$DotnetInstallScript' -OutFile $InstallPath/$DotnetInstallScript"
+    & "$PSScriptRoot/Invoke-WithRetry.ps1" "Invoke-WebRequest 'https://dot.net/v1/$DotnetInstallScript' -OutFile $DotnetInstallScriptPath"
 }
 
-$DotnetChannel = "5.0"
+$DotnetChannel = "Current"
 
 $InstallFailed = $false
 if ($IsRunningOnUnix) {
-    & chmod +x $InstallPath/$DotnetInstallScript
-    & $InstallPath/$DotnetInstallScript --channel $DotnetChannel --version "latest" --install-dir $InstallPath
+    & chmod +x $DotnetInstallScriptPath
+    & $DotnetInstallScriptPath --channel $DotnetChannel --version "latest" --install-dir $InstallPath
     $InstallFailed = ($LASTEXITCODE -ne 0)
 }
 else {
-    & $InstallPath/$DotnetInstallScript -Channel $DotnetChannel -Version "latest" -InstallDir $InstallPath
+    & $DotnetInstallScriptPath -Channel $DotnetChannel -Version "latest" -InstallDir $InstallPath
     $InstallFailed = (-not $?)
 }
+
+# See https://github.com/NuGet/NuGet.Client/pull/4259
+$Env:NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY = "3,1000"
 
 if ($InstallFailed) { throw "Failed to install the .NET Core SDK" }

--- a/eng/common/Retain-Build.ps1
+++ b/eng/common/Retain-Build.ps1
@@ -1,0 +1,43 @@
+# Adapted from https://github.com/dotnet/arcade/blob/main/eng/common/retain-build.ps1
+Param(
+    [Parameter(Mandatory = $true)][int] $BuildId,
+    [Parameter(Mandatory = $true)][string] $AzdoOrgUri, 
+    [Parameter(Mandatory = $true)][string] $AzdoProject,
+    [Parameter(Mandatory = $true)][string] $Token
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+function Get-AzDOHeaders(
+    [string] $Token) {
+    $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":${Token}"))
+    $headers = @{"Authorization" = "Basic $base64AuthInfo" }
+    return $headers
+}
+
+function Update-BuildRetention(
+    [string] $AzdoOrgUri,
+    [string] $AzdoProject,
+    [int] $BuildId,
+    [string] $Token) {
+    $headers = Get-AzDOHeaders -Token $Token
+    $requestBody = "{
+        `"keepForever`": `"true`"
+    }"
+
+    $requestUri = "${AzdoOrgUri}/${AzdoProject}/_apis/build/builds/${BuildId}?api-version=6.0"
+    Write-Host "Attempting to retain build using the following URI: ${requestUri} ..."
+
+    try {
+        Invoke-RestMethod -Uri $requestUri -Method Patch -Body $requestBody -Header $headers -contentType "application/json"
+        Write-Host "Updated retention settings for build ${BuildId}."
+    }
+    catch {
+        Write-Host "##[error] Failed to update retention settings for build: $($_.Exception.Response.StatusDescription)"
+        exit 1
+    }
+}
+
+Update-BuildRetention -AzdoOrgUri $AzdoOrgUri -AzdoProject $AzdoProject -BuildId $BuildId -Token $Token
+exit 0

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -50,23 +50,23 @@ try {
     $args = $OptionalImageBuilderArgs
 
     if ($Version) {
-        $args += " --version " + ($Version -join " --version ")
+        $args += ($Version | foreach { ' --version "{0}"' -f $_ })
     }
 
     if ($OS) {
-        $args += " --os-version " + ($OS -join " --os-version ")
+        $args += ($OS | foreach { ' --os-version "{0}"' -f $_ })
     }
 
     if ($Architecture) {
-        $args += " --architecture $Architecture"
+        $args += ' --architecture "{0}"' -f $Architecture
     }
 
     if ($Paths) {
-        $args += " --path " + ($Paths -join " --path ")
+        $args += ($Paths | foreach { ' --path "{0}"' -f $_ })
     }
 
     if ($Manifest) {
-        $args += " --manifest $Manifest"
+        $args += ' --manifest "{0}"' -f $Manifest
     }
 
     ./eng/common/Invoke-ImageBuilder.ps1 "build $args"

--- a/eng/common/package-scripts/Dockerfile.scripts
+++ b/eng/common/package-scripts/Dockerfile.scripts
@@ -1,0 +1,3 @@
+ARG BASETAG
+FROM $BASETAG
+COPY . /scripts

--- a/eng/common/package-scripts/get-installed-packages.container.sh
+++ b/eng/common/package-scripts/get-installed-packages.container.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env sh
+
+pkgManagerArgs="$PKG_MANAGER_ARGS"
+
+# If package manager is apt
+if type apt > /dev/null 2>/dev/null; then
+    # Extract the package name and version out of the list of installed packages.
+    # Example output of "apt list":
+    #   zlib1g/now 1:1.2.11.dfsg-1 amd64 [installed,local]
+    # Regex consists of two capture groups:
+    #   1: Package name: all chars up until the first '/' character
+    #   2: Package version: substring after the first whitespace occurrence and before the next whitespace
+    # Output is the format of "DEB,<pkg-name>=<pkg-version>"
+    apt list --installed $pkgManagerArgs 2>/dev/null | grep installed | sed -n 's/^\([^/]*\)\S*\s\(\S*\).*/DEB,\1=\2/p' | sort
+    exit 0
+fi
+
+# If package manager is apk
+if type apk > /dev/null 2>/dev/null; then
+    # Extract the package name and version out of the list of installed packages.
+    # This uses the output of the "apk info" command to build a regex to find the version from the "apk list"
+    # command. The reason the "apk info -v" or "apk list --installed" commands (which provide both the package name and version)
+    # aren't used just by itself is because of the ambiguity between what characters are part of the package name and which are 
+    # part of the version. For example, the output for something like "libssl1.1-1.1.1k-r0" can be ambiguous because of the dash 
+    # separator. In this case, the package name is "libssl1.1" and the version is "1.1.1k-r0". You can't necessarily assume that 
+    # the first '-' character indicates a version separator because some package names also contain a '-' character.  What the 
+    # command below does is to first get the list of package names (w/o any versions) and then feed each package name into another
+    # command to lookup that package name with the "apk list" command to get the version details.
+    # Example of the output of "apk info -d musl":
+    #   musl-1.2.2-r3 description:
+    #   the musl c library (libc) implementation
+    # Output is the format of "APK,<pkg-name>=<pkg-version>"
+    apk info $pkgManagerArgs 2>/dev/null | xargs -I {} sh -c "apk list 2>/dev/null {} | grep '\[installed\]' 2>/dev/null | sed -n 's/\({}\)-\(\S*\)\s.*/APK,\1=\2/p'" | sort
+    exit 0
+fi
+
+formatRpmPackagesOutput() {
+    # Extract the RPM package name and version out of the list of installed packages.
+    # Example output:
+    #   zstd-libs.x86_64   1.4.4-1.cm1   @System
+    # Because some package names can be very long, the output can be split across multiple lines if not formatted
+    # properly. To do this, the columns are piped with xargs to be formatted by the column command.
+    # Regex consists of two capture groups:
+    #   1: Package name: all chars up until the last '.' character of the first column
+    #   2: Package version: substring after the remaining arch text/whitespace and before the next whitespace
+    # Output is the format of "RPM,<pkg-name>=<pkg-version>"
+    tail -n +2 | xargs -n3 | column -t | sed -n 's/^\(\S*\)\.\S*\s*\(\S*\)\s*.*/RPM,\1=\2/p'
+}
+commonRpmBasedPkgManagerArgs="list installed $pkgManagerArgs --quiet"
+
+# If package manager is dnf
+if type dnf > /dev/null 2>/dev/null; then
+    dnf $commonRpmBasedPkgManagerArgs | formatRpmPackagesOutput
+    exit 0
+fi
+
+# If package manager is tdnf
+if type tdnf > /dev/null 2>/dev/null; then
+    tdnf $commonRpmBasedPkgManagerArgs | formatRpmPackagesOutput
+    exit 0
+fi
+
+# If package manager is yum
+if type yum > /dev/null 2>/dev/null; then
+    yum $commonRpmBasedPkgManagerArgs | formatRpmPackagesOutput
+    exit 0
+fi
+
+# If package manager is zypper
+if type zypper > /dev/null 2>/dev/null; then
+    # Extract the package name and version out of the list of installed packages.
+    # Example output:
+    # i+ | glibc  | package | 2.26-lp152.26.9.1  | x86_64 | Main Update Repository
+    # Regex consists of two capture groups:
+    #   1: Package name: Skips the Status column and captures the characters surrounded by the vertical bars indicating the Name column.
+    #   2: Package version: The next column after the Type (package) column.
+    # Output is the format of "RPM,<pkg-name>=<pkg-version>"
+    zypper --quiet search --installed-only --type package --details 2>/dev/null | sed -n 's/^[^|]*|\s*\(\S*\)\s*|\s*package\s*|\s*\(\S*\).*/RPM,\1=\2/p' | sort
+    exit 0
+fi
+
+echo "Unsupported package manager. Current supported package managers: apt, apk, dnf, tdnf, yum, zypper" >&2
+exit 1

--- a/eng/common/package-scripts/get-installed-packages.sh
+++ b/eng/common/package-scripts/get-installed-packages.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env sh
+
+# This is the main script for retrieving the list of installed packages.
+
+usage() {
+    echo "Usage: $0 [<OPTIONS>...] IMAGETAG DOCKERFILEPATH"
+    echo
+    echo "Queries a container to determine which packages are installed"
+    echo 
+    echo "Options:"
+    echo "  -h: Print this help message"
+    echo "  -a: Additional package manager args"
+    echo "Arguments:"
+    echo "  IMAGETAG: The tag of the image to query"
+    echo "  DOCKERFILEPATH: The path to the image's Dockerfile"
+}
+
+while getopts "ha:o:" opt; do
+    case $opt in
+        h)
+            usage
+            exit 0
+            ;;
+        a)
+            pkgManagerArgs=$OPTARG
+            shift 2
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            exit 1
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+imageTag=$1
+dockerfilePath=$2
+scriptDir=$(dirname $(realpath $0))
+
+docker run \
+    --rm \
+    -i \
+    -e PKG_MANAGER_ARGS="$pkgManagerArgs" \
+    --entrypoint /bin/sh \
+    --user root \
+    $imageTag \
+    < $scriptDir/get-installed-packages.container.sh

--- a/eng/common/package-scripts/get-upgradable-packages.container.bash.sh
+++ b/eng/common/package-scripts/get-upgradable-packages.container.bash.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+
+# This is the Bash-based script for retrieving the list of upgradable packages
+
+printPackageInfo() {
+    echo $1
+    echo "- Current: $2"
+    echo "- Upgrade: $3"
+}
+
+writeError() {
+    echo "Error: $1" >>/dev/stderr
+    exit 1
+}
+
+addUpgradeablePackageVersion() {
+    local pkgName=$1
+    local currentVersion=$2
+    local upgradeVersion=$3
+
+    # If the package is not already in the list, add it
+    if [[ -z ${upgradablePackageVersions[$pkgName]} ]]; then
+        local versionData=$(echo "$currentVersion,$upgradeVersion")
+        upgradablePackageVersions[$pkgName]=$versionData
+
+        printPackageInfo "$pkgName" "$currentVersion" "$upgradeVersion"
+    fi
+}
+
+checkForUpgradableVersionWithApt() {
+    pkgName=$1
+    pkgVersion=$2
+
+    echo "Finding latest version of package $pkgName"
+    local pkgInfo=$(apt policy $pkgManagerArgs $pkgName 2>/dev/null)
+    if [[ $pkgInfo == "" ]]; then
+        writeError "Package '$pkgName' does not exist."
+    fi
+
+    # Get the candidate version of the package to be installed
+    local candidateVersion=$(echo "$pkgInfo" | sed -n 's/.*Candidate:\s*\(\S*\)/\1/p')
+
+    # If a newer version of the package is available
+    if [[ $candidateVersion != $pkgVersion ]]; then
+        # Check if the candidate package version comes from a security repository
+        apt-cache madison $pkgName | grep $candidateVersion | grep security 1>/dev/null
+
+        # If the candidate version comes from a security repository, add it to the list of upgradable packages
+        if [[ $? == 0 ]]; then
+            addUpgradeablePackageVersion "$pkgName" "$pkgVersion" "$candidateVersion"
+        fi
+    fi
+}
+
+checkForUpgradableVersionWithApk() {
+    pkgName=$1
+    pkgVersion=$2
+
+    echo "Finding latest version of package $pkgName"
+    availableVersion=$(apk list $pkgManagerArgs $pkgName | tac | sed -n "1 s/$pkgName-\(\S*\).*/\1/p")
+    if [[ $availableVersion == "" ]]; then
+        writeError "Package '$pkgName' does not exist."
+    fi
+
+    # If a newer version of the package is available
+    if [[ $availableVersion != $pkgVersion ]]; then
+        # If the package exists, add it to the list of upgradable packages
+        if [[ $availableVersion != "" ]]; then
+            addUpgradeablePackageVersion "$pkgName" "$pkgVersion" "$availableVersion"
+        fi
+    fi
+}
+
+checkForUpgradableVersionWithCommonRpmBasedPkgMgr() {
+    pkgName=$1
+    pkgVersion=$2
+    pkgManagerName=$3
+    headerLineCount=${4:-2}
+
+    echo "Finding latest version of package $pkgName"
+    $pkgManagerName install $pkgManagerArgs -y $pkgName 1>/dev/null 2>/dev/null
+
+    # If the package exists
+    if [[ $? == 0 ]]; then
+        local installedVersion=$($pkgManagerName list installed $pkgManagerArgs $pkgName | tail -n +$headerLineCount | sed -n 's/\S*\s*\(\S*\)\s*.*/\1/p')
+        # If a newer version of the package is available
+        if [[ $installedVersion != $pkgVersion ]]; then
+            addUpgradeablePackageVersion "$pkgName" "$pkgVersion" "$installedVersion"
+        fi
+    else
+        writeError "Package '$pkgName' does not exist."
+    fi
+}
+
+checkForUpgradableVersionWithDnf() {
+    pkgName=$1
+    pkgVersion=$2
+
+    checkForUpgradableVersionWithCommonRpmBasedPkgMgr "$pkgName" "$pkgVersion" "dnf"
+}
+
+checkForUpgradableVersionWithTdnf() {
+    pkgName=$1
+    pkgVersion=$2
+
+    checkForUpgradableVersionWithCommonRpmBasedPkgMgr "$pkgName" "$pkgVersion" "tdnf"
+}
+
+checkForUpgradableVersionWithYum() {
+    pkgName=$1
+    pkgVersion=$2
+
+    checkForUpgradableVersionWithCommonRpmBasedPkgMgr "$pkgName" "$pkgVersion" "yum" 3
+}
+
+checkForUpgradableVersionWithZypper() {
+    pkgName=$1
+    pkgVersion=$2
+
+    echo "Finding latest version of package $pkgName"
+    availableVersion=$(zypper info $pkgManagerArgs $pkgName | sed -n 's/^Version\s*:\s*\(\S*\).*/\1/p')
+    if [[ $availableVersion == "" ]]; then
+        writeError "Package '$pkgName' does not exist."
+    fi
+
+    # If a newer version of the package is available
+    if [[ $availableVersion != $pkgVersion ]]; then
+        # If the package exists, add it to the list of upgradable packages
+        if [[ $availableVersion != "" ]]; then
+            addUpgradeablePackageVersion "$pkgName" "$pkgVersion" "$availableVersion"
+        fi
+    fi
+}
+
+outputPackagesToUpgrade() {
+    echo
+    echo "Packages requiring an upgrade:"
+
+    local packagesToUpgrade=()
+    local pkg
+    # Lookup the provided package names to see if any are in the list of upgradable packages
+    for pkg in "${packages[@]}"
+    do
+        if [[ ! $pkg =~ $packageVersionRegex ]]; then
+            writeError "Unable to parse package version info. Value: $pkg"
+        fi
+
+        local pkgName=${BASH_REMATCH[1]}
+        versionData=${upgradablePackageVersions[$pkgName]}
+
+        if [ ! -z "$versionData" ]; then
+            # Split versionData by comma
+            local versionArray=( ${versionData//,/ } )
+            local currentVersion=${versionArray[0]}
+            local upgradeVersion=${versionArray[1]}
+            
+            packagesToUpgrade+=($(echo "$pkgName,$currentVersion,$upgradeVersion"))
+            printPackageInfo "$pkgName" "$currentVersion" "$upgradeVersion"
+        fi
+    done
+
+    local upgradeCount=${#packagesToUpgrade[@]}
+    if [ $upgradeCount = 0 ]; then
+        echo "<none>"
+    fi
+
+    local outputDir=$(dirname "$outputPath")
+    mkdir -p $outputDir
+
+    printf "%s\n" "${packagesToUpgrade[@]}" > $outputPath
+}
+
+updatePackageCacheWithApt() {
+    apt update 1>/dev/null 2>/dev/null
+}
+
+updatePackageCacheWithApk() {
+    apk update 1>/dev/null
+}
+
+updatePackageCacheWithCommonRpmBasedPkgMgr() {
+    pkgMgr=$1
+    $1 makecache 1>/dev/null
+}
+
+updatePackageCacheWithDnf() {
+    updatePackageCacheWithCommonRpmBasedPkgMgr dnf
+}
+
+updatePackageCacheWithTdnf() {
+    updatePackageCacheWithCommonRpmBasedPkgMgr tdnf
+}
+
+updatePackageCacheWithYum() {
+    updatePackageCacheWithCommonRpmBasedPkgMgr yum
+}
+
+updatePackageCacheWithZypper() {
+    zypper ref 1>/dev/null
+}
+
+
+
+outputPath="$1"
+pkgManagerArgs="$2"
+shift 2
+packages=( $@ )
+
+declare -A upgradablePackageVersions
+upgradablePackageVersions=()
+
+if type apt > /dev/null 2>/dev/null; then
+    pkgType="Apt"
+elif type apk > /dev/null 2>/dev/null; then
+    pkgType="Apk"
+elif type dnf > /dev/null 2>/dev/null; then
+    pkgType="Dnf"
+elif type tdnf > /dev/null 2>/dev/null; then
+    pkgType="Tdnf"
+elif type yum > /dev/null 2>/dev/null; then
+    pkgType="Yum"
+elif type zypper > /dev/null 2>/dev/null; then
+    pkgType="Zypper"
+else
+    writeError "Unsupported package manager. Current supported package managers: apt, apk, tdnf, yum, zypper"
+fi
+
+if [[ $(type -t updatePackageCacheWith$pkgType) != "function" ]]; then
+    writeError "Missing function named 'updatePackageCacheWith$pkgType'"
+fi
+
+if [[ $(type -t checkForUpgradableVersionWith$pkgType) != "function" ]]; then
+    writeError "Missing function named 'checkForUpgradableVersionWith$pkgType'"
+fi
+
+echo "Updating package cache..."
+updatePackageCacheWith$pkgType
+
+packageVersionRegex="(\S+)=(\S+)"
+for pkgName in "${packages[@]}"
+do
+    echo "Processing $pkgName"
+    if [[ ! $pkgName =~ $packageVersionRegex ]]; then
+        writeError "Package version info for '$pkgName' must be in the form of <pkg-name>=<pkg-version>"
+    fi
+
+    checkForUpgradableVersionWith$pkgType ${BASH_REMATCH[1]} ${BASH_REMATCH[2]}
+done
+outputPackagesToUpgrade

--- a/eng/common/package-scripts/get-upgradable-packages.container.sh
+++ b/eng/common/package-scripts/get-upgradable-packages.container.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env sh
+
+# This is just a wrapper around the Bash-based script. This ensures that Bash is installed and then runs the Bash script. 
+
+ensureBashInstalledForApt() {
+    echo "Ensuring bash is installed"
+    apt update 1>/dev/null 2>/dev/null
+    apt install -y bash 1>/dev/null 2>/dev/null
+}
+
+ensureBashInstalledForApk() {
+    echo "Ensuring bash is installed"
+    apk add bash 1>/dev/null
+}
+
+ensureBashInstalledForRpmBasedPkgMgr() {
+    echo "Ensuring bash is installed"
+    local pkgMgr=$1
+    $pkgMgr makecache 1>/dev/null
+    $pkgMgr install -y bash 1>/dev/null
+}
+
+ensureBashInstalledForZypper() {
+    echo "Ensuring bash is installed"
+    zypper ref 1>/dev/null
+    zypper install -y bash 1>/dev/null
+}
+
+
+scriptDir=$(dirname $0)
+
+outputPath="$1"
+pkgManagerArgs="$2"
+shift 2
+packages=$@
+
+if type apt > /dev/null 2>/dev/null; then
+    ensureBashInstalledForApt
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+if type apk > /dev/null 2>/dev/null; then
+    ensureBashInstalledForApk
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+if type dnf > /dev/null 2>/dev/null; then
+    ensureBashInstalledForRpmBasedPkgMgr dnf
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+if type tdnf > /dev/null 2>/dev/null; then
+    ensureBashInstalledForRpmBasedPkgMgr tdnf
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+if type yum > /dev/null 2>/dev/null; then
+    ensureBashInstalledForRpmBasedPkgMgr yum
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+if type zypper > /dev/null 2>/dev/null; then
+    ensureBashInstalledForZypper
+    $scriptDir/get-upgradable-packages.container.bash.sh $outputPath "$pkgManagerArgs" $packages
+    exit 0
+fi
+
+echo "Unsupported package manager. Current supported package managers: apt, apk, tdnf, yum, zypper" >&2
+exit 1

--- a/eng/common/package-scripts/get-upgradable-packages.sh
+++ b/eng/common/package-scripts/get-upgradable-packages.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env sh
+
+# This is the main script for retrieving the list of upgradable packages.
+
+usage() {
+    echo "Usage: $0 [<OPTIONS>...] IMAGETAG DOCKERFILEPATH [PACKAGEVERSION...]"
+    echo
+    echo "Queries a container to determine which packages are upgradable"
+    echo 
+    echo "Options:"
+    echo "  -h: Print this help message"
+    echo "  -a: Additional package manager args"
+    echo "  -o: Output path for a formatted list of upgradable packages"
+    echo "Arguments:"
+    echo "  IMAGETAG: The tag of the image to query"
+    echo "  DOCKERFILEPATH: The path to the image's Dockerfile"
+    echo "  PACKAGEVERSION: A package version to check whether its upgradable (format: NAME=VERSION)"
+}
+
+while getopts "ha:o:" opt; do
+    case $opt in
+        h)
+            usage
+            exit 0
+            ;;
+        a)
+            pkgManagerArgs=$OPTARG
+            shift 2
+            ;;
+        o)
+            outputPath=$OPTARG
+            shift 2
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            exit 1
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+imageTag=$1
+dockerfilePath=$2
+shift 2
+packagelist=$@
+
+scriptDir="$(dirname $(realpath $0))"
+containerName="container$RANDOM"
+containerOutputPath="/$containerName.txt"
+
+scriptsWrapperImageTag="tag$RANDOM"
+docker build -t $scriptsWrapperImageTag -f $scriptDir/Dockerfile.scripts --build-arg BASETAG=$imageTag $scriptDir 1>/dev/null 2>/dev/null
+
+docker run \
+    --name $containerName \
+    --entrypoint /bin/sh \
+    --user root \
+    $scriptsWrapperImageTag \
+    -c "/scripts/get-upgradable-packages.container.sh $containerOutputPath \"$pkgManagerArgs\" $packagelist"
+
+if [ -n "$outputPath" ]; then
+    docker cp $containerName:$containerOutputPath $outputPath
+fi
+
+docker rm $containerName 1>/dev/null

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -13,7 +13,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  condition: and(${{ parameters.matrix }}, in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
+  condition: and(${{ parameters.matrix }}, not(canceled()), in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
   dependsOn:
   - PreBuildValidation
   - CopyBaseImages
@@ -25,6 +25,7 @@ jobs:
   variables:
     imageBuilderDockerRunExtraOptions: $(build.imageBuilderDockerRunExtraOptions)
     versionsRepoPath: versions
+    sbomDirectory: $(Build.ArtifactStagingDirectory)/sbom
     ${{ if eq(parameters.noCache, false) }}:
       versionsBasePath: $(versionsRepoPath)/
       pipelineDisabledCache: false
@@ -65,13 +66,25 @@ jobs:
         echo "##vso[task.setvariable variable=testScriptPath]$testScriptPath"
         echo "##vso[task.setvariable variable=testResultsDirectory]$testResultsDirectory"
       displayName: Override Common Paths
+  - powershell: |
+      if ("${{ parameters.noCache }}" -eq "false") {
+        $baseContainerRepoPath = "/repo/$(buildRepoName)"
+      }
+      else {
+        $baseContainerRepoPath = "/repo"
+      }
+      echo "##vso[task.setvariable variable=baseContainerRepoPath]$baseContainerRepoPath"
+    displayName: Set Base Container Repo Path
   - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}
   - ${{ parameters.customInitSteps }}
   - template: ../steps/set-image-info-path-var.yml
     parameters:
       publicSourceBranch: $(publicSourceBranch)
+  - powershell: echo "##vso[task.setvariable variable=imageBuilderBuildArgs]"
+    condition: eq(variables.imageBuilderBuildArgs, '')
+    displayName: Initialize Image Builder Build Args
   - powershell: |
-      $imageBuilderBuildArgs = "$(imageBuilder.queueArgs) --image-info-output-path $(artifactsPath)/$(legName)-image-info.json"
+      $imageBuilderBuildArgs = "$(imageBuilderBuildArgs) $(imageBuilder.queueArgs) --image-info-output-path $(artifactsPath)/$(legName)-image-info.json"
       if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.internalProjectName }}") {
         $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push --registry-creds ""$(acr.server)=$(acr.userName);$(acr.password)"""
       }
@@ -83,7 +96,7 @@ jobs:
 
       echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$imageBuilderBuildArgs"
     displayName: Set Image Builder Build Args
-  - script: >
+  - powershell: >
       $(runImageBuilderCmd) build
       --manifest $(manifest)
       $(imageBuilderPaths)
@@ -92,14 +105,55 @@ jobs:
       --architecture $(architecture)
       --retry
       --source-repo $(publicGitRepoUri)
+      --get-installed-pkgs-path $(baseContainerRepoPath)/$(engCommonRelativePath)/package-scripts/get-installed-packages.sh
+      --digests-out-var 'builtImages'
       $(manifestVariables)
       $(imageBuilderBuildArgs)
+    name: BuildImages
     displayName: Build Images
   - publish: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
     artifact: $(legName)-image-info-$(System.JobAttempt)
     displayName: Publish Image Info File Artifact
+  - ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+      # Define the task here to load it into the agent so that we can invoke the tool manually
+    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+      inputs:
+        BuildDropPath: $(Build.ArtifactStagingDirectory)
+      displayName: Load Manifest Generator
+      condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))
+    - powershell: |
+        $images = "$(BuildImages.builtImages)"
+        if (-not $images) { return 0 }
+        $taskDir = $(Get-ChildItem -Recurse -Directory -Filter "ManifestGeneratorTask*" -Path '$(Agent.WorkFolder)').FullName
+        $manifestToolDllPath = $(Get-ChildItem -Recurse -File -Filter "Microsoft.ManifestTool.dll" -Path $taskDir).FullName
+        $dotnetDir = $(Get-ChildItem -Recurse -Directory -Filter "dotnet-*" -Path $taskDir).FullName
+
+        # Call the manifest tool for each image to produce seperate SBOMs
+        # Manifest tool docs: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/custom-sbom-generation-workflows
+        $images -Split ',' | ForEach-Object {
+          echo "Generating SBOM for $_";
+          $formattedImageName = $_.Replace('$(acr.server)/$(stagingRepoPrefix)', "").Replace('/', '_').Replace(':', '_');
+          $sbomChildDir = "$(sbomDirectory)/$formattedImageName";
+          New-Item -Type Directory -Path $sbomChildDir > $null;
+          & "$dotnetDir/dotnet" "$manifestToolDllPath" `
+            Generate `
+            -BuildDropPath '$(Build.ArtifactStagingDirectory)' `
+            -BuildComponentPath '$(Agent.BuildDirectory)' `
+            -PackageName '.NET' `
+            -PackageVersion '$(Build.BuildNumber)' `
+            -ManifestDirPath $sbomChildDir `
+            -DockerImagesToScan $_ `
+            -Verbosity Information 
+        }
+      displayName: Generate SBOMs
+      condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))
   - ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
     - template: ${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}
       parameters:
         condition: ne(variables.testScriptPath, '')
   - template: ${{ format('../steps/cleanup-docker-{0}.yml', parameters.dockerClientOS) }}
+  - ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+    - publish: $(sbomDirectory)
+      artifact: $(legName)-sboms
+      displayName: Publish SBOM
+      condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))

--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -10,6 +10,7 @@ jobs:
 - job: ${{ parameters.name }}
   pool: ${{ parameters.pool }}
   steps:
+  - template: ../steps/retain-build.yml
   - template: ../steps/init-docker-linux.yml
   - template: ../steps/validate-branch.yml
     parameters:

--- a/eng/common/templates/jobs/generate-sbom.yml
+++ b/eng/common/templates/jobs/generate-sbom.yml
@@ -1,0 +1,47 @@
+parameters:
+  pool: {}
+
+jobs:
+- job: GenerateSBOM
+  pool: ${{ parameters.pool }}
+  strategy:
+    matrix:
+      amd64:
+        arch: amd64
+      arm32:
+        arch: arm
+      arm64:
+        arch: arm64
+  variables:
+    sbomDirectory: $(Build.ArtifactStagingDirectory)/sbom
+  steps:
+  - template: ../steps/init-docker-linux.yml
+  - template: ../steps/download-build-artifact.yml
+    parameters:
+      targetPath: $(Build.ArtifactStagingDirectory)
+      artifactName: image-info
+  - script: >
+      $(runImageBuilderCmd) trimUnchangedPlatforms
+      '$(artifactsPath)/image-info.json'
+    displayName: Trim Unchanged Images
+  - script: >
+      $(runImageBuilderCmd) pullImages
+      --architecture '$(arch)'
+      --manifest 'manifest.json'
+      --output-var 'pulledImages'
+      --image-info '$(artifactsPath)/image-info.json'
+    name: PullImages
+    displayName: Pull Images
+  - script: mkdir $(sbomDirectory)
+    displayName: Create SBOM Directory
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: Generate SBOM
+    inputs:
+      PackageName: ".NET"
+      PackageVersion: $(Build.BuildNumber)
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
+      ManifestDirPath: $(sbomDirectory)
+      dockerImagesToScan: $(PullImages.pulledImages)
+  - publish: $(sbomDirectory)
+    artifact: sbom_linux_$(arch)
+    displayName: Publish SBOM

--- a/eng/common/templates/jobs/post-build.yml
+++ b/eng/common/templates/jobs/post-build.yml
@@ -1,15 +1,34 @@
+parameters:
+  pool: {}
+
 jobs:
 - job: Build
-  pool:
-    vmImage: $(defaultLinuxAmd64PoolImage)
+  pool: ${{ parameters.pool }}
+  variables:
+    imageInfosSubDir: "/image-infos"
+    sbomSubDir: "/sbom"
   steps:
   - template: ../steps/init-docker-linux.yml
   - template: ../steps/download-build-artifact.yml
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
-  - pwsh: |
+  - powershell: |
+      # Move all image-info artifacts to their own directory
+      New-Item -ItemType Directory -Path $(Build.ArtifactStagingDirectory)$(imageInfosSubDir)
+      Get-ChildItem -Directory -Filter "*-image-info-*" $(Build.ArtifactStagingDirectory) |
+        Move-Item -Verbose -Destination $(Build.ArtifactStagingDirectory)$(imageInfosSubDir)
+    displayName: Collect Image Info Files
+  - powershell: |
+      # Move the contents of all the SBOM artifact directories to a single location
+      New-Item -ItemType Directory -Path $(Build.ArtifactStagingDirectory)$(sbomSubDir)
+      Get-ChildItem -Directory -Filter "*-sboms" $(Build.ArtifactStagingDirectory) |
+        ForEach-Object {
+          Get-ChildItem $_ -Directory | Move-Item -Verbose -Destination $(Build.ArtifactStagingDirectory)$(sbomSubDir)
+        }
+    displayName: Consolidate SBOMs to Single Directory
+  - powershell: |
       # Deletes the artifacts from all the unsuccessful jobs
-      Get-ChildItem $(Build.ArtifactStagingDirectory) -Directory |
+      Get-ChildItem $(Build.ArtifactStagingDirectory)$(imageInfosSubDir) -Directory |
           ForEach-Object {
               [pscustomobject]@{
                   # Parse the artifact name to separate the base of the name from the job attempt number 
@@ -30,10 +49,13 @@ jobs:
   - script: >
       $(runImageBuilderCmd) mergeImageInfo
       --manifest $(manifest)
-      $(artifactsPath)
-      $(artifactsPath)/image-info.json
+      $(artifactsPath)$(imageInfosSubDir)
+      $(artifactsPath)$(imageInfosSubDir)/image-info.json
       $(manifestVariables)
     displayName: Merge Image Info Files
-  - publish: $(Build.ArtifactStagingDirectory)/image-info.json
+  - publish: $(Build.ArtifactStagingDirectory)$(sbomSubDir)
+    artifact: sboms
+    displayName: Publish SBOM Artifact
+  - publish: $(Build.ArtifactStagingDirectory)$(imageInfosSubDir)/image-info.json
     artifact: image-info
     displayName: Publish Image Info File Artifact

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -14,9 +14,16 @@ jobs:
       --registry-override '$(acr.server)'
       $(manifestVariables)
       $(imageBuilder.queueArgs)
+  - name: publishNotificationRepoName
+    value: $(Build.Repository.Name)
   - ${{ parameters.customPublishVariables }}
   steps:
+  - template: ../steps/retain-build.yml
   - template: ../steps/init-docker-linux.yml
+  - pwsh: |
+      $azdoOrgName = Split-Path -Leaf $Env:SYSTEM_COLLECTIONURI
+      echo "##vso[task.setvariable variable=azdoOrgName]$azdoOrgName"
+    displayName: Set Publish Variables
   - ${{ parameters.customInitSteps }}
   - template: ../steps/validate-branch.yml
     parameters:
@@ -86,16 +93,10 @@ jobs:
       '$(gitHubVersionsRepoInfo.userName)'
       '$(gitHubVersionsRepoInfo.email)'
       '$(gitHubVersionsRepoInfo.accessToken)'
-      '$(azdoVersionsRepoInfo.accessToken)'
-      '$(azdoVersionsRepoInfo.org)'
-      '$(azdoVersionsRepoInfo.project)'
       --git-owner '$(gitHubVersionsRepoInfo.org)'
       --git-repo '$(gitHubVersionsRepoInfo.repo)'
       --git-branch '$(gitHubVersionsRepoInfo.branch)'
       --git-path '$(gitHubImageInfoVersionsPath)'
-      --azdo-repo '$(azdoVersionsRepoInfo.repo)'
-      --azdo-branch '$(azdoVersionsRepoInfo.branch)'
-      --azdo-path '$(azdoImageInfoVersionsPath)'
       $(dryRunArg)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Image Info
@@ -121,4 +122,27 @@ jobs:
       $(imageBuilder.commonCmdArgs)
     displayName: Ingest Kusto Image Info
     condition: and(succeeded(), eq(variables['ingestKustoImageInfo'], 'true'))
+  - script: >
+      $(runImageBuilderCmd) postPublishNotification
+      '$(publishNotificationRepoName)'
+      '$(Build.SourceBranchName)'
+      '$(artifactsPath)/image-info.json'
+      $(Build.BuildId)
+      '$(System.AccessToken)'
+      '$(azdoOrgName)'
+      '$(System.TeamProject)'
+      '$(gitHubNotificationsRepoInfo.accessToken)'
+      '$(gitHubNotificationsRepoInfo.org)'
+      '$(gitHubNotificationsRepoInfo.repo)'
+      --task "Copy Images"
+      --task "Publish Manifest"
+      --task "Wait for Image Ingestion"
+      --task "Publish Readmes"
+      --task "Wait for MCR Doc Ingestion"
+      --task "Publish Image Info"
+      --task "Ingest Kusto Image Info"
+      $(dryRunArg)
+      $(imageBuilder.commonCmdArgs)
+    displayName: Post Publish Notification
+    condition: and(always(), eq(variables['publishNotificationsEnabled'], 'true'))
   - template: ../steps/cleanup-docker-linux.yml

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -33,8 +33,6 @@ parameters:
     vmImage: $(defaultWindows2016PoolImage)
   windows1809Pool:
     vmImage: $(defaultWindows1809PoolImage)
-  windows2004Pool:
-    vmImage: $(defaultWindows2004PoolImage)
   windows20H2Pool:
     vmImage: $(defaultWindows20H2PoolImage)
   windows2022Pool:
@@ -85,9 +83,9 @@ stages:
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
   - template: ../jobs/build-images.yml
     parameters:
-      name: Linux_arm64v8
+      name: Linux_arm64
       pool: ${{ parameters.linuxArm64Pool }}
-      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm64v8']
+      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm64']
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
@@ -98,9 +96,9 @@ stages:
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
   - template: ../jobs/build-images.yml
     parameters:
-      name: Linux_arm32v7
+      name: Linux_arm32
       pool: ${{ parameters.linuxArm32Pool }}
-      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm32v7']
+      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.LinuxArm32']
       dockerClientOS: linux
       buildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
@@ -114,19 +112,6 @@ stages:
       name: Windows1809_amd64
       pool: ${{ parameters.windows1809Pool }}
       matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows1809Amd64']
-      dockerClientOS: windows
-      buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
-      customInitSteps: ${{ parameters.customBuildInitSteps }}
-      noCache: ${{ parameters.noCache }}
-      internalProjectName: ${{ parameters.internalProjectName }}
-      publicProjectName: ${{ parameters.publicProjectName }}
-      internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
-      publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
-    parameters:
-      name: Windows2004_amd64
-      pool: ${{ parameters.windows2004Pool }}
-      matrix: dependencies.GenerateBuildMatrix.outputs['matrix.Windows2004Amd64']
       dockerClientOS: windows
       buildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
       customInitSteps: ${{ parameters.customBuildInitSteps }}
@@ -183,6 +168,8 @@ stages:
   condition: and(succeeded(), contains(variables['stages'], 'build'))
   jobs:
   - template: ../jobs/post-build.yml
+    parameters:
+      pool: ${{ parameters.linuxAmd64Pool }}
 
 ################################################################################
 # Test Images
@@ -220,16 +207,16 @@ stages:
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-linux-client.yml
       parameters:
-        name: Linux_arm64v8
+        name: Linux_arm64
         pool: ${{ parameters.linuxArm64Pool }}
-        matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm64v8']
+        matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm64']
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-linux-client.yml
       parameters:
-        name: Linux_arm32v7
+        name: Linux_arm32
         pool: ${{ parameters.linuxArm32Pool }}
-        matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm32v7']
+        matrix: dependencies.GenerateTestMatrix.outputs['matrix.LinuxArm32']
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-windows-client.yml
@@ -237,13 +224,6 @@ stages:
         name: Windows1809_amd64
         pool: ${{ parameters.windows1809Pool }}
         matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows1809Amd64']
-        testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
-        internalProjectName: ${{ parameters.internalProjectName }}
-    - template: ../jobs/test-images-windows-client.yml
-      parameters:
-        name: Windows2004_amd64
-        pool: ${{ parameters.windows2004Pool }}
-        matrix: dependencies.GenerateTestMatrix.outputs['matrix.Windows2004Amd64']
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
     - template: ../jobs/test-images-windows-client.yml
@@ -278,31 +258,33 @@ stages:
     dependsOn: Post_Build
   condition: "
     and(
-      contains(variables['stages'], 'publish'),
-      or(
+      not(canceled()),
+      and(
+        contains(variables['stages'], 'publish'),
         or(
-          and(
-            and(
-              contains(variables['stages'], 'build'),
-              succeeded('Post_Build')),
-            and(
-              contains(variables['stages'], 'test'),
-              in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
           or(
             and(
-              not(contains(variables['stages'], 'build')),
+              and(
+                contains(variables['stages'], 'build'),
+                succeeded('Post_Build')),
               and(
                 contains(variables['stages'], 'test'),
                 in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
-            and(
-              not(contains(variables['stages'], 'test')),
+            or(
               and(
-                contains(variables['stages'], 'build'),
-                succeeded('Post_Build'))))),
-        not(
-          or(
-            contains(variables['stages'], 'build'),
-            contains(variables['stages'], 'test')))))"
+                not(contains(variables['stages'], 'build')),
+                and(
+                  contains(variables['stages'], 'test'),
+                  in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))),
+              and(
+                not(contains(variables['stages'], 'test')),
+                and(
+                  contains(variables['stages'], 'build'),
+                  succeeded('Post_Build'))))),
+          not(
+            or(
+              contains(variables['stages'], 'build'),
+              contains(variables['stages'], 'test'))))))"
   jobs:
   - template: ../jobs/publish.yml
     parameters:

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -6,13 +6,13 @@ parameters:
   internalProjectName: null
   publicProjectName: null
   buildMatrixCustomBuildLegGroupArgs: ""
+  testMatrixCustomBuildLegGroupArgs: ""
   customBuildInitSteps: []
   customPublishInitSteps: []
   windowsAmdBuildJobTimeout: 60
   windowsAmdTestJobTimeout: 60
   linuxAmdBuildJobTimeout: 60
-  linuxAmd64Pool:
-    vmImage: $(defaultLinuxAmd64PoolImage)
+  linuxAmd64Pool: ""
   buildMatrixType: platformDependencyGraph
   testMatrixType: platformVersionedOs
 
@@ -23,8 +23,27 @@ stages:
     internalProjectName: ${{ parameters.internalProjectName }}
     publicProjectName: ${{ parameters.publicProjectName }}
     buildMatrixCustomBuildLegGroupArgs: ${{ parameters.buildMatrixCustomBuildLegGroupArgs }}
+    testMatrixCustomBuildLegGroupArgs: ${{ parameters.testMatrixCustomBuildLegGroupArgs }}
     customBuildInitSteps: ${{ parameters.customBuildInitSteps }}
-    customPublishInitSteps: ${{ parameters.customPublishInitSteps }}
+    customPublishInitSteps:
+    - pwsh: |
+        # When reporting the repo name in the publish notification, we don't want to include
+        # the org part of the repo name (e.g. we want "dotnet-docker", not "dotnet-dotnet-docker").
+        # This also accounts for the different separators between AzDO and GitHub repo names.
+
+        $repoName = "$(Build.Repository.Name)"
+
+        $orgSeparatorIndex = $repoName.IndexOf("/")
+        if ($orgSeparatorIndex -eq -1) {
+          $orgSeparatorIndex = $repoName.IndexOf("-")
+        }
+
+        if ($orgSeparatorIndex -ge 0) {
+          $repoName = $repoName.Substring($orgSeparatorIndex + 1)
+        }
+        echo "##vso[task.setvariable variable=publishNotificationRepoName]$repoName"
+      displayName: "Set Custom Repo Name Var"
+    - ${{ parameters.customPublishInitSteps }}
     windowsAmdBuildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
     windowsAmdTestJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     linuxAmdBuildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
@@ -38,25 +57,26 @@ stages:
       customPublishVariables:
       - group: DotNet-AllOrgs-Darc-Pats
 
-    linuxAmd64Pool: ${{ parameters.linuxAmd64Pool }}
+    linuxAmd64Pool:
+      ${{ if ne(parameters.linuxAmd64Pool, '') }}:
+        ${{ parameters.linuxAmd64Pool }}
+      ${{ elseif eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+        vmImage: $(defaultLinuxAmd64PoolImage)
+      ${{ elseif eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+    
     linuxArm64Pool:
-        ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-          name: DotNetCore-Docker-Public
-        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-          name: DotNetCore-Docker
-        demands:
-        - Agent.OS -equals linux
-        - Agent.OSArchitecture -equals ARM64
+      ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+        name: DotNetCore-Docker-Public
+      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        name: Docker-Linux-Arm-Internal
     linuxArm32Pool:
-        ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-          name: DotNetCore-Docker-Public
-        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-          name: DotNetCore-Docker
-        demands:
-        - Agent.OS -equals linux
-        - Agent.OSArchitecture -equals ARM64
+      ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+        name: DotNetCore-Docker-Public
+      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        name: Docker-Linux-Arm-Internal
     windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
     windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
-    windows2004Pool: Docker-2004-${{ variables['System.TeamProject'] }}
     windows20H2Pool: Docker-20H2-${{ variables['System.TeamProject'] }}
     windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}

--- a/eng/common/templates/steps/retain-build.yml
+++ b/eng/common/templates/steps/retain-build.yml
@@ -1,0 +1,9 @@
+steps:
+- powershell: >
+    $(engCommonPath)/Retain-Build.ps1
+    -BuildId $(Build.BuildId)
+    -AzdoOrgUri '$(System.CollectionUri)'
+    -AzdoProject '$(System.TeamProject)'
+    -Token '$(System.AccessToken)'
+  displayName: Enable permanent build retention
+  condition: and(succeeded(), eq(variables.retainBuild, 'true'))

--- a/eng/common/templates/steps/set-image-info-path-var.yml
+++ b/eng/common/templates/steps/set-image-info-path-var.yml
@@ -3,12 +3,7 @@ parameters:
 
 steps:
 - powershell: |
-    if ("$(System.TeamProject)" -eq "$(publicProjectName)") {
-        $basePath = "$(gitHubVersionsRepoInfo.path)"
-    }
-    else {
-        $basePath= "$(azdoVersionsRepoInfo.path)"
-    }
+    $basePath = "$(gitHubVersionsRepoInfo.path)"
 
     $publicSourceBranch = "${{ parameters.publicSourceBranch }}"
 
@@ -21,5 +16,4 @@ steps:
 
     echo "##vso[task.setvariable variable=imageInfoVersionsPath]$basePath/$imageInfoName"
     echo "##vso[task.setvariable variable=gitHubImageInfoVersionsPath]$(gitHubVersionsRepoInfo.path)/$imageInfoName"
-    echo "##vso[task.setvariable variable=azdoImageInfoVersionsPath]$(azdoVersionsRepoInfo.path)/$imageInfoName"
   displayName: Set Image Info Path Vars

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -17,6 +17,8 @@ variables:
   value: ""
 - name: ingestKustoImageInfo
   value: true
+- name: publishNotificationsEnabled
+  value: false
 - name: manifestVariables
   value: ""
 - name: mcrImageIngestionTimeout
@@ -41,8 +43,6 @@ variables:
   value: vs2017-win2016
 - name: defaultWindows1809PoolImage
   value: windows-2019
-- name: defaultWindows2004PoolImage
-  value: null
 - name: defaultWindows20H2PoolImage
   value: null
 - name: defaultWindows2022PoolImage

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1442784
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1689405
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -21,6 +21,15 @@ variables:
 - name: mcrDocsRepoInfo.email
   value: $(dotnetDockerBot.email)
 
+- name: publishNotificationsEnabled
+  value: true
+- name: gitHubNotificationsRepoInfo.org
+  value: dotnet
+- name: gitHubNotificationsRepoInfo.repo
+  value: dotnet-docker-internal
+- name: gitHubNotificationsRepoInfo.accessToken
+  value: $(BotAccount-dotnet-docker-bot-PAT)
+
 - name: gitHubVersionsRepoInfo.org
   value: dotnet
 - name: gitHubVersionsRepoInfo.repo
@@ -35,19 +44,6 @@ variables:
   value: $(dotnetDockerBot.userName)
 - name: gitHubVersionsRepoInfo.email
   value: $(dotnetDockerBot.email)
-
-- name: azdoVersionsRepoInfo.org
-  value: dnceng
-- name: azdoVersionsRepoInfo.project
-  value: ${{ variables.internalProjectName }}
-- name: azdoVersionsRepoInfo.repo
-  value: dotnet-versions
-- name: azdoVersionsRepoInfo.branch
-  value: main
-- name: azdoVersionsRepoInfo.path
-  value: ${{ variables.commonVersionsImageInfoPath }}
-- name: azdoVersionsRepoInfo.accessToken
-  value: $(dn-bot-devdiv-dnceng-rw-code-pat)
 
 - name: kusto.servicePrincipalPassword
   value: $(app-DotnetDockerTelemetryIngestion-client-secret)

--- a/eng/pipeline/stages/build-test-publish-repo.yml
+++ b/eng/pipeline/stages/build-test-publish-repo.yml
@@ -12,6 +12,12 @@ stages:
         - template: ../../../pipeline/steps/set-public-source-branch-var.yml
       customPublishInitSteps:
         - template: ../../../pipeline/steps/set-public-source-branch-var.yml
+      # Specific pools for arm builds.
+      linuxArm64Pool:
+        ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
+          name: DotNetCore-Docker-Public
+        ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
+          name: Docker-Linux-Arm-Internal
       # On Windows, 'docker login' is incompatible with 'manifest-tool' unless we use these pools.
       # https://github.com/dotnet/docker-tools/issues/905
       windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}

--- a/manifest.json
+++ b/manifest.json
@@ -239,10 +239,10 @@
             "1-bullseye": {},
             "1.18": {},
             "1.18-bullseye": {},
-            "1.18.0": {},
-            "1.18.0-1": {},
-            "1.18.0-1-bullseye": {},
-            "1.18.0-bullseye": {},
+            "1.18.1": {},
+            "1.18.1-1": {},
+            "1.18.1-1-bullseye": {},
+            "1.18.1-bullseye": {},
             "bullseye": {},
             "latest": {}
           },
@@ -253,7 +253,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.18.0-1-bullseye-amd64": {}
+                "1.18.1-1-bullseye-amd64": {}
               }
             },
             {
@@ -263,7 +263,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.18.0-1-bullseye-arm64v8": {}
+                "1.18.1-1-bullseye-arm64v8": {}
               }
             }
           ]
@@ -273,8 +273,8 @@
           "sharedTags": {
             "1-buster": {},
             "1.18-buster": {},
-            "1.18.0-1-buster": {},
-            "1.18.0-buster": {},
+            "1.18.1-1-buster": {},
+            "1.18.1-buster": {},
             "buster": {}
           },
           "platforms": [
@@ -284,7 +284,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "1.18.0-1-buster-amd64": {}
+                "1.18.1-1-buster-amd64": {}
               }
             },
             {
@@ -294,7 +294,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "1.18.0-1-buster-arm64v8": {}
+                "1.18.1-1-buster-arm64v8": {}
               }
             }
           ]
@@ -304,8 +304,8 @@
           "sharedTags": {
             "1-stretch": {},
             "1.18-stretch": {},
-            "1.18.0-1-stretch": {},
-            "1.18.0-stretch": {},
+            "1.18.1-1-stretch": {},
+            "1.18.1-stretch": {},
             "stretch": {}
           },
           "platforms": [
@@ -315,7 +315,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "1.18.0-1-stretch-amd64": {}
+                "1.18.1-1-stretch-amd64": {}
               }
             },
             {
@@ -325,7 +325,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "1.18.0-1-stretch-arm64v8": {}
+                "1.18.1-1-stretch-arm64v8": {}
               }
             }
           ]
@@ -335,8 +335,8 @@
           "sharedTags": {
             "1-windowsservercore-ltsc2022": {},
             "1.18-windowsservercore-ltsc2022": {},
-            "1.18.0-1-windowsservercore-ltsc2022": {},
-            "1.18.0-windowsservercore-ltsc2022": {},
+            "1.18.1-1-windowsservercore-ltsc2022": {},
+            "1.18.1-windowsservercore-ltsc2022": {},
             "windowsservercore-ltsc2022": {}
           },
           "platforms": [
@@ -346,7 +346,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2022",
               "tags": {
-                "1.18.0-1-windowsservercore-ltsc2022-amd64": {}
+                "1.18.1-1-windowsservercore-ltsc2022-amd64": {}
               }
             }
           ]
@@ -356,8 +356,8 @@
           "sharedTags": {
             "1-windowsservercore-1809": {},
             "1.18-windowsservercore-1809": {},
-            "1.18.0-1-windowsservercore-1809": {},
-            "1.18.0-windowsservercore-1809": {},
+            "1.18.1-1-windowsservercore-1809": {},
+            "1.18.1-windowsservercore-1809": {},
             "windowsservercore-1809": {}
           },
           "platforms": [
@@ -367,7 +367,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1809",
               "tags": {
-                "1.18.0-1-windowsservercore-1809-amd64": {}
+                "1.18.1-1-windowsservercore-1809-amd64": {}
               }
             }
           ]
@@ -377,8 +377,8 @@
           "sharedTags": {
             "1-windowsservercore-ltsc2016": {},
             "1.18-windowsservercore-ltsc2016": {},
-            "1.18.0-1-windowsservercore-ltsc2016": {},
-            "1.18.0-windowsservercore-ltsc2016": {},
+            "1.18.1-1-windowsservercore-ltsc2016": {},
+            "1.18.1-windowsservercore-ltsc2016": {},
             "windowsservercore-ltsc2016": {}
           },
           "platforms": [
@@ -388,7 +388,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
               "tags": {
-                "1.18.0-1-windowsservercore-ltsc2016-amd64": {}
+                "1.18.1-1-windowsservercore-ltsc2016-amd64": {}
               }
             }
           ]
@@ -398,14 +398,14 @@
           "sharedTags": {
             "1-nanoserver-ltsc2022": {},
             "1.18-nanoserver-ltsc2022": {},
-            "1.18.0-1-nanoserver-ltsc2022": {},
-            "1.18.0-nanoserver-ltsc2022": {},
+            "1.18.1-1-nanoserver-ltsc2022": {},
+            "1.18.1-nanoserver-ltsc2022": {},
             "nanoserver-ltsc2022": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "DOWNLOADER_TAG": "1.18.0-1-windowsservercore-ltsc2022-amd64",
+                "DOWNLOADER_TAG": "1.18.1-1-windowsservercore-ltsc2022-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -413,7 +413,7 @@
               "os": "windows",
               "osVersion": "nanoserver-ltsc2022",
               "tags": {
-                "1.18.0-1-nanoserver-ltsc2022-amd64": {}
+                "1.18.1-1-nanoserver-ltsc2022-amd64": {}
               }
             }
           ]
@@ -423,14 +423,14 @@
           "sharedTags": {
             "1-nanoserver-1809": {},
             "1.18-nanoserver-1809": {},
-            "1.18.0-1-nanoserver-1809": {},
-            "1.18.0-nanoserver-1809": {},
+            "1.18.1-1-nanoserver-1809": {},
+            "1.18.1-nanoserver-1809": {},
             "nanoserver-1809": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "DOWNLOADER_TAG": "1.18.0-1-windowsservercore-1809-amd64",
+                "DOWNLOADER_TAG": "1.18.1-1-windowsservercore-1809-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -438,7 +438,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "1.18.0-1-nanoserver-1809-amd64": {}
+                "1.18.1-1-nanoserver-1809-amd64": {}
               }
             }
           ]

--- a/manifest.json
+++ b/manifest.json
@@ -285,10 +285,10 @@
             "1-fips-cbl-mariner1.0": {},
             "1.17-fips": {},
             "1.17-fips-cbl-mariner1.0": {},
-            "1.17.7-1-fips": {},
-            "1.17.7-1-fips-cbl-mariner1.0": {},
-            "1.17.7-fips": {},
-            "1.17.7-fips-cbl-mariner1.0": {}
+            "1.17.8-2-fips": {},
+            "1.17.8-2-fips-cbl-mariner1.0": {},
+            "1.17.8-fips": {},
+            "1.17.8-fips-cbl-mariner1.0": {}
           },
           "platforms": [
             {
@@ -296,7 +296,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.17.7-1-fips-cbl-mariner1.0-amd64": {}
+                "1.17.8-2-fips-cbl-mariner1.0-amd64": {}
               }
             }
           ]

--- a/manifest.json
+++ b/manifest.json
@@ -13,10 +13,10 @@
           "sharedTags": {
             "1.17": {},
             "1.17-bullseye": {},
-            "1.17.8": {},
-            "1.17.8-1": {},
-            "1.17.8-1-bullseye": {},
-            "1.17.8-bullseye": {}
+            "1.17.9": {},
+            "1.17.9-1": {},
+            "1.17.9-1-bullseye": {},
+            "1.17.9-bullseye": {}
           },
           "platforms": [
             {
@@ -25,7 +25,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.17.8-1-bullseye-amd64": {}
+                "1.17.9-1-bullseye-amd64": {}
               }
             },
             {
@@ -35,7 +35,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.17.8-1-bullseye-arm64v8": {}
+                "1.17.9-1-bullseye-arm64v8": {}
               }
             }
           ]
@@ -44,8 +44,8 @@
           "productVersion": "1.17",
           "sharedTags": {
             "1.17-buster": {},
-            "1.17.8-1-buster": {},
-            "1.17.8-buster": {}
+            "1.17.9-1-buster": {},
+            "1.17.9-buster": {}
           },
           "platforms": [
             {
@@ -54,7 +54,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "1.17.8-1-buster-amd64": {}
+                "1.17.9-1-buster-amd64": {}
               }
             },
             {
@@ -64,7 +64,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "1.17.8-1-buster-arm64v8": {}
+                "1.17.9-1-buster-arm64v8": {}
               }
             }
           ]
@@ -73,8 +73,8 @@
           "productVersion": "1.17",
           "sharedTags": {
             "1.17-stretch": {},
-            "1.17.8-1-stretch": {},
-            "1.17.8-stretch": {}
+            "1.17.9-1-stretch": {},
+            "1.17.9-stretch": {}
           },
           "platforms": [
             {
@@ -83,7 +83,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "1.17.8-1-stretch-amd64": {}
+                "1.17.9-1-stretch-amd64": {}
               }
             },
             {
@@ -93,7 +93,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "1.17.8-1-stretch-arm64v8": {}
+                "1.17.9-1-stretch-arm64v8": {}
               }
             }
           ]
@@ -102,8 +102,8 @@
           "productVersion": "1.17",
           "sharedTags": {
             "1.17-windowsservercore-ltsc2022": {},
-            "1.17.8-1-windowsservercore-ltsc2022": {},
-            "1.17.8-windowsservercore-ltsc2022": {}
+            "1.17.9-1-windowsservercore-ltsc2022": {},
+            "1.17.9-windowsservercore-ltsc2022": {}
           },
           "platforms": [
             {
@@ -112,7 +112,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2022",
               "tags": {
-                "1.17.8-1-windowsservercore-ltsc2022-amd64": {}
+                "1.17.9-1-windowsservercore-ltsc2022-amd64": {}
               }
             }
           ]
@@ -121,8 +121,8 @@
           "productVersion": "1.17",
           "sharedTags": {
             "1.17-windowsservercore-1809": {},
-            "1.17.8-1-windowsservercore-1809": {},
-            "1.17.8-windowsservercore-1809": {}
+            "1.17.9-1-windowsservercore-1809": {},
+            "1.17.9-windowsservercore-1809": {}
           },
           "platforms": [
             {
@@ -131,7 +131,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1809",
               "tags": {
-                "1.17.8-1-windowsservercore-1809-amd64": {}
+                "1.17.9-1-windowsservercore-1809-amd64": {}
               }
             }
           ]
@@ -140,8 +140,8 @@
           "productVersion": "1.17",
           "sharedTags": {
             "1.17-windowsservercore-ltsc2016": {},
-            "1.17.8-1-windowsservercore-ltsc2016": {},
-            "1.17.8-windowsservercore-ltsc2016": {}
+            "1.17.9-1-windowsservercore-ltsc2016": {},
+            "1.17.9-windowsservercore-ltsc2016": {}
           },
           "platforms": [
             {
@@ -150,7 +150,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
               "tags": {
-                "1.17.8-1-windowsservercore-ltsc2016-amd64": {}
+                "1.17.9-1-windowsservercore-ltsc2016-amd64": {}
               }
             }
           ]
@@ -159,13 +159,13 @@
           "productVersion": "1.17",
           "sharedTags": {
             "1.17-nanoserver-ltsc2022": {},
-            "1.17.8-1-nanoserver-ltsc2022": {},
-            "1.17.8-nanoserver-ltsc2022": {}
+            "1.17.9-1-nanoserver-ltsc2022": {},
+            "1.17.9-nanoserver-ltsc2022": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "DOWNLOADER_TAG": "1.17.8-1-windowsservercore-ltsc2022-amd64",
+                "DOWNLOADER_TAG": "1.17.9-1-windowsservercore-ltsc2022-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -173,7 +173,7 @@
               "os": "windows",
               "osVersion": "nanoserver-ltsc2022",
               "tags": {
-                "1.17.8-1-nanoserver-ltsc2022-amd64": {}
+                "1.17.9-1-nanoserver-ltsc2022-amd64": {}
               }
             }
           ]
@@ -182,13 +182,13 @@
           "productVersion": "1.17",
           "sharedTags": {
             "1.17-nanoserver-1809": {},
-            "1.17.8-1-nanoserver-1809": {},
-            "1.17.8-nanoserver-1809": {}
+            "1.17.9-1-nanoserver-1809": {},
+            "1.17.9-nanoserver-1809": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "DOWNLOADER_TAG": "1.17.8-1-windowsservercore-1809-amd64",
+                "DOWNLOADER_TAG": "1.17.9-1-windowsservercore-1809-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -196,7 +196,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "1.17.8-1-nanoserver-1809-amd64": {}
+                "1.17.9-1-nanoserver-1809-amd64": {}
               }
             }
           ]

--- a/manifest.json
+++ b/manifest.json
@@ -20,11 +20,22 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/bullseye",
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
                 "1.17.8-1-bullseye-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.17/bullseye",
+              "os": "linux",
+              "osVersion": "bullseye",
+              "tags": {
+                "1.17.8-1-bullseye-arm64v8": {}
               }
             }
           ]
@@ -38,11 +49,22 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/buster",
               "os": "linux",
               "osVersion": "buster",
               "tags": {
                 "1.17.8-1-buster-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.17/buster",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "1.17.8-1-buster-arm64v8": {}
               }
             }
           ]
@@ -56,11 +78,22 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/stretch",
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
                 "1.17.8-1-stretch-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.17/stretch",
+              "os": "linux",
+              "osVersion": "stretch",
+              "tags": {
+                "1.17.8-1-stretch-arm64v8": {}
               }
             }
           ]
@@ -74,6 +107,7 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/windows/windowsservercore-ltsc2022",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2022",
@@ -92,6 +126,7 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/windows/windowsservercore-1809",
               "os": "windows",
               "osVersion": "windowsservercore-1809",
@@ -110,6 +145,7 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/windows/windowsservercore-ltsc2016",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
@@ -132,6 +168,7 @@
                 "DOWNLOADER_TAG": "1.17.8-1-windowsservercore-ltsc2022-amd64",
                 "REPO": "$(Repo:golang)"
               },
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/windows/nanoserver-ltsc2022",
               "os": "windows",
               "osVersion": "nanoserver-ltsc2022",
@@ -154,6 +191,7 @@
                 "DOWNLOADER_TAG": "1.17.8-1-windowsservercore-1809-amd64",
                 "REPO": "$(Repo:golang)"
               },
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17/windows/nanoserver-1809",
               "os": "windows",
               "osVersion": "nanoserver-1809",
@@ -175,11 +213,21 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.17-fips/cbl-mariner1.0",
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
                 "1.17.8-2-fips-cbl-mariner1.0-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/microsoft/1.17-fips/cbl-mariner1.0",
+              "os": "linux",
+              "osVersion": "cbl-mariner1.0",
+              "tags": {
+                "1.17.8-2-fips-cbl-mariner1.0-arm64": {}
               }
             }
           ]
@@ -200,11 +248,22 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/bullseye",
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
                 "1.18.0-1-bullseye-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.18/bullseye",
+              "os": "linux",
+              "osVersion": "bullseye",
+              "tags": {
+                "1.18.0-1-bullseye-arm64v8": {}
               }
             }
           ]
@@ -220,11 +279,22 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/buster",
               "os": "linux",
               "osVersion": "buster",
               "tags": {
                 "1.18.0-1-buster-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.18/buster",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "1.18.0-1-buster-arm64v8": {}
               }
             }
           ]
@@ -240,11 +310,22 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/stretch",
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
                 "1.18.0-1-stretch-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.18/stretch",
+              "os": "linux",
+              "osVersion": "stretch",
+              "tags": {
+                "1.18.0-1-stretch-arm64v8": {}
               }
             }
           ]
@@ -260,6 +341,7 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/windows/windowsservercore-ltsc2022",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2022",
@@ -280,6 +362,7 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/windows/windowsservercore-1809",
               "os": "windows",
               "osVersion": "windowsservercore-1809",
@@ -300,6 +383,7 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/windows/windowsservercore-ltsc2016",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
@@ -324,6 +408,7 @@
                 "DOWNLOADER_TAG": "1.18.0-1-windowsservercore-ltsc2022-amd64",
                 "REPO": "$(Repo:golang)"
               },
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/windows/nanoserver-ltsc2022",
               "os": "windows",
               "osVersion": "nanoserver-ltsc2022",
@@ -348,6 +433,7 @@
                 "DOWNLOADER_TAG": "1.18.0-1-windowsservercore-1809-amd64",
                 "REPO": "$(Repo:golang)"
               },
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18/windows/nanoserver-1809",
               "os": "windows",
               "osVersion": "nanoserver-1809",
@@ -371,11 +457,21 @@
           },
           "platforms": [
             {
+              "architecture": "amd64",
               "dockerfile": "src/microsoft/1.18-fips/cbl-mariner1.0",
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
                 "1.18.0-2-fips-cbl-mariner1.0-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/microsoft/1.18-fips/cbl-mariner1.0",
+              "os": "linux",
+              "osVersion": "cbl-mariner1.0",
+              "tags": {
+                "1.18.0-2-fips-cbl-mariner1.0-arm64": {}
               }
             }
           ]

--- a/patches/0002-Add-Mariner-support-with-FIPS-dependency-flag.patch
+++ b/patches/0002-Add-Mariner-support-with-FIPS-dependency-flag.patch
@@ -4,11 +4,11 @@ Date: Fri, 11 Feb 2022 18:07:18 -0600
 Subject: [PATCH] Add Mariner support with FIPS dependency flag
 
 ---
- Dockerfile-linux.template | 45 +++++++++++++++++++++++++++++++++++++++
- 1 file changed, 45 insertions(+)
+ Dockerfile-linux.template | 48 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 48 insertions(+)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index c300098..ee0c959 100644
+index a79ec02..106f1d0 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
 @@ -4,6 +4,16 @@
@@ -71,18 +71,21 @@ index c300098..ee0c959 100644
  	; \
  	rm -rf /var/lib/apt/lists/*
  {{ ) end -}}
-@@ -46,6 +85,10 @@ ENV GOLANG_VERSION {{ .version }}
+@@ -46,6 +85,13 @@ ENV GOLANG_VERSION {{ .version }}
  				ppc64le: "ppc64le",
  				s390x: "s390x",
  			}
 +		elif is_cbl_mariner then
 +			{
 +				amd64: "x86_64",
++				arm32v6: "armhf",
++				arm32v7: "armv7",
++				arm64v8: "aarch64",
 +			}
  		else
  			{
  				amd64: "amd64",
-@@ -63,6 +106,8 @@ RUN set -eux; \
+@@ -63,6 +109,8 @@ RUN set -eux; \
  {{ if is_alpine then ( -}}
  	apk add --no-cache --virtual .fetch-deps gnupg; \
  	arch="$(apk --print-arch)"; \

--- a/patches/0003-Add-downloader-stage-to-Windows-Dockerfile.patch
+++ b/patches/0003-Add-downloader-stage-to-Windows-Dockerfile.patch
@@ -17,7 +17,7 @@ reference later.
  1 file changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/Dockerfile-windows-nanoserver.template b/Dockerfile-windows-nanoserver.template
-index be196ac..aaecdb5 100644
+index 6fd53f6..8e3ecb3 100644
 --- a/Dockerfile-windows-nanoserver.template
 +++ b/Dockerfile-windows-nanoserver.template
 @@ -1,3 +1,9 @@
@@ -30,12 +30,12 @@ index be196ac..aaecdb5 100644
  FROM mcr.microsoft.com/windows/{{ env.windowsVariant }}:{{ env.windowsRelease }}
  
  SHELL ["cmd", "/S", "/C"]
-@@ -32,7 +38,7 @@ USER ContainerUser
+@@ -18,7 +24,7 @@ USER ContainerUser
  ENV GOLANG_VERSION {{ .version }}
  
  # Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
--COPY --from=golang:{{ .version }}-windowsservercore-{{ env.windowsRelease }} {{
-+COPY --from=downloader {{
- 	install_directory
- 	| gsub("\\\\"; "\\\\")
- 	| [ . , . ]
+-COPY --from=golang:{{ .version }}-windowsservercore-{{ env.windowsRelease }} ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]
++COPY --from=downloader ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]
+ RUN go version
+ 
+ WORKDIR $GOPATH

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -28,8 +28,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.2/go.20220307.2.linux-amd64.tar.gz'; \
-			sha256='865b919aafd27f20f17266333cc1f58c1288ce30d6e1825c9df44bccc085b799'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.3/go.20220307.3.linux-amd64.tar.gz'; \
+			sha256='6877d8a8f0a640b239ab3193e1327a18d38e557a896ac66d21c1f8ef56cff763'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -28,12 +28,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220401.1/go.20220401.1.linux-amd64.tar.gz'; \
-			sha256='9fe4c70c8ec15ca406aab68e9efed871b16d5db27f69bfb74fe87f099dcaa41e'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220407.3/go.20220407.3.linux-amd64.tar.gz'; \
+			sha256='0342dd738eb1a7e2ed5840e32b1c1a80dc5efac449c3d785339bca875f4a2567'; \
 			;; \
 		'aarch64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220401.1/go.20220401.1.linux-arm64.tar.gz'; \
-			sha256='b7e54d90fcaccd2bec45bd75ad78628a923715063fb7f985ded2836a35a63f9e'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220407.3/go.20220407.3.linux-arm64.tar.gz'; \
+			sha256='632756bf5f84c115d8f8fdfab649a396f029a13878bedb0783f6a0e3b3962790'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -28,8 +28,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.3/go.20220307.3.linux-amd64.tar.gz'; \
-			sha256='6877d8a8f0a640b239ab3193e1327a18d38e557a896ac66d21c1f8ef56cff763'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220315.4/go.20220315.4.linux-amd64.tar.gz'; \
+			sha256='9804167d4125f5915e90e6058526ca8aab18e16810aede483b0345fcfbdf61a1'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -28,8 +28,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.6/go.20220329.6.linux-amd64.tar.gz'; \
-			sha256='661b1d3d3d2b1a2d8d151a85c6972c0995ce18098639b8f72668f6b587834ad4'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220401.1/go.20220401.1.linux-amd64.tar.gz'; \
+			sha256='9fe4c70c8ec15ca406aab68e9efed871b16d5db27f69bfb74fe87f099dcaa41e'; \
+			;; \
+		'aarch64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220401.1/go.20220401.1.linux-arm64.tar.gz'; \
+			sha256='b7e54d90fcaccd2bec45bd75ad78628a923715063fb7f985ded2836a35a63f9e'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -28,8 +28,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220216.3/go.20220216.3.linux-amd64.tar.gz'; \
-			sha256='416eb5c5b81d5802a6f5baeec8c3abcacae438da81a026d00129d72852a6760f'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.2/go.20220307.2.linux-amd64.tar.gz'; \
+			sha256='865b919aafd27f20f17266333cc1f58c1288ce30d6e1825c9df44bccc085b799'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -21,15 +21,15 @@ RUN tdnf install -y \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.7
+ENV GOLANG_VERSION 1.17.8
 
 RUN set -eux; \
 	arch="$(uname -m)"; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.2/go.20220329.2.linux-amd64.tar.gz'; \
-			sha256='6bcea3b832c24ef39ed780b45167a9cd13afd0ef5526bb6c626f8e11b6b028fc'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.6/go.20220329.6.linux-amd64.tar.gz'; \
+			sha256='661b1d3d3d2b1a2d8d151a85c6972c0995ce18098639b8f72668f6b587834ad4'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -28,8 +28,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220315.4/go.20220315.4.linux-amd64.tar.gz'; \
-			sha256='9804167d4125f5915e90e6058526ca8aab18e16810aede483b0345fcfbdf61a1'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.2/go.20220329.2.linux-amd64.tar.gz'; \
+			sha256='6bcea3b832c24ef39ed780b45167a9cd13afd0ef5526bb6c626f8e11b6b028fc'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/bullseye/Dockerfile
+++ b/src/microsoft/1.17/bullseye/Dockerfile
@@ -20,19 +20,19 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.8
+ENV GOLANG_VERSION 1.17.9
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-amd64.tar.gz'; \
-			sha256='5014d7ce47db6c70a1d18340deb33e45c802746ba7e7498f42dfbd8a310fb8c8'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-amd64.tar.gz'; \
+			sha256='54af8ed5c858365fb424a8cd1fa258a209e334699a6f88c051784bf06df11676'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-arm64.tar.gz'; \
-			sha256='0df2e76bfc2f61e44daf05d9ba8171fb46c6ee8ebb088593b6a4cd408c151e9b'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-arm64.tar.gz'; \
+			sha256='d5aa78c1316bbb5c0638da9624f698aada990628e2321716b0b289084a1c08aa'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/bullseye/Dockerfile
+++ b/src/microsoft/1.17/bullseye/Dockerfile
@@ -27,8 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.linux-amd64.tar.gz'; \
-			sha256='fa8a829cf00f9370ba2032335700e3d65e1c58b0ff5bea1cd72145d2d1a51631'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-amd64.tar.gz'; \
+			sha256='5014d7ce47db6c70a1d18340deb33e45c802746ba7e7498f42dfbd8a310fb8c8'; \
+			;; \
+		'arm64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-arm64.tar.gz'; \
+			sha256='0df2e76bfc2f61e44daf05d9ba8171fb46c6ee8ebb088593b6a4cd408c151e9b'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/bullseye/Dockerfile
+++ b/src/microsoft/1.17/bullseye/Dockerfile
@@ -27,8 +27,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.linux-amd64.tar.gz'; \
-			sha256='fa8a829cf00f9370ba2032335700e3d65e1c58b0ff5bea1cd72145d2d1a51631'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220315.2/go.20220315.2.linux-amd64.tar.gz'; \
+			sha256='a066cecebdaf0b633ce6ce5a10aef8030efd488145a6e95de1ca6396ddff6e0a'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/buster/Dockerfile
+++ b/src/microsoft/1.17/buster/Dockerfile
@@ -20,19 +20,19 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.8
+ENV GOLANG_VERSION 1.17.9
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-amd64.tar.gz'; \
-			sha256='5014d7ce47db6c70a1d18340deb33e45c802746ba7e7498f42dfbd8a310fb8c8'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-amd64.tar.gz'; \
+			sha256='54af8ed5c858365fb424a8cd1fa258a209e334699a6f88c051784bf06df11676'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-arm64.tar.gz'; \
-			sha256='0df2e76bfc2f61e44daf05d9ba8171fb46c6ee8ebb088593b6a4cd408c151e9b'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-arm64.tar.gz'; \
+			sha256='d5aa78c1316bbb5c0638da9624f698aada990628e2321716b0b289084a1c08aa'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/buster/Dockerfile
+++ b/src/microsoft/1.17/buster/Dockerfile
@@ -27,8 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.linux-amd64.tar.gz'; \
-			sha256='fa8a829cf00f9370ba2032335700e3d65e1c58b0ff5bea1cd72145d2d1a51631'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-amd64.tar.gz'; \
+			sha256='5014d7ce47db6c70a1d18340deb33e45c802746ba7e7498f42dfbd8a310fb8c8'; \
+			;; \
+		'arm64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-arm64.tar.gz'; \
+			sha256='0df2e76bfc2f61e44daf05d9ba8171fb46c6ee8ebb088593b6a4cd408c151e9b'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/buster/Dockerfile
+++ b/src/microsoft/1.17/buster/Dockerfile
@@ -27,8 +27,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.linux-amd64.tar.gz'; \
-			sha256='fa8a829cf00f9370ba2032335700e3d65e1c58b0ff5bea1cd72145d2d1a51631'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220315.2/go.20220315.2.linux-amd64.tar.gz'; \
+			sha256='a066cecebdaf0b633ce6ce5a10aef8030efd488145a6e95de1ca6396ddff6e0a'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/stretch/Dockerfile
+++ b/src/microsoft/1.17/stretch/Dockerfile
@@ -20,19 +20,19 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.8
+ENV GOLANG_VERSION 1.17.9
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-amd64.tar.gz'; \
-			sha256='5014d7ce47db6c70a1d18340deb33e45c802746ba7e7498f42dfbd8a310fb8c8'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-amd64.tar.gz'; \
+			sha256='54af8ed5c858365fb424a8cd1fa258a209e334699a6f88c051784bf06df11676'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-arm64.tar.gz'; \
-			sha256='0df2e76bfc2f61e44daf05d9ba8171fb46c6ee8ebb088593b6a4cd408c151e9b'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-arm64.tar.gz'; \
+			sha256='d5aa78c1316bbb5c0638da9624f698aada990628e2321716b0b289084a1c08aa'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/stretch/Dockerfile
+++ b/src/microsoft/1.17/stretch/Dockerfile
@@ -27,8 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.linux-amd64.tar.gz'; \
-			sha256='fa8a829cf00f9370ba2032335700e3d65e1c58b0ff5bea1cd72145d2d1a51631'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-amd64.tar.gz'; \
+			sha256='5014d7ce47db6c70a1d18340deb33e45c802746ba7e7498f42dfbd8a310fb8c8'; \
+			;; \
+		'arm64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-arm64.tar.gz'; \
+			sha256='0df2e76bfc2f61e44daf05d9ba8171fb46c6ee8ebb088593b6a4cd408c151e9b'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/stretch/Dockerfile
+++ b/src/microsoft/1.17/stretch/Dockerfile
@@ -27,8 +27,8 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.linux-amd64.tar.gz'; \
-			sha256='fa8a829cf00f9370ba2032335700e3d65e1c58b0ff5bea1cd72145d2d1a51631'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220315.2/go.20220315.2.linux-amd64.tar.gz'; \
+			sha256='a066cecebdaf0b633ce6ce5a10aef8030efd488145a6e95de1ca6396ddff6e0a'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/windows/nanoserver-1809/Dockerfile
+++ b/src/microsoft/1.17/windows/nanoserver-1809/Dockerfile
@@ -7,7 +7,7 @@
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
 # It's easy to download Go and install it in server core, but not nanoserver. So, to build
 # nanoserver, copy over the server core installation.
-ARG DOWNLOADER_TAG=1.17.8-windowsservercore-1809
+ARG DOWNLOADER_TAG=1.17.9-windowsservercore-1809
 FROM $REPO:$DOWNLOADER_TAG AS downloader
 
 FROM mcr.microsoft.com/windows/nanoserver:1809
@@ -27,7 +27,7 @@ RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.17.8
+ENV GOLANG_VERSION 1.17.9
 
 # Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
 COPY --from=downloader ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]

--- a/src/microsoft/1.17/windows/nanoserver-ltsc2022/Dockerfile
+++ b/src/microsoft/1.17/windows/nanoserver-ltsc2022/Dockerfile
@@ -7,7 +7,7 @@
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
 # It's easy to download Go and install it in server core, but not nanoserver. So, to build
 # nanoserver, copy over the server core installation.
-ARG DOWNLOADER_TAG=1.17.8-windowsservercore-ltsc2022
+ARG DOWNLOADER_TAG=1.17.9-windowsservercore-ltsc2022
 FROM $REPO:$DOWNLOADER_TAG AS downloader
 
 FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
@@ -27,7 +27,7 @@ RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.17.8
+ENV GOLANG_VERSION 1.17.9
 
 # Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
 COPY --from=downloader ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]

--- a/src/microsoft/1.17/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-1809/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.17.8
+ENV GOLANG_VERSION 1.17.9
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '68c32ee9f6460035915a16f318eb6e03dfc4428d2ec9f5251c427b429ad44a44'; \
+	$sha256 = 'dac299d353e8963ea0d0019064b0861ef4cb938ef5ec6a77a2a5da6e0aa1700b'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-1809/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.17.8
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '3f376538245436da78193101863751c502da489e29317acaf18bdb0d2852d654'; \
+	$sha256 = '68c32ee9f6460035915a16f318eb6e03dfc4428d2ec9f5251c427b429ad44a44'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-1809/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.17.8
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220315.2/go.20220315.2.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '3f376538245436da78193101863751c502da489e29317acaf18bdb0d2852d654'; \
+	$sha256 = 'ba9c0a51d9b2af502f4cc78cc43c6d4fc7bbced899682122b5237a30014f6d13'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-ltsc2016/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.17.8
+ENV GOLANG_VERSION 1.17.9
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '68c32ee9f6460035915a16f318eb6e03dfc4428d2ec9f5251c427b429ad44a44'; \
+	$sha256 = 'dac299d353e8963ea0d0019064b0861ef4cb938ef5ec6a77a2a5da6e0aa1700b'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-ltsc2016/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.17.8
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '3f376538245436da78193101863751c502da489e29317acaf18bdb0d2852d654'; \
+	$sha256 = '68c32ee9f6460035915a16f318eb6e03dfc4428d2ec9f5251c427b429ad44a44'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-ltsc2016/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.17.8
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220315.2/go.20220315.2.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '3f376538245436da78193101863751c502da489e29317acaf18bdb0d2852d654'; \
+	$sha256 = 'ba9c0a51d9b2af502f4cc78cc43c6d4fc7bbced899682122b5237a30014f6d13'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-ltsc2022/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.17.8
+ENV GOLANG_VERSION 1.17.9
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '68c32ee9f6460035915a16f318eb6e03dfc4428d2ec9f5251c427b429ad44a44'; \
+	$sha256 = 'dac299d353e8963ea0d0019064b0861ef4cb938ef5ec6a77a2a5da6e0aa1700b'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-ltsc2022/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.17.8
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '3f376538245436da78193101863751c502da489e29317acaf18bdb0d2852d654'; \
+	$sha256 = '68c32ee9f6460035915a16f318eb6e03dfc4428d2ec9f5251c427b429ad44a44'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-ltsc2022/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.17.8
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220315.2/go.20220315.2.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '3f376538245436da78193101863751c502da489e29317acaf18bdb0d2852d654'; \
+	$sha256 = 'ba9c0a51d9b2af502f4cc78cc43c6d4fc7bbced899682122b5237a30014f6d13'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
@@ -28,8 +28,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220329.7/go.20220329.7.linux-amd64.tar.gz'; \
-			sha256='3ea93d412f30297866d60bc728278197ea9c9ee8671167f1b207782af9e9e7f6'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220401.2/go.20220401.2.linux-amd64.tar.gz'; \
+			sha256='dd80089e36c2e0219d4292bc06c4c468bb0d80766e3ef25b1cb8f0999c347f7e'; \
+			;; \
+		'aarch64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220401.2/go.20220401.2.linux-arm64.tar.gz'; \
+			sha256='d24bb3090c4fe81afebe74166c73091c178d63439177a1d4155c7d062ed2323e'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
@@ -28,12 +28,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220401.2/go.20220401.2.linux-amd64.tar.gz'; \
-			sha256='dd80089e36c2e0219d4292bc06c4c468bb0d80766e3ef25b1cb8f0999c347f7e'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220407.1/go.20220407.1.linux-amd64.tar.gz'; \
+			sha256='52227bc6cdaec6f2a3c47e9b89b9c311be4e49456c90efb8b996e4266e5128cc'; \
 			;; \
 		'aarch64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220401.2/go.20220401.2.linux-arm64.tar.gz'; \
-			sha256='d24bb3090c4fe81afebe74166c73091c178d63439177a1d4155c7d062ed2323e'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220407.1/go.20220407.1.linux-arm64.tar.gz'; \
+			sha256='7ab29e484046d3cb214c1ff83a66f33f4d89641542373d123f4a1a99ba280e2a'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/bullseye/Dockerfile
+++ b/src/microsoft/1.18/bullseye/Dockerfile
@@ -27,8 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.linux-amd64.tar.gz'; \
-			sha256='b5ed9d893fb12934daf41edea40b15c4b43533761665d8c61a00d666c8d341ef'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-amd64.tar.gz'; \
+			sha256='ecd5cdd9a3c8ec2d57170c8c4daa7c55309c96e4f186aa79709ccb5aab4a2f40'; \
+			;; \
+		'arm64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-arm64.tar.gz'; \
+			sha256='e640c8cc2eddc11d6d7b8bd7936797f62641eacee57c1e3f7e90381bcb4b33eb'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/bullseye/Dockerfile
+++ b/src/microsoft/1.18/bullseye/Dockerfile
@@ -20,19 +20,19 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.18.0
+ENV GOLANG_VERSION 1.18.1
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-amd64.tar.gz'; \
-			sha256='ecd5cdd9a3c8ec2d57170c8c4daa7c55309c96e4f186aa79709ccb5aab4a2f40'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-amd64.tar.gz'; \
+			sha256='0ecd8a6b43ae3e993eedddde6141a7785fc65d1cc8a322c6e67fa02420a883fd'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-arm64.tar.gz'; \
-			sha256='e640c8cc2eddc11d6d7b8bd7936797f62641eacee57c1e3f7e90381bcb4b33eb'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-arm64.tar.gz'; \
+			sha256='7965396729a9efb2d166e9b33eb142629f9c505240c4e373bbd783cf5f8af61a'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/buster/Dockerfile
+++ b/src/microsoft/1.18/buster/Dockerfile
@@ -27,8 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.linux-amd64.tar.gz'; \
-			sha256='b5ed9d893fb12934daf41edea40b15c4b43533761665d8c61a00d666c8d341ef'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-amd64.tar.gz'; \
+			sha256='ecd5cdd9a3c8ec2d57170c8c4daa7c55309c96e4f186aa79709ccb5aab4a2f40'; \
+			;; \
+		'arm64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-arm64.tar.gz'; \
+			sha256='e640c8cc2eddc11d6d7b8bd7936797f62641eacee57c1e3f7e90381bcb4b33eb'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/buster/Dockerfile
+++ b/src/microsoft/1.18/buster/Dockerfile
@@ -20,19 +20,19 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.18.0
+ENV GOLANG_VERSION 1.18.1
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-amd64.tar.gz'; \
-			sha256='ecd5cdd9a3c8ec2d57170c8c4daa7c55309c96e4f186aa79709ccb5aab4a2f40'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-amd64.tar.gz'; \
+			sha256='0ecd8a6b43ae3e993eedddde6141a7785fc65d1cc8a322c6e67fa02420a883fd'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-arm64.tar.gz'; \
-			sha256='e640c8cc2eddc11d6d7b8bd7936797f62641eacee57c1e3f7e90381bcb4b33eb'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-arm64.tar.gz'; \
+			sha256='7965396729a9efb2d166e9b33eb142629f9c505240c4e373bbd783cf5f8af61a'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/stretch/Dockerfile
+++ b/src/microsoft/1.18/stretch/Dockerfile
@@ -27,8 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.linux-amd64.tar.gz'; \
-			sha256='b5ed9d893fb12934daf41edea40b15c4b43533761665d8c61a00d666c8d341ef'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-amd64.tar.gz'; \
+			sha256='ecd5cdd9a3c8ec2d57170c8c4daa7c55309c96e4f186aa79709ccb5aab4a2f40'; \
+			;; \
+		'arm64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-arm64.tar.gz'; \
+			sha256='e640c8cc2eddc11d6d7b8bd7936797f62641eacee57c1e3f7e90381bcb4b33eb'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/stretch/Dockerfile
+++ b/src/microsoft/1.18/stretch/Dockerfile
@@ -20,19 +20,19 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.18.0
+ENV GOLANG_VERSION 1.18.1
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-amd64.tar.gz'; \
-			sha256='ecd5cdd9a3c8ec2d57170c8c4daa7c55309c96e4f186aa79709ccb5aab4a2f40'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-amd64.tar.gz'; \
+			sha256='0ecd8a6b43ae3e993eedddde6141a7785fc65d1cc8a322c6e67fa02420a883fd'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-arm64.tar.gz'; \
-			sha256='e640c8cc2eddc11d6d7b8bd7936797f62641eacee57c1e3f7e90381bcb4b33eb'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-arm64.tar.gz'; \
+			sha256='7965396729a9efb2d166e9b33eb142629f9c505240c4e373bbd783cf5f8af61a'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/windows/nanoserver-1809/Dockerfile
+++ b/src/microsoft/1.18/windows/nanoserver-1809/Dockerfile
@@ -7,7 +7,7 @@
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
 # It's easy to download Go and install it in server core, but not nanoserver. So, to build
 # nanoserver, copy over the server core installation.
-ARG DOWNLOADER_TAG=1.18.0-windowsservercore-1809
+ARG DOWNLOADER_TAG=1.18.1-windowsservercore-1809
 FROM $REPO:$DOWNLOADER_TAG AS downloader
 
 FROM mcr.microsoft.com/windows/nanoserver:1809
@@ -27,7 +27,7 @@ RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.18.0
+ENV GOLANG_VERSION 1.18.1
 
 # Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
 COPY --from=downloader ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]

--- a/src/microsoft/1.18/windows/nanoserver-ltsc2022/Dockerfile
+++ b/src/microsoft/1.18/windows/nanoserver-ltsc2022/Dockerfile
@@ -7,7 +7,7 @@
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
 # It's easy to download Go and install it in server core, but not nanoserver. So, to build
 # nanoserver, copy over the server core installation.
-ARG DOWNLOADER_TAG=1.18.0-windowsservercore-ltsc2022
+ARG DOWNLOADER_TAG=1.18.1-windowsservercore-ltsc2022
 FROM $REPO:$DOWNLOADER_TAG AS downloader
 
 FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
@@ -27,7 +27,7 @@ RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.18.0
+ENV GOLANG_VERSION 1.18.1
 
 # Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
 COPY --from=downloader ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]

--- a/src/microsoft/1.18/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.18/windows/windowsservercore-1809/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.18.0
+ENV GOLANG_VERSION 1.18.1
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '13fe9c56edf90884b963b95f12dd9019fbf77e051ee96cd73943ad67c141e652'; \
+	$sha256 = '43a319ba7aa6a015771e34f87f1aff66e2a5ce76480c2832cc930786b6939e8f'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.18/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.18/windows/windowsservercore-1809/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.18.0
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '5100de35f79dcb259aa01121b75b4d019869aebc9bc959a8c8873f8865f1ff59'; \
+	$sha256 = '13fe9c56edf90884b963b95f12dd9019fbf77e051ee96cd73943ad67c141e652'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.18/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/1.18/windows/windowsservercore-ltsc2016/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.18.0
+ENV GOLANG_VERSION 1.18.1
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '13fe9c56edf90884b963b95f12dd9019fbf77e051ee96cd73943ad67c141e652'; \
+	$sha256 = '43a319ba7aa6a015771e34f87f1aff66e2a5ce76480c2832cc930786b6939e8f'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.18/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/1.18/windows/windowsservercore-ltsc2016/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.18.0
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '5100de35f79dcb259aa01121b75b4d019869aebc9bc959a8c8873f8865f1ff59'; \
+	$sha256 = '13fe9c56edf90884b963b95f12dd9019fbf77e051ee96cd73943ad67c141e652'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.18/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.18/windows/windowsservercore-ltsc2022/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.18.0
+ENV GOLANG_VERSION 1.18.1
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '13fe9c56edf90884b963b95f12dd9019fbf77e051ee96cd73943ad67c141e652'; \
+	$sha256 = '43a319ba7aa6a015771e34f87f1aff66e2a5ce76480c2832cc930786b6939e8f'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.18/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.18/windows/windowsservercore-ltsc2022/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.18.0
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '5100de35f79dcb259aa01121b75b4d019869aebc9bc959a8c8873f8865f1ff59'; \
+	$sha256 = '13fe9c56edf90884b963b95f12dd9019fbf77e051ee96cd73943ad67c141e652'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -133,26 +133,26 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "dd80089e36c2e0219d4292bc06c4c468bb0d80766e3ef25b1cb8f0999c347f7e",
+        "sha256": "52227bc6cdaec6f2a3c47e9b89b9c311be4e49456c90efb8b996e4266e5128cc",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220401.2/go.20220401.2.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220407.1/go.20220407.1.linux-amd64.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "d24bb3090c4fe81afebe74166c73091c178d63439177a1d4155c7d062ed2323e",
+        "sha256": "7ab29e484046d3cb214c1ff83a66f33f4d89641542373d123f4a1a99ba280e2a",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220401.2/go.20220401.2.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220407.1/go.20220407.1.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "83c1eee6dee98fb656cb5330424e8e8d3a971229cd9a7a8b8d6d0252934364ff",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220401.2/go.20220401.2.windows-amd64.zip"
+        "sha256": "9ab80428df6b32d8b178b1f6cb454411441dfc72d72293b33f43059cedbd5679",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220407.1/go.20220407.1.windows-amd64.zip"
       }
     },
     "variants": [

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -75,17 +75,17 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "865b919aafd27f20f17266333cc1f58c1288ce30d6e1825c9df44bccc085b799",
+        "sha256": "6877d8a8f0a640b239ab3193e1327a18d38e557a896ac66d21c1f8ef56cff763",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.2/go.20220307.2.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.3/go.20220307.3.linux-amd64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "69126f5f93cd247f07a2823dd3a06a5ac7f4de5ceb8aba777ca0a5f17b21fe23",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.2/go.20220307.2.windows-amd64.zip"
+        "sha256": "a5aba99ca5fc6cf8bdef0d61ca0b916ed663e03bfca15177549bf404b4315909",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.3/go.20220307.3.windows-amd64.zip"
       }
     },
     "variants": [

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -75,17 +75,17 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "6877d8a8f0a640b239ab3193e1327a18d38e557a896ac66d21c1f8ef56cff763",
+        "sha256": "9804167d4125f5915e90e6058526ca8aab18e16810aede483b0345fcfbdf61a1",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.3/go.20220307.3.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220315.4/go.20220315.4.linux-amd64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "a5aba99ca5fc6cf8bdef0d61ca0b916ed663e03bfca15177549bf404b4315909",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.3/go.20220307.3.windows-amd64.zip"
+        "sha256": "d9a7bce358cbdd60ef5630c8f19f063728d9a703bb59df3b6304dc38b7b3fb2c",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220315.4/go.20220315.4.windows-amd64.zip"
       }
     },
     "variants": [

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -6,27 +6,27 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "5014d7ce47db6c70a1d18340deb33e45c802746ba7e7498f42dfbd8a310fb8c8",
+        "sha256": "54af8ed5c858365fb424a8cd1fa258a209e334699a6f88c051784bf06df11676",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-amd64.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "0df2e76bfc2f61e44daf05d9ba8171fb46c6ee8ebb088593b6a4cd408c151e9b",
+        "sha256": "d5aa78c1316bbb5c0638da9624f698aada990628e2321716b0b289084a1c08aa",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "68c32ee9f6460035915a16f318eb6e03dfc4428d2ec9f5251c427b429ad44a44",
+        "sha256": "dac299d353e8963ea0d0019064b0861ef4cb938ef5ec6a77a2a5da6e0aa1700b",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.windows-amd64.zip"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.windows-amd64.zip"
       }
     },
     "variants": [
@@ -39,7 +39,7 @@
       "windows/nanoserver-ltsc2022",
       "windows/nanoserver-1809"
     ],
-    "version": "1.17.8",
+    "version": "1.17.9",
     "revision": "1",
     "preferredVariant": "bullseye"
   },

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -38,18 +38,18 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "fa8a829cf00f9370ba2032335700e3d65e1c58b0ff5bea1cd72145d2d1a51631",
+        "sha256": "a066cecebdaf0b633ce6ce5a10aef8030efd488145a6e95de1ca6396ddff6e0a",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220315.2/go.20220315.2.linux-amd64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "3f376538245436da78193101863751c502da489e29317acaf18bdb0d2852d654",
+        "sha256": "ba9c0a51d9b2af502f4cc78cc43c6d4fc7bbced899682122b5237a30014f6d13",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.windows-amd64.zip"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220315.2/go.20220315.2.windows-amd64.zip"
       }
     },
     "variants": [

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -87,27 +87,27 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "ecd5cdd9a3c8ec2d57170c8c4daa7c55309c96e4f186aa79709ccb5aab4a2f40",
+        "sha256": "0ecd8a6b43ae3e993eedddde6141a7785fc65d1cc8a322c6e67fa02420a883fd",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-amd64.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "e640c8cc2eddc11d6d7b8bd7936797f62641eacee57c1e3f7e90381bcb4b33eb",
+        "sha256": "7965396729a9efb2d166e9b33eb142629f9c505240c4e373bbd783cf5f8af61a",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "13fe9c56edf90884b963b95f12dd9019fbf77e051ee96cd73943ad67c141e652",
+        "sha256": "43a319ba7aa6a015771e34f87f1aff66e2a5ce76480c2832cc930786b6939e8f",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.windows-amd64.zip"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.windows-amd64.zip"
       }
     },
     "variants": [
@@ -120,7 +120,7 @@
       "windows/nanoserver-ltsc2022",
       "windows/nanoserver-1809"
     ],
-    "version": "1.18.0",
+    "version": "1.18.1",
     "revision": "1",
     "preferredMajor": true,
     "preferredMinor": true,

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -6,18 +6,27 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "fa8a829cf00f9370ba2032335700e3d65e1c58b0ff5bea1cd72145d2d1a51631",
+        "sha256": "5014d7ce47db6c70a1d18340deb33e45c802746ba7e7498f42dfbd8a310fb8c8",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-amd64.tar.gz"
+      },
+      "arm64v8": {
+        "env": {
+          "GOARCH": "arm64",
+          "GOOS": "linux"
+        },
+        "sha256": "0df2e76bfc2f61e44daf05d9ba8171fb46c6ee8ebb088593b6a4cd408c151e9b",
+        "supported": true,
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "3f376538245436da78193101863751c502da489e29317acaf18bdb0d2852d654",
+        "sha256": "68c32ee9f6460035915a16f318eb6e03dfc4428d2ec9f5251c427b429ad44a44",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220303.3/go.20220303.3.windows-amd64.zip"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220330.1/go.20220330.1.windows-amd64.zip"
       }
     },
     "variants": [
@@ -41,17 +50,26 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "661b1d3d3d2b1a2d8d151a85c6972c0995ce18098639b8f72668f6b587834ad4",
+        "sha256": "9fe4c70c8ec15ca406aab68e9efed871b16d5db27f69bfb74fe87f099dcaa41e",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.6/go.20220329.6.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220401.1/go.20220401.1.linux-amd64.tar.gz"
+      },
+      "arm64v8": {
+        "env": {
+          "GOARCH": "arm64",
+          "GOOS": "linux"
+        },
+        "sha256": "b7e54d90fcaccd2bec45bd75ad78628a923715063fb7f985ded2836a35a63f9e",
+        "supported": true,
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220401.1/go.20220401.1.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "d873b137e5778faffb967cfe92ec7e9ab30dfb283ed3211d097e46273753eec4",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.6/go.20220329.6.windows-amd64.zip"
+        "sha256": "5241ef99d1b53a6309660fbcda7ad563e1bbe634ac2047bf3d8469aff8616853",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220401.1/go.20220401.1.windows-amd64.zip"
       }
     },
     "variants": [
@@ -69,18 +87,27 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "b5ed9d893fb12934daf41edea40b15c4b43533761665d8c61a00d666c8d341ef",
+        "sha256": "ecd5cdd9a3c8ec2d57170c8c4daa7c55309c96e4f186aa79709ccb5aab4a2f40",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-amd64.tar.gz"
+      },
+      "arm64v8": {
+        "env": {
+          "GOARCH": "arm64",
+          "GOOS": "linux"
+        },
+        "sha256": "e640c8cc2eddc11d6d7b8bd7936797f62641eacee57c1e3f7e90381bcb4b33eb",
+        "supported": true,
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "5100de35f79dcb259aa01121b75b4d019869aebc9bc959a8c8873f8865f1ff59",
+        "sha256": "13fe9c56edf90884b963b95f12dd9019fbf77e051ee96cd73943ad67c141e652",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220315.1/go.20220315.1.windows-amd64.zip"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220330.3/go.20220330.3.windows-amd64.zip"
       }
     },
     "variants": [
@@ -106,17 +133,26 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "3ea93d412f30297866d60bc728278197ea9c9ee8671167f1b207782af9e9e7f6",
+        "sha256": "dd80089e36c2e0219d4292bc06c4c468bb0d80766e3ef25b1cb8f0999c347f7e",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220329.7/go.20220329.7.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220401.2/go.20220401.2.linux-amd64.tar.gz"
+      },
+      "arm64v8": {
+        "env": {
+          "GOARCH": "arm64",
+          "GOOS": "linux"
+        },
+        "sha256": "d24bb3090c4fe81afebe74166c73091c178d63439177a1d4155c7d062ed2323e",
+        "supported": true,
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220401.2/go.20220401.2.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "1c2f4bb1abe9eccf7b33589abd3f114d549c2f35fb8643d5526b74a4c0394c1a",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220329.7/go.20220329.7.windows-amd64.zip"
+        "sha256": "83c1eee6dee98fb656cb5330424e8e8d3a971229cd9a7a8b8d6d0252934364ff",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220401.2/go.20220401.2.windows-amd64.zip"
       }
     },
     "variants": [

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -50,26 +50,26 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "9fe4c70c8ec15ca406aab68e9efed871b16d5db27f69bfb74fe87f099dcaa41e",
+        "sha256": "0342dd738eb1a7e2ed5840e32b1c1a80dc5efac449c3d785339bca875f4a2567",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220401.1/go.20220401.1.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220407.3/go.20220407.3.linux-amd64.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "b7e54d90fcaccd2bec45bd75ad78628a923715063fb7f985ded2836a35a63f9e",
+        "sha256": "632756bf5f84c115d8f8fdfab649a396f029a13878bedb0783f6a0e3b3962790",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220401.1/go.20220401.1.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220407.3/go.20220407.3.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "5241ef99d1b53a6309660fbcda7ad563e1bbe634ac2047bf3d8469aff8616853",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220401.1/go.20220401.1.windows-amd64.zip"
+        "sha256": "94d41f1982839ee336918a544d3576122dd366977a8050a652874efeed45e393",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220407.3/go.20220407.3.windows-amd64.zip"
       }
     },
     "variants": [

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -75,17 +75,17 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "9804167d4125f5915e90e6058526ca8aab18e16810aede483b0345fcfbdf61a1",
+        "sha256": "6bcea3b832c24ef39ed780b45167a9cd13afd0ef5526bb6c626f8e11b6b028fc",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220315.4/go.20220315.4.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.2/go.20220329.2.linux-amd64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "d9a7bce358cbdd60ef5630c8f19f063728d9a703bb59df3b6304dc38b7b3fb2c",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220315.4/go.20220315.4.windows-amd64.zip"
+        "sha256": "22bf646733caea07d4f65795463bd1617add48c4fceac7aefb014177bcdc02c7",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.2/go.20220329.2.windows-amd64.zip"
       }
     },
     "variants": [

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -75,24 +75,24 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "6bcea3b832c24ef39ed780b45167a9cd13afd0ef5526bb6c626f8e11b6b028fc",
+        "sha256": "661b1d3d3d2b1a2d8d151a85c6972c0995ce18098639b8f72668f6b587834ad4",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.2/go.20220329.2.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.6/go.20220329.6.linux-amd64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "22bf646733caea07d4f65795463bd1617add48c4fceac7aefb014177bcdc02c7",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.2/go.20220329.2.windows-amd64.zip"
+        "sha256": "d873b137e5778faffb967cfe92ec7e9ab30dfb283ed3211d097e46273753eec4",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220329.6/go.20220329.6.windows-amd64.zip"
       }
     },
     "variants": [
       "cbl-mariner1.0"
     ],
-    "version": "1.17.7",
-    "revision": "1",
+    "version": "1.17.8",
+    "revision": "2",
     "preferredMinor": true,
     "preferredVariant": "cbl-mariner1.0",
     "branchSuffix": "-fips"

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -75,17 +75,17 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "416eb5c5b81d5802a6f5baeec8c3abcacae438da81a026d00129d72852a6760f",
+        "sha256": "865b919aafd27f20f17266333cc1f58c1288ce30d6e1825c9df44bccc085b799",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220216.3/go.20220216.3.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.2/go.20220307.2.linux-amd64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "c1e850744b25fc167df1e3f0b8408e24ece5f7d4cff037624ee1e6597399d85c",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220216.3/go.20220216.3.windows-amd64.zip"
+        "sha256": "69126f5f93cd247f07a2823dd3a06a5ac7f4de5ceb8aba777ca0a5f17b21fe23",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220307.2/go.20220307.2.windows-amd64.zip"
       }
     },
     "variants": [


### PR DESCRIPTION
Auto-update infra updated the nightly branch with 1.18.1-1 and 1.17.9-1, so merge to get those changes. I double checked that they applied correctly by running `dockerupdate -f ...` again with the new build asset JSONs--no diff.

This merge also means we'll produce linux-arm64 images for this release.

This is a fast-forward merge, since I merged main into nightly recently.