### PR TITLE
Update to June 2022 releases: 1.17.11, 1.18.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,10 +13,10 @@
           "sharedTags": {
             "1.17": {},
             "1.17-bullseye": {},
-            "1.17.10": {},
-            "1.17.10-1": {},
-            "1.17.10-1-bullseye": {},
-            "1.17.10-bullseye": {}
+            "1.17.11": {},
+            "1.17.11-1": {},
+            "1.17.11-1-bullseye": {},
+            "1.17.11-bullseye": {}
           },
           "platforms": [
             {
@@ -25,7 +25,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.17.10-1-bullseye-amd64": {}
+                "1.17.11-1-bullseye-amd64": {}
               }
             },
             {
@@ -35,7 +35,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.17.10-1-bullseye-arm64v8": {}
+                "1.17.11-1-bullseye-arm64v8": {}
               }
             },
             {
@@ -45,7 +45,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.17.10-1-bullseye-arm32v7": {}
+                "1.17.11-1-bullseye-arm32v7": {}
               }
             }
           ]
@@ -54,8 +54,8 @@
           "productVersion": "1.17",
           "sharedTags": {
             "1.17-buster": {},
-            "1.17.10-1-buster": {},
-            "1.17.10-buster": {}
+            "1.17.11-1-buster": {},
+            "1.17.11-buster": {}
           },
           "platforms": [
             {
@@ -64,7 +64,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "1.17.10-1-buster-amd64": {}
+                "1.17.11-1-buster-amd64": {}
               }
             },
             {
@@ -74,7 +74,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "1.17.10-1-buster-arm64v8": {}
+                "1.17.11-1-buster-arm64v8": {}
               }
             },
             {
@@ -84,7 +84,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "1.17.10-1-buster-arm32v7": {}
+                "1.17.11-1-buster-arm32v7": {}
               }
             }
           ]
@@ -93,8 +93,8 @@
           "productVersion": "1.17",
           "sharedTags": {
             "1.17-stretch": {},
-            "1.17.10-1-stretch": {},
-            "1.17.10-stretch": {}
+            "1.17.11-1-stretch": {},
+            "1.17.11-stretch": {}
           },
           "platforms": [
             {
@@ -103,7 +103,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "1.17.10-1-stretch-amd64": {}
+                "1.17.11-1-stretch-amd64": {}
               }
             },
             {
@@ -113,7 +113,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "1.17.10-1-stretch-arm64v8": {}
+                "1.17.11-1-stretch-arm64v8": {}
               }
             },
             {
@@ -123,7 +123,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "1.17.10-1-stretch-arm32v7": {}
+                "1.17.11-1-stretch-arm32v7": {}
               }
             }
           ]
@@ -132,8 +132,8 @@
           "productVersion": "1.17",
           "sharedTags": {
             "1.17-windowsservercore-ltsc2022": {},
-            "1.17.10-1-windowsservercore-ltsc2022": {},
-            "1.17.10-windowsservercore-ltsc2022": {}
+            "1.17.11-1-windowsservercore-ltsc2022": {},
+            "1.17.11-windowsservercore-ltsc2022": {}
           },
           "platforms": [
             {
@@ -142,7 +142,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2022",
               "tags": {
-                "1.17.10-1-windowsservercore-ltsc2022-amd64": {}
+                "1.17.11-1-windowsservercore-ltsc2022-amd64": {}
               }
             }
           ]
@@ -151,8 +151,8 @@
           "productVersion": "1.17",
           "sharedTags": {
             "1.17-windowsservercore-1809": {},
-            "1.17.10-1-windowsservercore-1809": {},
-            "1.17.10-windowsservercore-1809": {}
+            "1.17.11-1-windowsservercore-1809": {},
+            "1.17.11-windowsservercore-1809": {}
           },
           "platforms": [
             {
@@ -161,7 +161,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1809",
               "tags": {
-                "1.17.10-1-windowsservercore-1809-amd64": {}
+                "1.17.11-1-windowsservercore-1809-amd64": {}
               }
             }
           ]
@@ -170,8 +170,8 @@
           "productVersion": "1.17",
           "sharedTags": {
             "1.17-windowsservercore-ltsc2016": {},
-            "1.17.10-1-windowsservercore-ltsc2016": {},
-            "1.17.10-windowsservercore-ltsc2016": {}
+            "1.17.11-1-windowsservercore-ltsc2016": {},
+            "1.17.11-windowsservercore-ltsc2016": {}
           },
           "platforms": [
             {
@@ -180,7 +180,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
               "tags": {
-                "1.17.10-1-windowsservercore-ltsc2016-amd64": {}
+                "1.17.11-1-windowsservercore-ltsc2016-amd64": {}
               }
             }
           ]
