### PR TITLE
[main] Merge from nightly for 1.17.9-1-fips, 1.18.1-1-fips

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -206,10 +206,10 @@
           "sharedTags": {
             "1.17-fips": {},
             "1.17-fips-cbl-mariner1.0": {},
-            "1.17.8-2-fips": {},
-            "1.17.8-2-fips-cbl-mariner1.0": {},
-            "1.17.8-fips": {},
-            "1.17.8-fips-cbl-mariner1.0": {}
+            "1.17.9-1-fips": {},
+            "1.17.9-1-fips-cbl-mariner1.0": {},
+            "1.17.9-fips": {},
+            "1.17.9-fips-cbl-mariner1.0": {}
           },
           "platforms": [
             {
@@ -218,7 +218,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.17.8-2-fips-cbl-mariner1.0-amd64": {}
+                "1.17.9-1-fips-cbl-mariner1.0-amd64": {}
               }
             },
             {
@@ -227,7 +227,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.17.8-2-fips-cbl-mariner1.0-arm64": {}
+                "1.17.9-1-fips-cbl-mariner1.0-arm64": {}
               }
             }
           ]

--- a/manifest.json
+++ b/manifest.json
@@ -450,10 +450,10 @@
             "1-fips-cbl-mariner1.0": {},
             "1.18-fips": {},
             "1.18-fips-cbl-mariner1.0": {},
-            "1.18.0-2-fips": {},
-            "1.18.0-2-fips-cbl-mariner1.0": {},
-            "1.18.0-fips": {},
-            "1.18.0-fips-cbl-mariner1.0": {}
+            "1.18.1-1-fips": {},
+            "1.18.1-1-fips-cbl-mariner1.0": {},
+            "1.18.1-fips": {},
+            "1.18.1-fips-cbl-mariner1.0": {}
           },
           "platforms": [
             {
@@ -462,7 +462,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.18.0-2-fips-cbl-mariner1.0-amd64": {}
+                "1.18.1-1-fips-cbl-mariner1.0-amd64": {}
               }
             },
             {
@@ -471,7 +471,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.18.0-2-fips-cbl-mariner1.0-arm64": {}
+                "1.18.1-1-fips-cbl-mariner1.0-arm64": {}
               }
             }
           ]

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -28,12 +28,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220407.3/go.20220407.3.linux-amd64.tar.gz'; \
-			sha256='0342dd738eb1a7e2ed5840e32b1c1a80dc5efac449c3d785339bca875f4a2567'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.1/go.20220414.1.linux-amd64.tar.gz'; \
+			sha256='d43858b283a32b75cf34d27bcc9fe5452df1257e0345e68eb0177e8daaa03853'; \
 			;; \
 		'aarch64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220407.3/go.20220407.3.linux-arm64.tar.gz'; \
-			sha256='632756bf5f84c115d8f8fdfab649a396f029a13878bedb0783f6a0e3b3962790'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.1/go.20220414.1.linux-arm64.tar.gz'; \
+			sha256='f84104eb43132a1a4183259da7f18584a4caee8a3c80023338c52ed6edb6d0d1'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -21,19 +21,19 @@ RUN tdnf install -y \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.8
+ENV GOLANG_VERSION 1.17.9
 
 RUN set -eux; \
 	arch="$(uname -m)"; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.1/go.20220414.1.linux-amd64.tar.gz'; \
-			sha256='d43858b283a32b75cf34d27bcc9fe5452df1257e0345e68eb0177e8daaa03853'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.4/go.20220414.4.linux-amd64.tar.gz'; \
+			sha256='97dbef56d8fd0928eafc7f2762f2dca07a05c0de44ca5434778aba8ab91c456f'; \
 			;; \
 		'aarch64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.1/go.20220414.1.linux-arm64.tar.gz'; \
-			sha256='f84104eb43132a1a4183259da7f18584a4caee8a3c80023338c52ed6edb6d0d1'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.4/go.20220414.4.linux-arm64.tar.gz'; \
+			sha256='6fccfc0515bcf3cc138b0888cb99bf066a62571bbd0ba4b09da242564e659dc7'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
@@ -28,12 +28,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220407.1/go.20220407.1.linux-amd64.tar.gz'; \
-			sha256='52227bc6cdaec6f2a3c47e9b89b9c311be4e49456c90efb8b996e4266e5128cc'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.2/go.20220414.2.linux-amd64.tar.gz'; \
+			sha256='78552092665773b64dc7ac01f2d94693b9b1fe35b8e2502192f8e50c73312abb'; \
 			;; \
 		'aarch64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220407.1/go.20220407.1.linux-arm64.tar.gz'; \
-			sha256='7ab29e484046d3cb214c1ff83a66f33f4d89641542373d123f4a1a99ba280e2a'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.2/go.20220414.2.linux-arm64.tar.gz'; \
+			sha256='7262be2e9b2a226ae9e5d75fde2db70c9d16212da2b367481a91b2fe5dd8a415'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
@@ -21,19 +21,19 @@ RUN tdnf install -y \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.18.0
+ENV GOLANG_VERSION 1.18.1
 
 RUN set -eux; \
 	arch="$(uname -m)"; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.2/go.20220414.2.linux-amd64.tar.gz'; \
-			sha256='78552092665773b64dc7ac01f2d94693b9b1fe35b8e2502192f8e50c73312abb'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.3/go.20220414.3.linux-amd64.tar.gz'; \
+			sha256='7b28ca61502d7034c32e0a03ecde15847db4ad323c2be88a14f3f6ffc065bff7'; \
 			;; \
 		'aarch64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.2/go.20220414.2.linux-arm64.tar.gz'; \
