### PR TITLE
Use MCR mirror for buildpack-deps base images

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -105,7 +105,6 @@ jobs:
       --architecture $(architecture)
       --retry
       --source-repo $(publicGitRepoUri)
-      --get-installed-pkgs-path $(baseContainerRepoPath)/$(engCommonRelativePath)/package-scripts/get-installed-packages.sh
       --digests-out-var 'builtImages'
       $(manifestVariables)
       $(imageBuilderBuildArgs)

--- a/eng/common/templates/jobs/copy-base-images.yml
+++ b/eng/common/templates/jobs/copy-base-images.yml
@@ -19,7 +19,7 @@ jobs:
       '$(acr.servicePrincipalTenant)'
       '$(acr.subscription)'
       '$(acr.resourceGroup)'
-      $(mirrorRegistryCreds)
+      $(dockerHubRegistryCreds)
       --repo-prefix $(mirrorRepoPrefix)
       --registry-override '$(acr.server)'
       --os-type 'linux'

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1689405
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1784901
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -49,5 +49,3 @@ variables:
   value: $(app-DotnetDockerTelemetryIngestion-client-secret)
 - name: mcrStatus.servicePrincipalPassword
   value: $(app-DotnetDockerMcrStatusApi-client-secret)
-- name: acr.password
-  value: $(BotAccount-dotnet-docker-acr-bot-password)

--- a/eng/common/templates/variables/dotnet/common.yml
+++ b/eng/common/templates/variables/dotnet/common.yml
@@ -4,10 +4,12 @@ variables:
   value: public
 - name: internalProjectName
   value: internal
-- name: mirrorRegistryCreds
+- name: dockerHubRegistryCreds
   value: --registry-creds 'docker.io=$(dotnetDockerHubBot.userName);$(BotAccount-dotnet-dockerhub-bot-PAT)'
 - name: acr.servicePrincipalPassword
   value: $(app-dotnetdockerbuild-client-secret)
+- name: acr.password
+  value: $(BotAccount-dotnet-docker-acr-bot-password)
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-Docker-Common

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,7 @@
 {
-  "readme": "README.md",
+  "readme": {
+    "path": "README.md"
+  },
   "registry": "mcr.microsoft.com",
   "variables": {},
   "includes": [],

--- a/patches/0004-Use-MCR-mirror-for-buildpack-deps.patch
+++ b/patches/0004-Use-MCR-mirror-for-buildpack-deps.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: microsoft-golang-bot <microsoft-golang-bot@users.noreply.github.com>
+Date: Fri, 3 Jun 2022 12:26:05 -0500
+Subject: [PATCH] Use MCR mirror for buildpack-deps
+
+---
+ Dockerfile-linux.template | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
+index e83d5ab..f661a6b 100644
+--- a/Dockerfile-linux.template
++++ b/Dockerfile-linux.template
+@@ -46,7 +46,7 @@ RUN tdnf install -y \
+ 	tdnf clean all
+ 
+ {{ ) else ( -}}
+-FROM buildpack-deps:{{ env.variant }}-scm
++FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:{{ env.variant }}-scm
+ 
+ # install cgo-related dependencies
+ RUN set -eux; \

--- a/src/microsoft/1.17/bullseye/Dockerfile
+++ b/src/microsoft/1.17/bullseye/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:bullseye-scm
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.17/buster/Dockerfile
+++ b/src/microsoft/1.17/buster/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:buster-scm
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:buster-scm
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.17/stretch/Dockerfile
+++ b/src/microsoft/1.17/stretch/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:stretch-scm
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:stretch-scm
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.18/bullseye/Dockerfile
+++ b/src/microsoft/1.18/bullseye/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:bullseye-scm
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.18/buster/Dockerfile
+++ b/src/microsoft/1.18/buster/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:buster-scm
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:buster-scm
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.18/stretch/Dockerfile
+++ b/src/microsoft/1.18/stretch/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:stretch-scm
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:stretch-scm
 
 # install cgo-related dependencies
 RUN set -eux; \


### PR DESCRIPTION
* Fixes https://github.com/microsoft/go/issues/562

This PR adds a patch to the template that's used to create the Debian images, changing the FROM to point to a mirror on MAR (MCR) rather than Docker Hub, for supply chain reasons. (First commit)

Changing the FROM line to point to MAR rather than parameterizing it in some way keeps it simple and easy to reproduce any issues locally. (Situations where parameterizing makes sense would be: if these Dockerfiles were the "primary" ones for an open source tool, or if we didn't already have patching infrastructure in place.)

The MAR mirror seems to behave differently from Docker Hub when it comes to the Docker manifest. We're using .NET Docker tooling for our CI, which uses `manifest-tool`, which didn't seem to be able to handle it, [getting a 404 error](https://dev.azure.com/dnceng/internal/_build/results?buildId=1805424&view=logs&j=fc59f0f2-c1bd-58ae-b870-833d1e8a924c&t=8d53baa0-ff68-5ea5-041a-af0e08303d7f&l=214) from MAR. A newer version of the .NET Docker tooling [switches to a custom implementation rather than using `manifest-tool` for this part of the build](https://github.com/dotnet/docker-tools/pull/998), fixing this issue. (Although perhaps by accident--I didn't dig much into the root cause. We should keep the .NET Docker tooling up to date anyway.) So by upgrading our tooling, this error is fixed. (Second commit)

The new .NET Docker tooling has a minor breaking change in the manifest.json schema, an easy fix. (Third commit)

---

I recommend reviewing commit 1 and 3 individually.

2 is short enough to review, but it's just copying `eng/common` files over with `cp -r ...`. The change here that affects us is `image-builder:1689405` -> `image-builder:1784901`.