@@ -189,13 +189,13 @@
           "productVersion": "1.17",
           "sharedTags": {
             "1.17-nanoserver-ltsc2022": {},
-            "1.17.10-1-nanoserver-ltsc2022": {},
-            "1.17.10-nanoserver-ltsc2022": {}
+            "1.17.11-1-nanoserver-ltsc2022": {},
+            "1.17.11-nanoserver-ltsc2022": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "DOWNLOADER_TAG": "1.17.10-1-windowsservercore-ltsc2022-amd64",
+                "DOWNLOADER_TAG": "1.17.11-1-windowsservercore-ltsc2022-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -203,7 +203,7 @@
               "os": "windows",
               "osVersion": "nanoserver-ltsc2022",
               "tags": {
-                "1.17.10-1-nanoserver-ltsc2022-amd64": {}
+                "1.17.11-1-nanoserver-ltsc2022-amd64": {}
               }
             }
           ]
@@ -212,13 +212,13 @@
           "productVersion": "1.17",
           "sharedTags": {
             "1.17-nanoserver-1809": {},
-            "1.17.10-1-nanoserver-1809": {},
-            "1.17.10-nanoserver-1809": {}
+            "1.17.11-1-nanoserver-1809": {},
+            "1.17.11-nanoserver-1809": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "DOWNLOADER_TAG": "1.17.10-1-windowsservercore-1809-amd64",
+                "DOWNLOADER_TAG": "1.17.11-1-windowsservercore-1809-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -226,7 +226,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "1.17.10-1-nanoserver-1809-amd64": {}
+                "1.17.11-1-nanoserver-1809-amd64": {}
               }
             }
           ]
@@ -236,10 +236,10 @@
           "sharedTags": {
             "1.17-fips": {},
             "1.17-fips-cbl-mariner1.0": {},
-            "1.17.10-1-fips": {},
-            "1.17.10-1-fips-cbl-mariner1.0": {},
-            "1.17.10-fips": {},
-            "1.17.10-fips-cbl-mariner1.0": {}
+            "1.17.11-1-fips": {},
+            "1.17.11-1-fips-cbl-mariner1.0": {},
+            "1.17.11-fips": {},
+            "1.17.11-fips-cbl-mariner1.0": {}
           },
           "platforms": [
             {
@@ -248,7 +248,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.17.10-1-fips-cbl-mariner1.0-amd64": {}
+                "1.17.11-1-fips-cbl-mariner1.0-amd64": {}
               }
             },
             {
@@ -257,7 +257,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.17.10-1-fips-cbl-mariner1.0-arm64v8": {}
+                "1.17.11-1-fips-cbl-mariner1.0-arm64v8": {}
               }
             }
           ]
@@ -269,10 +269,10 @@
             "1-bullseye": {},
             "1.18": {},
             "1.18-bullseye": {},
-            "1.18.2": {},
-            "1.18.2-1": {},
-            "1.18.2-1-bullseye": {},
-            "1.18.2-bullseye": {},
+            "1.18.3": {},
+            "1.18.3-1": {},
+            "1.18.3-1-bullseye": {},
+            "1.18.3-bullseye": {},
             "bullseye": {},
             "latest": {}
           },
@@ -283,7 +283,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.18.2-1-bullseye-amd64": {}
+                "1.18.3-1-bullseye-amd64": {}
               }
             },
             {
@@ -293,7 +293,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.18.2-1-bullseye-arm64v8": {}
+                "1.18.3-1-bullseye-arm64v8": {}
               }
             },
             {
@@ -303,7 +303,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.18.2-1-bullseye-arm32v7": {}
+                "1.18.3-1-bullseye-arm32v7": {}
               }
             }
           ]
@@ -313,8 +313,8 @@
           "sharedTags": {
             "1-buster": {},
             "1.18-buster": {},
-            "1.18.2-1-buster": {},
-            "1.18.2-buster": {},
+            "1.18.3-1-buster": {},
+            "1.18.3-buster": {},
             "buster": {}
           },
           "platforms": [
@@ -324,7 +324,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "1.18.2-1-buster-amd64": {}
+                "1.18.3-1-buster-amd64": {}
               }
             },
             {
@@ -334,7 +334,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "1.18.2-1-buster-arm64v8": {}
+                "1.18.3-1-buster-arm64v8": {}
               }
             },
             {
@@ -344,7 +344,7 @@
               "os": "linux",
               "osVersion": "buster",
               "tags": {
-                "1.18.2-1-buster-arm32v7": {}
+                "1.18.3-1-buster-arm32v7": {}
               }
             }
           ]
