### PR TITLE
Add arm/v7 armhf images that include the arm/v6 build of Go

### DIFF
--- a/eng/pipeline/stages/build-test-publish-repo.yml
+++ b/eng/pipeline/stages/build-test-publish-repo.yml
@@ -18,6 +18,11 @@ stages:
           name: DotNetCore-Docker-Public
         ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
           name: Docker-Linux-Arm-Internal
+      linuxArm32Pool:
+        ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
+          name: DotNetCore-Docker-Public
+        ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
+          name: Docker-Linux-Arm-Internal
       # On Windows, 'docker login' is incompatible with 'manifest-tool' unless we use these pools.
       # https://github.com/dotnet/docker-tools/issues/905
       windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}

--- a/manifest.json
+++ b/manifest.json
@@ -535,6 +535,15 @@
               }
             },
             {
+              "architecture": "arm",
+              "dockerfile": "src/microsoft/1.18-fips/cbl-mariner1.0",
+              "os": "linux",
+              "osVersion": "cbl-mariner1.0",
+              "tags": {
+                "1.18.1-1-fips-cbl-mariner1.0-arm32v7": {}
+              }
+            },
+            {
               "architecture": "arm64",
               "dockerfile": "src/microsoft/1.18-fips/cbl-mariner1.0",
               "os": "linux",

--- a/manifest.json
+++ b/manifest.json
@@ -304,6 +304,16 @@
               "tags": {
                 "1.18.1-1-bullseye-arm64v8": {}
               }
+            },
+            {
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/1.18/bullseye",
+              "os": "linux",
+              "osVersion": "bullseye",
+              "tags": {
+                "1.18.1-1-bullseye-arm32v7": {}
+              }
             }
           ]
         },
@@ -335,6 +345,16 @@
               "tags": {
                 "1.18.1-1-buster-arm64v8": {}
               }
+            },
+            {
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/1.18/buster",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "1.18.1-1-buster-arm32v7": {}
+              }
             }
           ]
         },
@@ -365,6 +385,16 @@
               "osVersion": "stretch",
               "tags": {
                 "1.18.1-1-stretch-arm64v8": {}
+              }
+            },
+            {
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/1.18/stretch",
+              "os": "linux",
+              "osVersion": "stretch",
+              "tags": {
+                "1.18.1-1-stretch-arm32v7": {}
               }
             }
           ]

--- a/manifest.json
+++ b/manifest.json
@@ -252,15 +252,6 @@
               }
             },
             {
-              "architecture": "arm",
-              "dockerfile": "src/microsoft/1.17-fips/cbl-mariner1.0",
-              "os": "linux",
-              "osVersion": "cbl-mariner1.0",
-              "tags": {
-                "1.17.9-1-fips-cbl-mariner1.0-arm32v7": {}
-              }
-            },
-            {
               "architecture": "arm64",
               "dockerfile": "src/microsoft/1.17-fips/cbl-mariner1.0",
               "os": "linux",
@@ -532,15 +523,6 @@
               "osVersion": "cbl-mariner1.0",
               "tags": {
                 "1.18.1-1-fips-cbl-mariner1.0-amd64": {}
-              }
-            },
-            {
-              "architecture": "arm",
-              "dockerfile": "src/microsoft/1.18-fips/cbl-mariner1.0",
-              "os": "linux",
-              "osVersion": "cbl-mariner1.0",
-              "tags": {
-                "1.18.1-1-fips-cbl-mariner1.0-arm32v7": {}
               }
             },
             {

--- a/manifest.json
+++ b/manifest.json
@@ -252,6 +252,15 @@
               }
             },
             {
+              "architecture": "arm",
+              "dockerfile": "src/microsoft/1.17-fips/cbl-mariner1.0",
+              "os": "linux",
+              "osVersion": "cbl-mariner1.0",
+              "tags": {
+                "1.17.9-1-fips-cbl-mariner1.0-arm32v7": {}
+              }
+            },
+            {
               "architecture": "arm64",
               "dockerfile": "src/microsoft/1.17-fips/cbl-mariner1.0",
               "os": "linux",

--- a/manifest.json
+++ b/manifest.json
@@ -37,6 +37,16 @@
               "tags": {
                 "1.17.9-1-bullseye-arm64v8": {}
               }
+            },
+            {
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/1.17/bullseye",
+              "os": "linux",
+              "osVersion": "bullseye",
+              "tags": {
+                "1.17.9-1-bullseye-arm32v7": {}
+              }
             }
           ]
         },