-			sha256='7262be2e9b2a226ae9e5d75fde2db70c9d16212da2b367481a91b2fe5dd8a415'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.3/go.20220414.3.linux-arm64.tar.gz'; \
+			sha256='cb253fa9ec98bab0901b54ec031f3e985e3376c637c43d78ef56388af64e7f9f'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -133,26 +133,26 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "52227bc6cdaec6f2a3c47e9b89b9c311be4e49456c90efb8b996e4266e5128cc",
+        "sha256": "78552092665773b64dc7ac01f2d94693b9b1fe35b8e2502192f8e50c73312abb",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220407.1/go.20220407.1.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.2/go.20220414.2.linux-amd64.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "7ab29e484046d3cb214c1ff83a66f33f4d89641542373d123f4a1a99ba280e2a",
+        "sha256": "7262be2e9b2a226ae9e5d75fde2db70c9d16212da2b367481a91b2fe5dd8a415",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220407.1/go.20220407.1.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.2/go.20220414.2.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "9ab80428df6b32d8b178b1f6cb454411441dfc72d72293b33f43059cedbd5679",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220407.1/go.20220407.1.windows-amd64.zip"
+        "sha256": "631ed2996d4ce9bcbb4c6ca13f436224e2e55a1c3a341575091838d2d1199b45",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.2/go.20220414.2.windows-amd64.zip"
       }
     },
     "variants": [

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -50,33 +50,33 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "d43858b283a32b75cf34d27bcc9fe5452df1257e0345e68eb0177e8daaa03853",
+        "sha256": "97dbef56d8fd0928eafc7f2762f2dca07a05c0de44ca5434778aba8ab91c456f",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.1/go.20220414.1.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.4/go.20220414.4.linux-amd64.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "f84104eb43132a1a4183259da7f18584a4caee8a3c80023338c52ed6edb6d0d1",
+        "sha256": "6fccfc0515bcf3cc138b0888cb99bf066a62571bbd0ba4b09da242564e659dc7",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.1/go.20220414.1.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.4/go.20220414.4.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "b00ca9a27bef7ad29d60aa23da887fb97b237a47452910df8c61b143070765e2",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.1/go.20220414.1.windows-amd64.zip"
+        "sha256": "35821193f534bf9681f98e61346211534c6edd3fcbdbec972337c4cc68ca806c",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.4/go.20220414.4.windows-amd64.zip"
       }
     },
     "variants": [
       "cbl-mariner1.0"
     ],
-    "version": "1.17.8",
-    "revision": "2",
+    "version": "1.17.9",
+    "revision": "1",
     "preferredVariant": "cbl-mariner1.0",
     "branchSuffix": "-fips"
   },

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -133,33 +133,33 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "78552092665773b64dc7ac01f2d94693b9b1fe35b8e2502192f8e50c73312abb",
+        "sha256": "7b28ca61502d7034c32e0a03ecde15847db4ad323c2be88a14f3f6ffc065bff7",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.2/go.20220414.2.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.3/go.20220414.3.linux-amd64.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "7262be2e9b2a226ae9e5d75fde2db70c9d16212da2b367481a91b2fe5dd8a415",
+        "sha256": "cb253fa9ec98bab0901b54ec031f3e985e3376c637c43d78ef56388af64e7f9f",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.2/go.20220414.2.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.3/go.20220414.3.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "631ed2996d4ce9bcbb4c6ca13f436224e2e55a1c3a341575091838d2d1199b45",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.2/go.20220414.2.windows-amd64.zip"
+        "sha256": "f16f31d942271c0d8afbb3776753dd8dbe56ea40aa8c6a43056cccf183207200",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.3/go.20220414.3.windows-amd64.zip"
       }
     },
     "variants": [
       "cbl-mariner1.0"
     ],
-    "version": "1.18.0",
-    "revision": "2",
+    "version": "1.18.1",
+    "revision": "1",
     "preferredMinor": true,
     "preferredVariant": "cbl-mariner1.0",
     "branchSuffix": "-fips"

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -50,26 +50,26 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "0342dd738eb1a7e2ed5840e32b1c1a80dc5efac449c3d785339bca875f4a2567",
+        "sha256": "d43858b283a32b75cf34d27bcc9fe5452df1257e0345e68eb0177e8daaa03853",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220407.3/go.20220407.3.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.1/go.20220414.1.linux-amd64.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "632756bf5f84c115d8f8fdfab649a396f029a13878bedb0783f6a0e3b3962790",
+        "sha256": "f84104eb43132a1a4183259da7f18584a4caee8a3c80023338c52ed6edb6d0d1",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220407.3/go.20220407.3.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.1/go.20220414.1.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "94d41f1982839ee336918a544d3576122dd366977a8050a652874efeed45e393",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220407.3/go.20220407.3.windows-amd64.zip"
+        "sha256": "b00ca9a27bef7ad29d60aa23da887fb97b237a47452910df8c61b143070765e2",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.1/go.20220414.1.windows-amd64.zip"
       }
     },
     "variants": [


### PR DESCRIPTION
Clean merge. Auto-update took care of the updates in the nightly branch, so bring them into the main branch to build and publish to MCR.

Similar to the non-FIPS update:
* https://github.com/microsoft/go-images/pull/100