@@ -354,8 +354,8 @@
           "sharedTags": {
             "1-stretch": {},
             "1.18-stretch": {},
-            "1.18.2-1-stretch": {},
-            "1.18.2-stretch": {},
+            "1.18.3-1-stretch": {},
+            "1.18.3-stretch": {},
             "stretch": {}
           },
           "platforms": [
@@ -365,7 +365,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "1.18.2-1-stretch-amd64": {}
+                "1.18.3-1-stretch-amd64": {}
               }
             },
             {
@@ -375,7 +375,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "1.18.2-1-stretch-arm64v8": {}
+                "1.18.3-1-stretch-arm64v8": {}
               }
             },
             {
@@ -385,7 +385,7 @@
               "os": "linux",
               "osVersion": "stretch",
               "tags": {
-                "1.18.2-1-stretch-arm32v7": {}
+                "1.18.3-1-stretch-arm32v7": {}
               }
             }
           ]
@@ -395,8 +395,8 @@
           "sharedTags": {
             "1-windowsservercore-ltsc2022": {},
             "1.18-windowsservercore-ltsc2022": {},
-            "1.18.2-1-windowsservercore-ltsc2022": {},
-            "1.18.2-windowsservercore-ltsc2022": {},
+            "1.18.3-1-windowsservercore-ltsc2022": {},
+            "1.18.3-windowsservercore-ltsc2022": {},
             "windowsservercore-ltsc2022": {}
           },
           "platforms": [
@@ -406,7 +406,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2022",
               "tags": {
-                "1.18.2-1-windowsservercore-ltsc2022-amd64": {}
+                "1.18.3-1-windowsservercore-ltsc2022-amd64": {}
               }
             }
           ]
@@ -416,8 +416,8 @@
           "sharedTags": {
             "1-windowsservercore-1809": {},
             "1.18-windowsservercore-1809": {},
-            "1.18.2-1-windowsservercore-1809": {},
-            "1.18.2-windowsservercore-1809": {},
+            "1.18.3-1-windowsservercore-1809": {},
+            "1.18.3-windowsservercore-1809": {},
             "windowsservercore-1809": {}
           },
           "platforms": [
@@ -427,7 +427,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1809",
               "tags": {
-                "1.18.2-1-windowsservercore-1809-amd64": {}
+                "1.18.3-1-windowsservercore-1809-amd64": {}
               }
             }
           ]
@@ -437,8 +437,8 @@
           "sharedTags": {
             "1-windowsservercore-ltsc2016": {},
             "1.18-windowsservercore-ltsc2016": {},
-            "1.18.2-1-windowsservercore-ltsc2016": {},
-            "1.18.2-windowsservercore-ltsc2016": {},
+            "1.18.3-1-windowsservercore-ltsc2016": {},
+            "1.18.3-windowsservercore-ltsc2016": {},
             "windowsservercore-ltsc2016": {}
           },
           "platforms": [
@@ -448,7 +448,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
               "tags": {
-                "1.18.2-1-windowsservercore-ltsc2016-amd64": {}
+                "1.18.3-1-windowsservercore-ltsc2016-amd64": {}
               }
             }
           ]
@@ -458,14 +458,14 @@
           "sharedTags": {
             "1-nanoserver-ltsc2022": {},
             "1.18-nanoserver-ltsc2022": {},
-            "1.18.2-1-nanoserver-ltsc2022": {},
-            "1.18.2-nanoserver-ltsc2022": {},
+            "1.18.3-1-nanoserver-ltsc2022": {},
+            "1.18.3-nanoserver-ltsc2022": {},
             "nanoserver-ltsc2022": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "DOWNLOADER_TAG": "1.18.2-1-windowsservercore-ltsc2022-amd64",
+                "DOWNLOADER_TAG": "1.18.3-1-windowsservercore-ltsc2022-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -473,7 +473,7 @@
               "os": "windows",
               "osVersion": "nanoserver-ltsc2022",
               "tags": {
-                "1.18.2-1-nanoserver-ltsc2022-amd64": {}
+                "1.18.3-1-nanoserver-ltsc2022-amd64": {}
               }
             }
           ]
@@ -483,14 +483,14 @@
           "sharedTags": {
             "1-nanoserver-1809": {},
             "1.18-nanoserver-1809": {},
-            "1.18.2-1-nanoserver-1809": {},
-            "1.18.2-nanoserver-1809": {},
+            "1.18.3-1-nanoserver-1809": {},
+            "1.18.3-nanoserver-1809": {},
             "nanoserver-1809": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "DOWNLOADER_TAG": "1.18.2-1-windowsservercore-1809-amd64",
+                "DOWNLOADER_TAG": "1.18.3-1-windowsservercore-1809-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -498,7 +498,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "1.18.2-1-nanoserver-1809-amd64": {}
+                "1.18.3-1-nanoserver-1809-amd64": {}
               }
             }
           ]