@@ -66,6 +76,16 @@
               "tags": {
                 "1.17.9-1-buster-arm64v8": {}
               }
+            },
+            {
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/1.17/buster",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "1.17.9-1-buster-arm32v7": {}
+              }
             }
           ]
         },
@@ -94,6 +114,16 @@
               "osVersion": "stretch",
               "tags": {
                 "1.17.9-1-stretch-arm64v8": {}
+              }
+            },
+            {
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/1.17/stretch",
+              "os": "linux",
+              "osVersion": "stretch",
+              "tags": {
+                "1.17.9-1-stretch-arm32v7": {}
               }
             }
           ]
@@ -227,7 +257,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.17.9-1-fips-cbl-mariner1.0-arm64": {}
+                "1.17.9-1-fips-cbl-mariner1.0-arm64v8": {}
               }
             }
           ]
@@ -471,7 +501,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.18.1-1-fips-cbl-mariner1.0-arm64": {}
+                "1.18.1-1-fips-cbl-mariner1.0-arm64v8": {}
               }
             }
           ]

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -28,12 +28,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.4/go.20220414.4.linux-amd64.tar.gz'; \
-			sha256='97dbef56d8fd0928eafc7f2762f2dca07a05c0de44ca5434778aba8ab91c456f'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220420.5/go.20220420.5.linux-amd64.tar.gz'; \
+			sha256='a02cb67e910fdc8261e1d49fc11fa1bce1f2379d6ace096f98fb8ab9a8bc4ebc'; \
 			;; \
 		'aarch64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.4/go.20220414.4.linux-arm64.tar.gz'; \
-			sha256='6fccfc0515bcf3cc138b0888cb99bf066a62571bbd0ba4b09da242564e659dc7'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220420.5/go.20220420.5.linux-arm64.tar.gz'; \
+			sha256='c4eea386101edbb5c13e73a37aa54eb32b4c9e58b7e98c611b2a28fa91c00b70'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/bullseye/Dockerfile
+++ b/src/microsoft/1.17/bullseye/Dockerfile
@@ -30,6 +30,10 @@ RUN set -eux; \
 			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-amd64.tar.gz'; \
 			sha256='ce0cd31de6965b8eb64fbc6d84fa0b0e7878bd45fbf6326efb019b41d60fff34'; \
 			;; \
+		'armhf') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-armv6l.tar.gz'; \
+			sha256='7447167ba3ea6d062d2fab5841d874e7c3710070f6b0f85d9c48f1943833e22e'; \
+			;; \
 		'arm64') \
 			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-arm64.tar.gz'; \
 			sha256='f9bfea1b86a46045a4677fdf2265281df3a4e5b37c26993ae39c4bd0a975f0cd'; \

--- a/src/microsoft/1.17/bullseye/Dockerfile
+++ b/src/microsoft/1.17/bullseye/Dockerfile
@@ -27,12 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-amd64.tar.gz'; \
-			sha256='54af8ed5c858365fb424a8cd1fa258a209e334699a6f88c051784bf06df11676'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-amd64.tar.gz'; \
+			sha256='ce0cd31de6965b8eb64fbc6d84fa0b0e7878bd45fbf6326efb019b41d60fff34'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-arm64.tar.gz'; \
-			sha256='d5aa78c1316bbb5c0638da9624f698aada990628e2321716b0b289084a1c08aa'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-arm64.tar.gz'; \
+			sha256='f9bfea1b86a46045a4677fdf2265281df3a4e5b37c26993ae39c4bd0a975f0cd'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/buster/Dockerfile
+++ b/src/microsoft/1.17/buster/Dockerfile
@@ -30,6 +30,10 @@ RUN set -eux; \
 			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-amd64.tar.gz'; \
 			sha256='ce0cd31de6965b8eb64fbc6d84fa0b0e7878bd45fbf6326efb019b41d60fff34'; \
 			;; \
+		'armhf') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-armv6l.tar.gz'; \
+			sha256='7447167ba3ea6d062d2fab5841d874e7c3710070f6b0f85d9c48f1943833e22e'; \
+			;; \
 		'arm64') \
 			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-arm64.tar.gz'; \
 			sha256='f9bfea1b86a46045a4677fdf2265281df3a4e5b37c26993ae39c4bd0a975f0cd'; \