@@ -510,10 +510,10 @@
             "1-fips-cbl-mariner1.0": {},
             "1.18-fips": {},
             "1.18-fips-cbl-mariner1.0": {},
-            "1.18.2-1-fips": {},
-            "1.18.2-1-fips-cbl-mariner1.0": {},
-            "1.18.2-fips": {},
-            "1.18.2-fips-cbl-mariner1.0": {}
+            "1.18.3-1-fips": {},
+            "1.18.3-1-fips-cbl-mariner1.0": {},
+            "1.18.3-fips": {},
+            "1.18.3-fips-cbl-mariner1.0": {}
           },
           "platforms": [
             {
@@ -522,7 +522,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.18.2-1-fips-cbl-mariner1.0-amd64": {}
+                "1.18.3-1-fips-cbl-mariner1.0-amd64": {}
               }
             },
             {
@@ -531,7 +531,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner1.0",
               "tags": {
-                "1.18.2-1-fips-cbl-mariner1.0-arm64v8": {}
+                "1.18.3-1-fips-cbl-mariner1.0-arm64v8": {}
               }
             }
           ]

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -21,19 +21,19 @@ RUN tdnf install -y \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.10
+ENV GOLANG_VERSION 1.17.11
 
 RUN set -eux; \
 	arch="$(uname -m)"; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220510.5/go.20220510.5.linux-amd64.tar.gz'; \
-			sha256='36306bf424fa76d87bc9a90f29482dd66b24d1fa72aebad061d02e37e47402e9'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220602.4/go.20220602.4.linux-amd64.tar.gz'; \
+			sha256='20f5466978a739fb8c6672fedbd47ef1602511367860869915ebbdbdb0ded741'; \
 			;; \
 		'aarch64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220510.5/go.20220510.5.linux-arm64.tar.gz'; \
-			sha256='76dab4b2c74075db074095e71b8d75a6f11187374a542e5e48e7d98ec37c8d4a'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220602.4/go.20220602.4.linux-arm64.tar.gz'; \
+			sha256='c2b392b9fe30ecef3d545b11cb4e7fafcf4c704fccab9e5fe67f7a40fc942e1c'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/bullseye/Dockerfile
+++ b/src/microsoft/1.17/bullseye/Dockerfile
@@ -20,23 +20,23 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.10
+ENV GOLANG_VERSION 1.17.11
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.linux-amd64.tar.gz'; \
-			sha256='a02c1ccce7c2741334cc21568d7b35e2d7c1ba29ed461b813abc3eb448b24706'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.linux-amd64.tar.gz'; \
+			sha256='3488c2705b3efecea2c424480513fa17c163a2674d6fd7428ecb044351f3c763'; \
 			;; \
 		'armhf') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.linux-armv6l.tar.gz'; \
-			sha256='b453e7c24e09f3f1297d2622ff3fb85cc3374b324eea8ad267cbde91194bf5c3'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.linux-armv6l.tar.gz'; \
+			sha256='ed3b8bfa5bb47302cbfc717298a57bc58a576fb09ae93609d1d705d7fc51d08a'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.linux-arm64.tar.gz'; \
-			sha256='04cc72e49526f073be32034ad88ecefc363f0fbe61b1c9f564636263386015b7'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.linux-arm64.tar.gz'; \
+			sha256='b165ed5e01e3cdc5551b1484f3acac6dccbe58b37ab30001716c59e3a8e036f7'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/buster/Dockerfile
+++ b/src/microsoft/1.17/buster/Dockerfile
@@ -20,23 +20,23 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.10
+ENV GOLANG_VERSION 1.17.11
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.linux-amd64.tar.gz'; \
-			sha256='a02c1ccce7c2741334cc21568d7b35e2d7c1ba29ed461b813abc3eb448b24706'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.linux-amd64.tar.gz'; \
+			sha256='3488c2705b3efecea2c424480513fa17c163a2674d6fd7428ecb044351f3c763'; \
 			;; \
 		'armhf') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.linux-armv6l.tar.gz'; \
-			sha256='b453e7c24e09f3f1297d2622ff3fb85cc3374b324eea8ad267cbde91194bf5c3'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.linux-armv6l.tar.gz'; \
+			sha256='ed3b8bfa5bb47302cbfc717298a57bc58a576fb09ae93609d1d705d7fc51d08a'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.linux-arm64.tar.gz'; \
-			sha256='04cc72e49526f073be32034ad88ecefc363f0fbe61b1c9f564636263386015b7'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.linux-arm64.tar.gz'; \
+			sha256='b165ed5e01e3cdc5551b1484f3acac6dccbe58b37ab30001716c59e3a8e036f7'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/stretch/Dockerfile
+++ b/src/microsoft/1.17/stretch/Dockerfile
@@ -20,23 +20,23 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.10
+ENV GOLANG_VERSION 1.17.11
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.linux-amd64.tar.gz'; \
-			sha256='a02c1ccce7c2741334cc21568d7b35e2d7c1ba29ed461b813abc3eb448b24706'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.linux-amd64.tar.gz'; \
+			sha256='3488c2705b3efecea2c424480513fa17c163a2674d6fd7428ecb044351f3c763'; \
 			;; \
 		'armhf') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.linux-armv6l.tar.gz'; \
-			sha256='b453e7c24e09f3f1297d2622ff3fb85cc3374b324eea8ad267cbde91194bf5c3'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.linux-armv6l.tar.gz'; \
+			sha256='ed3b8bfa5bb47302cbfc717298a57bc58a576fb09ae93609d1d705d7fc51d08a'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.linux-arm64.tar.gz'; \
-			sha256='04cc72e49526f073be32034ad88ecefc363f0fbe61b1c9f564636263386015b7'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.linux-arm64.tar.gz'; \
+			sha256='b165ed5e01e3cdc5551b1484f3acac6dccbe58b37ab30001716c59e3a8e036f7'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.17/windows/nanoserver-1809/Dockerfile
+++ b/src/microsoft/1.17/windows/nanoserver-1809/Dockerfile
@@ -7,7 +7,7 @@
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
 # It's easy to download Go and install it in server core, but not nanoserver. So, to build
 # nanoserver, copy over the server core installation.