--- a/src/microsoft/1.17/buster/Dockerfile
+++ b/src/microsoft/1.17/buster/Dockerfile
@@ -27,12 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-amd64.tar.gz'; \
-			sha256='54af8ed5c858365fb424a8cd1fa258a209e334699a6f88c051784bf06df11676'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-amd64.tar.gz'; \
+			sha256='ce0cd31de6965b8eb64fbc6d84fa0b0e7878bd45fbf6326efb019b41d60fff34'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-arm64.tar.gz'; \
-			sha256='d5aa78c1316bbb5c0638da9624f698aada990628e2321716b0b289084a1c08aa'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-arm64.tar.gz'; \
+			sha256='f9bfea1b86a46045a4677fdf2265281df3a4e5b37c26993ae39c4bd0a975f0cd'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/stretch/Dockerfile
+++ b/src/microsoft/1.17/stretch/Dockerfile
@@ -30,6 +30,10 @@ RUN set -eux; \
 			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-amd64.tar.gz'; \
 			sha256='ce0cd31de6965b8eb64fbc6d84fa0b0e7878bd45fbf6326efb019b41d60fff34'; \
 			;; \
+		'armhf') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-armv6l.tar.gz'; \
+			sha256='7447167ba3ea6d062d2fab5841d874e7c3710070f6b0f85d9c48f1943833e22e'; \
+			;; \
 		'arm64') \
 			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-arm64.tar.gz'; \
 			sha256='f9bfea1b86a46045a4677fdf2265281df3a4e5b37c26993ae39c4bd0a975f0cd'; \

--- a/src/microsoft/1.17/stretch/Dockerfile
+++ b/src/microsoft/1.17/stretch/Dockerfile
@@ -27,12 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-amd64.tar.gz'; \
-			sha256='54af8ed5c858365fb424a8cd1fa258a209e334699a6f88c051784bf06df11676'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-amd64.tar.gz'; \
+			sha256='ce0cd31de6965b8eb64fbc6d84fa0b0e7878bd45fbf6326efb019b41d60fff34'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-arm64.tar.gz'; \
-			sha256='d5aa78c1316bbb5c0638da9624f698aada990628e2321716b0b289084a1c08aa'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-arm64.tar.gz'; \
+			sha256='f9bfea1b86a46045a4677fdf2265281df3a4e5b37c26993ae39c4bd0a975f0cd'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-1809/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.17.9
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'dac299d353e8963ea0d0019064b0861ef4cb938ef5ec6a77a2a5da6e0aa1700b'; \
+	$sha256 = 'af899d802bae238cfefcd996141b1add2c0955ba7fb19d1b7f562356519df4de'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-ltsc2016/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.17.9
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'dac299d353e8963ea0d0019064b0861ef4cb938ef5ec6a77a2a5da6e0aa1700b'; \
+	$sha256 = 'af899d802bae238cfefcd996141b1add2c0955ba7fb19d1b7f562356519df4de'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-ltsc2022/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.17.9
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'dac299d353e8963ea0d0019064b0861ef4cb938ef5ec6a77a2a5da6e0aa1700b'; \
+	$sha256 = 'af899d802bae238cfefcd996141b1add2c0955ba7fb19d1b7f562356519df4de'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
@@ -28,12 +28,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.3/go.20220414.3.linux-amd64.tar.gz'; \
-			sha256='7b28ca61502d7034c32e0a03ecde15847db4ad323c2be88a14f3f6ffc065bff7'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220421.1/go.20220421.1.linux-amd64.tar.gz'; \
+			sha256='5b07069f219f1d740e58ce3b562034e9d295f995bc5422ff05bf37b429263c4e'; \
 			;; \
 		'aarch64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.3/go.20220414.3.linux-arm64.tar.gz'; \
-			sha256='cb253fa9ec98bab0901b54ec031f3e985e3376c637c43d78ef56388af64e7f9f'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220421.1/go.20220421.1.linux-arm64.tar.gz'; \
+			sha256='bd57cec707771bcea95ed04afa9655a8390d49587c5083e7ea977a69f161dc36'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/bullseye/Dockerfile
+++ b/src/microsoft/1.18/bullseye/Dockerfile
@@ -27,12 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-amd64.tar.gz'; \
-			sha256='0ecd8a6b43ae3e993eedddde6141a7785fc65d1cc8a322c6e67fa02420a883fd'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-amd64.tar.gz'; \
+			sha256='43befa6ecc764854df12ed00672b84ae7f19d0cceed4ce23807cb106f0b067f5'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-arm64.tar.gz'; \
-			sha256='7965396729a9efb2d166e9b33eb142629f9c505240c4e373bbd783cf5f8af61a'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-arm64.tar.gz'; \
+			sha256='870d1794b2de1a6f0604e2c3cf19604d0d7c6f6247f3a544b8a64ec44f8b24d7'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/bullseye/Dockerfile
+++ b/src/microsoft/1.18/bullseye/Dockerfile
@@ -30,6 +30,10 @@ RUN set -eux; \
 			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-amd64.tar.gz'; \
 			sha256='43befa6ecc764854df12ed00672b84ae7f19d0cceed4ce23807cb106f0b067f5'; \
 			;; \
+		'armhf') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-armv6l.tar.gz'; \
+			sha256='fcce5540ea86052c7d1549f6f89ab3265ebbbd09eb807d8b6c298deafb1c0f82'; \
+			;; \
 		'arm64') \
 			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-arm64.tar.gz'; \
 			sha256='870d1794b2de1a6f0604e2c3cf19604d0d7c6f6247f3a544b8a64ec44f8b24d7'; \

--- a/src/microsoft/1.18/buster/Dockerfile
+++ b/src/microsoft/1.18/buster/Dockerfile
@@ -27,12 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-amd64.tar.gz'; \
-			sha256='0ecd8a6b43ae3e993eedddde6141a7785fc65d1cc8a322c6e67fa02420a883fd'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-amd64.tar.gz'; \
+			sha256='43befa6ecc764854df12ed00672b84ae7f19d0cceed4ce23807cb106f0b067f5'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-arm64.tar.gz'; \
-			sha256='7965396729a9efb2d166e9b33eb142629f9c505240c4e373bbd783cf5f8af61a'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-arm64.tar.gz'; \
+			sha256='870d1794b2de1a6f0604e2c3cf19604d0d7c6f6247f3a544b8a64ec44f8b24d7'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/buster/Dockerfile
+++ b/src/microsoft/1.18/buster/Dockerfile
@@ -30,6 +30,10 @@ RUN set -eux; \
 			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-amd64.tar.gz'; \
 			sha256='43befa6ecc764854df12ed00672b84ae7f19d0cceed4ce23807cb106f0b067f5'; \
 			;; \
+		'armhf') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-armv6l.tar.gz'; \
+			sha256='fcce5540ea86052c7d1549f6f89ab3265ebbbd09eb807d8b6c298deafb1c0f82'; \
+			;; \
 		'arm64') \
 			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-arm64.tar.gz'; \
 			sha256='870d1794b2de1a6f0604e2c3cf19604d0d7c6f6247f3a544b8a64ec44f8b24d7'; \