-ARG DOWNLOADER_TAG=1.17.10-windowsservercore-1809
+ARG DOWNLOADER_TAG=1.17.11-windowsservercore-1809
 FROM $REPO:$DOWNLOADER_TAG AS downloader
 
 FROM mcr.microsoft.com/windows/nanoserver:1809
@@ -27,7 +27,7 @@ RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.17.10
+ENV GOLANG_VERSION 1.17.11
 
 # Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
 COPY --from=downloader ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]

--- a/src/microsoft/1.17/windows/nanoserver-ltsc2022/Dockerfile
+++ b/src/microsoft/1.17/windows/nanoserver-ltsc2022/Dockerfile
@@ -7,7 +7,7 @@
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
 # It's easy to download Go and install it in server core, but not nanoserver. So, to build
 # nanoserver, copy over the server core installation.
-ARG DOWNLOADER_TAG=1.17.10-windowsservercore-ltsc2022
+ARG DOWNLOADER_TAG=1.17.11-windowsservercore-ltsc2022
 FROM $REPO:$DOWNLOADER_TAG AS downloader
 
 FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
@@ -27,7 +27,7 @@ RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.17.10
+ENV GOLANG_VERSION 1.17.11
 
 # Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
 COPY --from=downloader ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]

--- a/src/microsoft/1.17/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-1809/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.17.10
+ENV GOLANG_VERSION 1.17.11
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'b1e3cc5ee327d8c88541a7317ee543f7ed07354d4b91b641166ee3db2160e44a'; \
+	$sha256 = 'b253c252bf2fe33619fdc2d12630c8cd0ea2a26bf969b12520e9568747c78d99'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-ltsc2016/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.17.10
+ENV GOLANG_VERSION 1.17.11
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'b1e3cc5ee327d8c88541a7317ee543f7ed07354d4b91b641166ee3db2160e44a'; \
+	$sha256 = 'b253c252bf2fe33619fdc2d12630c8cd0ea2a26bf969b12520e9568747c78d99'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.17/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.17/windows/windowsservercore-ltsc2022/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.17.10
+ENV GOLANG_VERSION 1.17.11
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'b1e3cc5ee327d8c88541a7317ee543f7ed07354d4b91b641166ee3db2160e44a'; \
+	$sha256 = 'b253c252bf2fe33619fdc2d12630c8cd0ea2a26bf969b12520e9568747c78d99'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
@@ -21,19 +21,19 @@ RUN tdnf install -y \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.18.2
+ENV GOLANG_VERSION 1.18.3
 
 RUN set -eux; \
 	arch="$(uname -m)"; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220510.6/go.20220510.6.linux-amd64.tar.gz'; \
-			sha256='eb92d491af5b718d6161c5a86b79473770647c3d0db1f0866418842d0dadaa93'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220602.6/go.20220602.6.linux-amd64.tar.gz'; \
+			sha256='48c7751dde281bdbf83224c7cb20381a4b3b9e1c7948d096dc1a9cdce8422f84'; \
 			;; \
 		'aarch64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220510.6/go.20220510.6.linux-arm64.tar.gz'; \