--- a/src/microsoft/1.18/stretch/Dockerfile
+++ b/src/microsoft/1.18/stretch/Dockerfile
@@ -27,12 +27,12 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-amd64.tar.gz'; \
-			sha256='0ecd8a6b43ae3e993eedddde6141a7785fc65d1cc8a322c6e67fa02420a883fd'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-amd64.tar.gz'; \
+			sha256='43befa6ecc764854df12ed00672b84ae7f19d0cceed4ce23807cb106f0b067f5'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-arm64.tar.gz'; \
-			sha256='7965396729a9efb2d166e9b33eb142629f9c505240c4e373bbd783cf5f8af61a'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-arm64.tar.gz'; \
+			sha256='870d1794b2de1a6f0604e2c3cf19604d0d7c6f6247f3a544b8a64ec44f8b24d7'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/stretch/Dockerfile
+++ b/src/microsoft/1.18/stretch/Dockerfile
@@ -30,6 +30,10 @@ RUN set -eux; \
 			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-amd64.tar.gz'; \
 			sha256='43befa6ecc764854df12ed00672b84ae7f19d0cceed4ce23807cb106f0b067f5'; \
 			;; \
+		'armhf') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-armv6l.tar.gz'; \
+			sha256='fcce5540ea86052c7d1549f6f89ab3265ebbbd09eb807d8b6c298deafb1c0f82'; \
+			;; \
 		'arm64') \
 			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-arm64.tar.gz'; \
 			sha256='870d1794b2de1a6f0604e2c3cf19604d0d7c6f6247f3a544b8a64ec44f8b24d7'; \

--- a/src/microsoft/1.18/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.18/windows/windowsservercore-1809/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.18.1
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '43a319ba7aa6a015771e34f87f1aff66e2a5ce76480c2832cc930786b6939e8f'; \
+	$sha256 = '62bc2eb4010e549cf05758b96e4a76bceb29321041e639f95c3dac063198092a'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.18/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/1.18/windows/windowsservercore-ltsc2016/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.18.1
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '43a319ba7aa6a015771e34f87f1aff66e2a5ce76480c2832cc930786b6939e8f'; \
+	$sha256 = '62bc2eb4010e549cf05758b96e4a76bceb29321041e639f95c3dac063198092a'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.18/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.18/windows/windowsservercore-ltsc2022/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.18.1
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '43a319ba7aa6a015771e34f87f1aff66e2a5ce76480c2832cc930786b6939e8f'; \
+	$sha256 = '62bc2eb4010e549cf05758b96e4a76bceb29321041e639f95c3dac063198092a'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -17,6 +17,7 @@
           "GOOS": "linux"
         },
         "sha256": "7447167ba3ea6d062d2fab5841d874e7c3710070f6b0f85d9c48f1943833e22e",
+        "supported": true,
         "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-armv6l.tar.gz"
       },
       "arm64v8": {
@@ -116,6 +117,7 @@
           "GOOS": "linux"
         },
         "sha256": "fcce5540ea86052c7d1549f6f89ab3265ebbbd09eb807d8b6c298deafb1c0f82",