-			sha256='e0256e419dc9e2a3be28fe0176772056e7531655db4a466826a388808df16c35'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220602.6/go.20220602.6.linux-arm64.tar.gz'; \
+			sha256='0e3888b6a4cd1a9148344f8d6f3f1568c240d1e829c00c7dc154af293db5690e'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/bullseye/Dockerfile
+++ b/src/microsoft/1.18/bullseye/Dockerfile
@@ -20,23 +20,23 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.18.2
+ENV GOLANG_VERSION 1.18.3
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.linux-amd64.tar.gz'; \
-			sha256='88854cf719158b74a56937e1cc9b222b4d4e3d1305635e9eb213e942e7cd2029'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.linux-amd64.tar.gz'; \
+			sha256='dfaa1cbe1186aae947c204e1b3f87b05cf44e761b9d47f6a8c6dd6b4970852c3'; \
 			;; \
 		'armhf') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.linux-armv6l.tar.gz'; \
-			sha256='967132f65726cccf1eb7b65051706d489b5bfbdca48d52f102497315ebe3c84f'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.linux-armv6l.tar.gz'; \
+			sha256='837cb4bdc753ed9a14a6192bad2b8615777b6f81ba321a245f7f9a80de74bec3'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.linux-arm64.tar.gz'; \
-			sha256='eb68f145e815f9ff0980835d60d345dc159736eb01adf96c3b93d1600a639ace'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.linux-arm64.tar.gz'; \
+			sha256='d82a70253d379c987e2dbea16b22f774e104357e5e791ad584c3cd213ff9a411'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/buster/Dockerfile
+++ b/src/microsoft/1.18/buster/Dockerfile
@@ -20,23 +20,23 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.18.2
+ENV GOLANG_VERSION 1.18.3
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.linux-amd64.tar.gz'; \
-			sha256='88854cf719158b74a56937e1cc9b222b4d4e3d1305635e9eb213e942e7cd2029'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.linux-amd64.tar.gz'; \
+			sha256='dfaa1cbe1186aae947c204e1b3f87b05cf44e761b9d47f6a8c6dd6b4970852c3'; \
 			;; \
 		'armhf') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.linux-armv6l.tar.gz'; \
-			sha256='967132f65726cccf1eb7b65051706d489b5bfbdca48d52f102497315ebe3c84f'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.linux-armv6l.tar.gz'; \
+			sha256='837cb4bdc753ed9a14a6192bad2b8615777b6f81ba321a245f7f9a80de74bec3'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.linux-arm64.tar.gz'; \
-			sha256='eb68f145e815f9ff0980835d60d345dc159736eb01adf96c3b93d1600a639ace'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.linux-arm64.tar.gz'; \
+			sha256='d82a70253d379c987e2dbea16b22f774e104357e5e791ad584c3cd213ff9a411'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/stretch/Dockerfile
+++ b/src/microsoft/1.18/stretch/Dockerfile
@@ -20,23 +20,23 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.18.2
+ENV GOLANG_VERSION 1.18.3
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.linux-amd64.tar.gz'; \
-			sha256='88854cf719158b74a56937e1cc9b222b4d4e3d1305635e9eb213e942e7cd2029'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.linux-amd64.tar.gz'; \
+			sha256='dfaa1cbe1186aae947c204e1b3f87b05cf44e761b9d47f6a8c6dd6b4970852c3'; \
 			;; \
 		'armhf') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.linux-armv6l.tar.gz'; \
-			sha256='967132f65726cccf1eb7b65051706d489b5bfbdca48d52f102497315ebe3c84f'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.linux-armv6l.tar.gz'; \
+			sha256='837cb4bdc753ed9a14a6192bad2b8615777b6f81ba321a245f7f9a80de74bec3'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.linux-arm64.tar.gz'; \
-			sha256='eb68f145e815f9ff0980835d60d345dc159736eb01adf96c3b93d1600a639ace'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.linux-arm64.tar.gz'; \
+			sha256='d82a70253d379c987e2dbea16b22f774e104357e5e791ad584c3cd213ff9a411'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18/windows/nanoserver-1809/Dockerfile
+++ b/src/microsoft/1.18/windows/nanoserver-1809/Dockerfile
@@ -7,7 +7,7 @@
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
 # It's easy to download Go and install it in server core, but not nanoserver. So, to build
 # nanoserver, copy over the server core installation.
-ARG DOWNLOADER_TAG=1.18.2-windowsservercore-1809
+ARG DOWNLOADER_TAG=1.18.3-windowsservercore-1809
 FROM $REPO:$DOWNLOADER_TAG AS downloader
 
 FROM mcr.microsoft.com/windows/nanoserver:1809
@@ -27,7 +27,7 @@ RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.18.2
+ENV GOLANG_VERSION 1.18.3
 
 # Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
 COPY --from=downloader ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]

--- a/src/microsoft/1.18/windows/nanoserver-ltsc2022/Dockerfile
+++ b/src/microsoft/1.18/windows/nanoserver-ltsc2022/Dockerfile
@@ -7,7 +7,7 @@
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
 # It's easy to download Go and install it in server core, but not nanoserver. So, to build
 # nanoserver, copy over the server core installation.
-ARG DOWNLOADER_TAG=1.18.2-windowsservercore-ltsc2022
+ARG DOWNLOADER_TAG=1.18.3-windowsservercore-ltsc2022
 FROM $REPO:$DOWNLOADER_TAG AS downloader
 
 FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
@@ -27,7 +27,7 @@ RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.18.2
+ENV GOLANG_VERSION 1.18.3
 
 # Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
 COPY --from=downloader ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]

--- a/src/microsoft/1.18/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.18/windows/windowsservercore-1809/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.18.2
+ENV GOLANG_VERSION 1.18.3
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'a1552dd2452ae802756d8263c6c482e9c0b4b606f3bfbac0911c426f84a8af92'; \
+	$sha256 = 'fb758d452eb73b3df7400c6dfcdaad627404ec007d86280ebbd23be780fca09f'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.18/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/1.18/windows/windowsservercore-ltsc2016/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.18.2
+ENV GOLANG_VERSION 1.18.3
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'a1552dd2452ae802756d8263c6c482e9c0b4b606f3bfbac0911c426f84a8af92'; \
+	$sha256 = 'fb758d452eb73b3df7400c6dfcdaad627404ec007d86280ebbd23be780fca09f'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.18/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.18/windows/windowsservercore-ltsc2022/Dockerfile
@@ -53,14 +53,14 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.18.2
+ENV GOLANG_VERSION 1.18.3
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.windows-amd64.zip'; \
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'a1552dd2452ae802756d8263c6c482e9c0b4b606f3bfbac0911c426f84a8af92'; \
+	$sha256 = 'fb758d452eb73b3df7400c6dfcdaad627404ec007d86280ebbd23be780fca09f'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -6,9 +6,9 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "a02c1ccce7c2741334cc21568d7b35e2d7c1ba29ed461b813abc3eb448b24706",
+        "sha256": "3488c2705b3efecea2c424480513fa17c163a2674d6fd7428ecb044351f3c763",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.linux-amd64.tar.gz"
       },
       "arm32v7": {
         "env": {
@@ -16,27 +16,27 @@
           "GOARM": "7",
           "GOOS": "linux"
         },
-        "sha256": "b453e7c24e09f3f1297d2622ff3fb85cc3374b324eea8ad267cbde91194bf5c3",
+        "sha256": "ed3b8bfa5bb47302cbfc717298a57bc58a576fb09ae93609d1d705d7fc51d08a",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.linux-armv6l.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.linux-armv6l.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "04cc72e49526f073be32034ad88ecefc363f0fbe61b1c9f564636263386015b7",
+        "sha256": "b165ed5e01e3cdc5551b1484f3acac6dccbe58b37ab30001716c59e3a8e036f7",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "b1e3cc5ee327d8c88541a7317ee543f7ed07354d4b91b641166ee3db2160e44a",
+        "sha256": "b253c252bf2fe33619fdc2d12630c8cd0ea2a26bf969b12520e9568747c78d99",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220510.2/go.20220510.2.windows-amd64.zip"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.17/20220602.2/go.20220602.2.windows-amd64.zip"
       }
     },
     "variants": [
@@ -49,7 +49,7 @@
       "windows/nanoserver-ltsc2022",
       "windows/nanoserver-1809"
     ],
-    "version": "1.17.10",
+    "version": "1.17.11",
     "revision": "1",
     "preferredVariant": "bullseye"
   },
@@ -60,9 +60,9 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "36306bf424fa76d87bc9a90f29482dd66b24d1fa72aebad061d02e37e47402e9",
+        "sha256": "20f5466978a739fb8c6672fedbd47ef1602511367860869915ebbdbdb0ded741",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220510.5/go.20220510.5.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220602.4/go.20220602.4.linux-amd64.tar.gz"
       },
       "arm32v7": {
         "env": {
@@ -70,31 +70,31 @@
           "GOARM": "7",
           "GOOS": "linux"
         },
-        "sha256": "a005d33c2fdeb2eaae8189950bd41ea42f58630cbbbcb1f9ada55bdccf82e1bc",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220510.5/go.20220510.5.linux-armv6l.tar.gz"
+        "sha256": "633080839a341ebe3e6a60d473d6126e1a593e96fda503f70a610a9b06a748f2",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220602.4/go.20220602.4.linux-armv6l.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "76dab4b2c74075db074095e71b8d75a6f11187374a542e5e48e7d98ec37c8d4a",
+        "sha256": "c2b392b9fe30ecef3d545b11cb4e7fafcf4c704fccab9e5fe67f7a40fc942e1c",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220510.5/go.20220510.5.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220602.4/go.20220602.4.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "e54c4370a6b1dd75d1362c067aa2b97e2040f5369e681dabedeab26e75725762",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220510.5/go.20220510.5.windows-amd64.zip"
+        "sha256": "e1b19518b924d3b5041cf3e731988408dfb39fe6e1f7b891702c542302f024bb",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220602.4/go.20220602.4.windows-amd64.zip"
       }
     },
     "variants": [
       "cbl-mariner1.0"
     ],