+        "supported": true,
         "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-armv6l.tar.gz"
       },
       "arm64v8": {

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -105,27 +105,36 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "0ecd8a6b43ae3e993eedddde6141a7785fc65d1cc8a322c6e67fa02420a883fd",
+        "sha256": "43befa6ecc764854df12ed00672b84ae7f19d0cceed4ce23807cb106f0b067f5",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-amd64.tar.gz"
+      },
+      "arm32v7": {
+        "env": {
+          "GOARCH": "arm",
+          "GOARM": "7",
+          "GOOS": "linux"
+        },
+        "sha256": "fcce5540ea86052c7d1549f6f89ab3265ebbbd09eb807d8b6c298deafb1c0f82",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-armv6l.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "7965396729a9efb2d166e9b33eb142629f9c505240c4e373bbd783cf5f8af61a",
+        "sha256": "870d1794b2de1a6f0604e2c3cf19604d0d7c6f6247f3a544b8a64ec44f8b24d7",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "43a319ba7aa6a015771e34f87f1aff66e2a5ce76480c2832cc930786b6939e8f",
+        "sha256": "62bc2eb4010e549cf05758b96e4a76bceb29321041e639f95c3dac063198092a",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.windows-amd64.zip"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220420.4/go.20220420.4.windows-amd64.zip"
       }
     },
     "variants": [

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -160,26 +160,35 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "7b28ca61502d7034c32e0a03ecde15847db4ad323c2be88a14f3f6ffc065bff7",
+        "sha256": "5b07069f219f1d740e58ce3b562034e9d295f995bc5422ff05bf37b429263c4e",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.3/go.20220414.3.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220421.1/go.20220421.1.linux-amd64.tar.gz"
+      },
+      "arm32v7": {
+        "env": {
+          "GOARCH": "arm",
+          "GOARM": "7",
+          "GOOS": "linux"
+        },
+        "sha256": "9c62001b8e1cfb2d1daf2c63108a2971f49152f498711903b477f89928204de9",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220421.1/go.20220421.1.linux-armv6l.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "cb253fa9ec98bab0901b54ec031f3e985e3376c637c43d78ef56388af64e7f9f",
+        "sha256": "bd57cec707771bcea95ed04afa9655a8390d49587c5083e7ea977a69f161dc36",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.3/go.20220414.3.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220421.1/go.20220421.1.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "f16f31d942271c0d8afbb3776753dd8dbe56ea40aa8c6a43056cccf183207200",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.3/go.20220414.3.windows-amd64.zip"
+        "sha256": "fd665b35383766450da2f7110dc30e194802c4214f34ebdd919f0dc21f2201b0",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220421.1/go.20220421.1.windows-amd64.zip"
       }
     },
     "variants": [

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -6,27 +6,36 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "54af8ed5c858365fb424a8cd1fa258a209e334699a6f88c051784bf06df11676",
+        "sha256": "ce0cd31de6965b8eb64fbc6d84fa0b0e7878bd45fbf6326efb019b41d60fff34",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-amd64.tar.gz"
+      },
+      "arm32v7": {
+        "env": {
+          "GOARCH": "arm",
+          "GOARM": "7",
+          "GOOS": "linux"
+        },
+        "sha256": "7447167ba3ea6d062d2fab5841d874e7c3710070f6b0f85d9c48f1943833e22e",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-armv6l.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "d5aa78c1316bbb5c0638da9624f698aada990628e2321716b0b289084a1c08aa",
+        "sha256": "f9bfea1b86a46045a4677fdf2265281df3a4e5b37c26993ae39c4bd0a975f0cd",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "dac299d353e8963ea0d0019064b0861ef4cb938ef5ec6a77a2a5da6e0aa1700b",
+        "sha256": "af899d802bae238cfefcd996141b1add2c0955ba7fb19d1b7f562356519df4de",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220412.2/go.20220412.2.windows-amd64.zip"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220420.3/go.20220420.3.windows-amd64.zip"
       }
     },
     "variants": [

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -59,26 +59,35 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "97dbef56d8fd0928eafc7f2762f2dca07a05c0de44ca5434778aba8ab91c456f",
+        "sha256": "a02cb67e910fdc8261e1d49fc11fa1bce1f2379d6ace096f98fb8ab9a8bc4ebc",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.4/go.20220414.4.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220420.5/go.20220420.5.linux-amd64.tar.gz"
+      },
+      "arm32v7": {
+        "env": {
+          "GOARCH": "arm",
+          "GOARM": "7",
+          "GOOS": "linux"
+        },
+        "sha256": "e6129ad51dcd33bc5b505f485ce3e36103eb4a2d0b15787de7a06b3963a86cad",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220420.5/go.20220420.5.linux-armv6l.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "6fccfc0515bcf3cc138b0888cb99bf066a62571bbd0ba4b09da242564e659dc7",
+        "sha256": "c4eea386101edbb5c13e73a37aa54eb32b4c9e58b7e98c611b2a28fa91c00b70",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.4/go.20220414.4.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220420.5/go.20220420.5.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "35821193f534bf9681f98e61346211534c6edd3fcbdbec972337c4cc68ca806c",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220414.4/go.20220414.4.windows-amd64.zip"
+        "sha256": "4f62527a7a7fc07c32552a21e45c18f195433ed952b540768ba61936dccb4a17",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220420.5/go.20220420.5.windows-amd64.zip"
       }
     },
     "variants": [


### PR DESCRIPTION
* https://github.com/microsoft/go/issues/519
* Based on https://github.com/microsoft/go-images/pull/106

Mariner doesn't have an armhf base image for us to use, only arm64, so it isn't included here. We can add non-Mariner FIPS-toolchain images once we expand the matrix:
* https://github.com/microsoft/go/issues/418