-    "version": "1.17.10",
+    "version": "1.17.11",
     "revision": "1",
     "preferredVariant": "cbl-mariner1.0",
     "branchSuffix": "-fips"
@@ -106,9 +106,9 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "88854cf719158b74a56937e1cc9b222b4d4e3d1305635e9eb213e942e7cd2029",
+        "sha256": "dfaa1cbe1186aae947c204e1b3f87b05cf44e761b9d47f6a8c6dd6b4970852c3",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.linux-amd64.tar.gz"
       },
       "arm32v7": {
         "env": {
@@ -116,27 +116,27 @@
           "GOARM": "7",
           "GOOS": "linux"
         },
-        "sha256": "967132f65726cccf1eb7b65051706d489b5bfbdca48d52f102497315ebe3c84f",
+        "sha256": "837cb4bdc753ed9a14a6192bad2b8615777b6f81ba321a245f7f9a80de74bec3",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.linux-armv6l.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.linux-armv6l.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "eb68f145e815f9ff0980835d60d345dc159736eb01adf96c3b93d1600a639ace",
+        "sha256": "d82a70253d379c987e2dbea16b22f774e104357e5e791ad584c3cd213ff9a411",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "a1552dd2452ae802756d8263c6c482e9c0b4b606f3bfbac0911c426f84a8af92",
+        "sha256": "fb758d452eb73b3df7400c6dfcdaad627404ec007d86280ebbd23be780fca09f",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220510.3/go.20220510.3.windows-amd64.zip"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220602.8/go.20220602.8.windows-amd64.zip"
       }
     },
     "variants": [
@@ -149,7 +149,7 @@
       "windows/nanoserver-ltsc2022",
       "windows/nanoserver-1809"
     ],
-    "version": "1.18.2",
+    "version": "1.18.3",
     "revision": "1",
     "preferredMajor": true,
     "preferredMinor": true,
@@ -162,9 +162,9 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "eb92d491af5b718d6161c5a86b79473770647c3d0db1f0866418842d0dadaa93",
+        "sha256": "48c7751dde281bdbf83224c7cb20381a4b3b9e1c7948d096dc1a9cdce8422f84",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220510.6/go.20220510.6.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220602.6/go.20220602.6.linux-amd64.tar.gz"
       },
       "arm32v7": {
         "env": {
@@ -172,31 +172,31 @@
           "GOARM": "7",
           "GOOS": "linux"
         },
-        "sha256": "d60044bc75ae1a613a44d5263f6e0388b5a6aa376ebfe077c08e1a908ccea547",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220510.6/go.20220510.6.linux-armv6l.tar.gz"
+        "sha256": "010dc645e2ee3a20f6fb6a5588a8968746df785d7bf78d56de0b54d718e77fa0",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220602.6/go.20220602.6.linux-armv6l.tar.gz"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "e0256e419dc9e2a3be28fe0176772056e7531655db4a466826a388808df16c35",
+        "sha256": "0e3888b6a4cd1a9148344f8d6f3f1568c240d1e829c00c7dc154af293db5690e",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220510.6/go.20220510.6.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220602.6/go.20220602.6.linux-arm64.tar.gz"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "fe613a3b2f4ed4138c9a3d3e3a157d19bf4ec3e8acbc937a06c9bece88ed38a9",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220510.6/go.20220510.6.windows-amd64.zip"
+        "sha256": "86992a79ec87da007c793ccd93226bdf67139e4f20223e5aafe81187c4f98407",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220602.6/go.20220602.6.windows-amd64.zip"
       }
     },
     "variants": [
       "cbl-mariner1.0"
     ],
-    "version": "1.18.2",
+    "version": "1.18.3",
     "revision": "1",
     "preferredMinor": true,
     "preferredVariant": "cbl-mariner1.0",


### PR DESCRIPTION
Completely tooled update: grabbed assets.json files from https://github.com/microsoft/go/releases and ran them with `dockerupdate`.