### PR TITLE
Add main (1.19) and main FIPS tags

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -535,6 +535,418 @@
               }
             }
           ]
+        },
+        {
+          "productVersion": "42.42",
+          "sharedTags": {
+            "main": {},
+            "main-bullseye": {}
+          },
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/main/bullseye",
+              "os": "linux",
+              "osVersion": "bullseye",
+              "tags": {
+                "main-bullseye-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/main/bullseye",
+              "os": "linux",
+              "osVersion": "bullseye",
+              "tags": {
+                "main-bullseye-arm64v8": {}
+              }
+            },
+            {
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/main/bullseye",
+              "os": "linux",
+              "osVersion": "bullseye",
+              "tags": {
+                "main-bullseye-arm32v7": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "42.42",
+          "sharedTags": {
+            "main-buster": {}
+          },
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/main/buster",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "main-buster-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/main/buster",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "main-buster-arm64v8": {}
+              }
+            },
+            {
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/main/buster",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "main-buster-arm32v7": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "42.42",
+          "sharedTags": {
+            "main-stretch": {}
+          },
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/main/stretch",
+              "os": "linux",
+              "osVersion": "stretch",
+              "tags": {
+                "main-stretch-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/main/stretch",
+              "os": "linux",
+              "osVersion": "stretch",
+              "tags": {
+                "main-stretch-arm64v8": {}
+              }
+            },
+            {
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/main/stretch",
+              "os": "linux",
+              "osVersion": "stretch",
+              "tags": {
+                "main-stretch-arm32v7": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "42.42",
+          "sharedTags": {
+            "main-cbl-mariner1.0": {}
+          },
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/main/cbl-mariner1.0",
+              "os": "linux",
+              "osVersion": "cbl-mariner1.0",
+              "tags": {
+                "main-cbl-mariner1.0-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/microsoft/main/cbl-mariner1.0",
+              "os": "linux",
+              "osVersion": "cbl-mariner1.0",
+              "tags": {
+                "main-cbl-mariner1.0-arm64v8": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "42.42",
+          "sharedTags": {
+            "main-fips-bullseye": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "FROM_TAG": "main-bullseye-amd64",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/main/fips-linux/bullseye",
+              "os": "linux",
+              "osVersion": "bullseye",
+              "tags": {
+                "main-fips-bullseye-amd64": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "FROM_TAG": "main-bullseye-arm64v8",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/main/fips-linux/bullseye",
+              "os": "linux",
+              "osVersion": "bullseye",
+              "tags": {
+                "main-fips-bullseye-arm64v8": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "FROM_TAG": "main-bullseye-arm32v7",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/main/fips-linux/bullseye",
+              "os": "linux",
+              "osVersion": "bullseye",
+              "tags": {
+                "main-fips-bullseye-arm32v7": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "42.42",
+          "sharedTags": {
+            "main-fips-buster": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "FROM_TAG": "main-buster-amd64",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/main/fips-linux/buster",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "main-fips-buster-amd64": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "FROM_TAG": "main-buster-arm64v8",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/main/fips-linux/buster",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "main-fips-buster-arm64v8": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "FROM_TAG": "main-buster-arm32v7",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/main/fips-linux/buster",
+              "os": "linux",
+              "osVersion": "buster",
+              "tags": {
+                "main-fips-buster-arm32v7": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "42.42",
+          "sharedTags": {
+            "main-fips-stretch": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "FROM_TAG": "main-stretch-amd64",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/main/fips-linux/stretch",
+              "os": "linux",
+              "osVersion": "stretch",
+              "tags": {
+                "main-fips-stretch-amd64": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "FROM_TAG": "main-stretch-arm64v8",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/main/fips-linux/stretch",
+              "os": "linux",
+              "osVersion": "stretch",
+              "tags": {
+                "main-fips-stretch-arm64v8": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "FROM_TAG": "main-stretch-arm32v7",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/main/fips-linux/stretch",
+              "os": "linux",
+              "osVersion": "stretch",
+              "tags": {
+                "main-fips-stretch-arm32v7": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "42.42",
+          "sharedTags": {
+            "main-fips-cbl-mariner1.0": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "FROM_TAG": "main-cbl-mariner1.0-amd64",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/main/fips-linux/cbl-mariner1.0",
+              "os": "linux",
+              "osVersion": "cbl-mariner1.0",
+              "tags": {
+                "main-fips-cbl-mariner1.0-amd64": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "FROM_TAG": "main-cbl-mariner1.0-arm64v8",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "arm64",
+              "dockerfile": "src/microsoft/main/fips-linux/cbl-mariner1.0",
+              "os": "linux",
+              "osVersion": "cbl-mariner1.0",
+              "tags": {
+                "main-fips-cbl-mariner1.0-arm64v8": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "42.42",
+          "sharedTags": {
+            "main-windowsservercore-ltsc2022": {}
+          },
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/main/windows/windowsservercore-ltsc2022",
+              "os": "windows",
+              "osVersion": "windowsservercore-ltsc2022",
+              "tags": {
+                "main-windowsservercore-ltsc2022-amd64": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "42.42",
+          "sharedTags": {
+            "main-windowsservercore-1809": {}
+          },
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/main/windows/windowsservercore-1809",
+              "os": "windows",
+              "osVersion": "windowsservercore-1809",
+              "tags": {
+                "main-windowsservercore-1809-amd64": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "42.42",
+          "sharedTags": {
+            "main-windowsservercore-ltsc2016": {}
+          },
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/main/windows/windowsservercore-ltsc2016",
+              "os": "windows",
+              "osVersion": "windowsservercore-ltsc2016",
+              "tags": {
+                "main-windowsservercore-ltsc2016-amd64": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "42.42",
+          "sharedTags": {
+            "main-nanoserver-ltsc2022": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "DOWNLOADER_TAG": "main-windowsservercore-ltsc2022-amd64",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/main/windows/nanoserver-ltsc2022",
+              "os": "windows",
+              "osVersion": "nanoserver-ltsc2022",
+              "tags": {
+                "main-nanoserver-ltsc2022-amd64": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "42.42",
+          "sharedTags": {
+            "main-nanoserver-1809": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "DOWNLOADER_TAG": "main-windowsservercore-1809-amd64",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/main/windows/nanoserver-1809",
+              "os": "windows",
+              "osVersion": "nanoserver-1809",
+              "tags": {
+                "main-nanoserver-1809-amd64": {}
+              }
+            }
+          ]
         }
       ]
     }

--- a/patches/0004-Add-support-for-fips-linux-variant-in-microsoft-go-i.patch
+++ b/patches/0004-Add-support-for-fips-linux-variant-in-microsoft-go-i.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: microsoft-golang-bot <microsoft-golang-bot@users.noreply.github.com>
+Date: Wed, 1 Jun 2022 12:03:45 -0500
+Subject: [PATCH] Add support for "fips-linux/*" variant in microsoft/go-images
+
+---
+ apply-templates.sh | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/apply-templates.sh b/apply-templates.sh
+index eaceaca..16f8ebb 100755
+--- a/apply-templates.sh
++++ b/apply-templates.sh
+@@ -50,6 +50,10 @@ for version; do
+ 				template="Dockerfile-windows-$windowsVariant.template"
+ 				;;
+ 
++			fips-linux/*)
++				template="Dockerfile-fips-linux.template"
++				;;
++
+ 			*)
+ 				template='Dockerfile-linux.template'
+ 				;;

--- a/src/microsoft/.gitignore
+++ b/src/microsoft/.gitignore
@@ -3,3 +3,5 @@
 # "apply-templates.sh" script use them while it runs from this directory. They
 # are effectively build artifacts.
 /Dockerfile-*.template
+# Include a Dockerfile template that we maintain here, not relevant to upstream.
+!/Dockerfile-fips-*.template

--- a/src/microsoft/Dockerfile-fips-linux.template
+++ b/src/microsoft/Dockerfile-fips-linux.template
@@ -1,0 +1,12 @@
+# This Dockerfile is based on our non-FIPS Dockerfile, but then adds a layer that enables the
+# OpenSSL-backed FIPS mode by default.
+#
+# The ARG default values are here for anyone who builds this repository without the .NET Docker
+# build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
+# The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
+ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
+ARG FROM_TAG={{ .version }}{{ if .revision != null then ("-" + .revision) else "" end }}-{{ env.variant }}
+
+FROM $REPO:$FROM_TAG
+
+ENV GOEXPERIMENT opensslcrypto

--- a/src/microsoft/main/bullseye/Dockerfile
+++ b/src/microsoft/main/bullseye/Dockerfile
@@ -1,0 +1,109 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM buildpack-deps:bullseye-scm
+
+# install cgo-related dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION main
+
+RUN set -eux; \
+	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+	url=; \
+	case "$arch" in \
+		'amd64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.linux-amd64.tar.gz'; \
+			sha256='12b1a5d4bf89cefef2cd921c65ba9ddb818b15eea5ee0b180db79ee9bc165b1f'; \
+			;; \
+		'armhf') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.linux-armv6l.tar.gz'; \
+			sha256='f9042b01220bd6ae7adb3e09717569443a3a99507f6941c205cae277e3cad22c'; \
+			;; \
+		'arm64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.linux-arm64.tar.gz'; \
+			sha256='9b4a78aa4395d6a724261ec822c452c07f96d7af9d52b5d04d0f5b71e0e5a283'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	build=; \
+	if [ -z "$url" ]; then \
+# https://github.com/golang/go/issues/38536#issuecomment-616897960
+		build=1; \
+		url=null; \
+		sha256=null; \
+		echo >&2; \
+		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
+		echo >&2; \
+	fi; \
+	\
+	wget -O go.tgz.asc "$url.sig"; \
+	wget -O go.tgz "$url" --progress=dot:giga; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
+	gpg --batch --import microsoft-managed-lang-compiler.asc; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	if [ -n "$build" ]; then \
+		savedAptMark="$(apt-mark showmanual)"; \
+		apt-get update; \
+		apt-get install -y --no-install-recommends golang-go; \
+		\
+		export GOCACHE='/tmp/gocache'; \
+		\
+		( \
+			cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+			./make.bash; \
+		); \
+		\
+		apt-mark auto '.*' > /dev/null; \
+		apt-mark manual $savedAptMark > /dev/null; \
+		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+		rm -rf /var/lib/apt/lists/*; \
+		\
+# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
+		rm -rf \
+			/usr/local/go/pkg/*/cmd \
+			/usr/local/go/pkg/bootstrap \
+			/usr/local/go/pkg/obj \
+			/usr/local/go/pkg/tool/*/api \
+			/usr/local/go/pkg/tool/*/go_bootstrap \
+			/usr/local/go/src/cmd/dist/dist \
+			"$GOCACHE" \
+		; \
+	fi; \
+	\
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH

--- a/src/microsoft/main/buster/Dockerfile
+++ b/src/microsoft/main/buster/Dockerfile
@@ -1,0 +1,109 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM buildpack-deps:buster-scm
+
+# install cgo-related dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION main
+
+RUN set -eux; \
+	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+	url=; \
+	case "$arch" in \
+		'amd64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.linux-amd64.tar.gz'; \
+			sha256='12b1a5d4bf89cefef2cd921c65ba9ddb818b15eea5ee0b180db79ee9bc165b1f'; \
+			;; \
+		'armhf') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.linux-armv6l.tar.gz'; \
+			sha256='f9042b01220bd6ae7adb3e09717569443a3a99507f6941c205cae277e3cad22c'; \
+			;; \
+		'arm64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.linux-arm64.tar.gz'; \
+			sha256='9b4a78aa4395d6a724261ec822c452c07f96d7af9d52b5d04d0f5b71e0e5a283'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	build=; \
+	if [ -z "$url" ]; then \
+# https://github.com/golang/go/issues/38536#issuecomment-616897960
+		build=1; \
+		url=null; \
+		sha256=null; \
+		echo >&2; \
+		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
+		echo >&2; \
+	fi; \
+	\
+	wget -O go.tgz.asc "$url.sig"; \
+	wget -O go.tgz "$url" --progress=dot:giga; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
+	gpg --batch --import microsoft-managed-lang-compiler.asc; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	if [ -n "$build" ]; then \
+		savedAptMark="$(apt-mark showmanual)"; \
+		apt-get update; \
+		apt-get install -y --no-install-recommends golang-go; \
+		\
+		export GOCACHE='/tmp/gocache'; \
+		\
+		( \
+			cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+			./make.bash; \
+		); \
+		\
+		apt-mark auto '.*' > /dev/null; \
+		apt-mark manual $savedAptMark > /dev/null; \
+		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+		rm -rf /var/lib/apt/lists/*; \
+		\
+# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
+		rm -rf \
+			/usr/local/go/pkg/*/cmd \
+			/usr/local/go/pkg/bootstrap \
+			/usr/local/go/pkg/obj \
+			/usr/local/go/pkg/tool/*/api \
+			/usr/local/go/pkg/tool/*/go_bootstrap \
+			/usr/local/go/src/cmd/dist/dist \
+			"$GOCACHE" \
+		; \
+	fi; \
+	\
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH

--- a/src/microsoft/main/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/main/cbl-mariner1.0/Dockerfile
@@ -1,0 +1,108 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM cblmariner.azurecr.io/base/core:1.0
+
+RUN tdnf install -y \
+		binutils \
+		gcc \
+		glibc \
+		glibc-devel \
+		kernel-headers \
+		iana-etc \
+	; \
+	tdnf clean all
+
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION main
+
+RUN set -eux; \
+	arch="$(uname -m)"; \
+	url=; \
+	case "$arch" in \
+		'x86_64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.linux-amd64.tar.gz'; \
+			sha256='12b1a5d4bf89cefef2cd921c65ba9ddb818b15eea5ee0b180db79ee9bc165b1f'; \
+			;; \
+		'armv7') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.linux-armv6l.tar.gz'; \
+			sha256='f9042b01220bd6ae7adb3e09717569443a3a99507f6941c205cae277e3cad22c'; \
+			;; \
+		'aarch64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.linux-arm64.tar.gz'; \
+			sha256='9b4a78aa4395d6a724261ec822c452c07f96d7af9d52b5d04d0f5b71e0e5a283'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	build=; \
+	if [ -z "$url" ]; then \
+# https://github.com/golang/go/issues/38536#issuecomment-616897960
+		build=1; \
+		url=null; \
+		sha256=null; \
+		echo >&2; \
+		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
+		echo >&2; \
+	fi; \
+	\
+	wget -O go.tgz.asc "$url.sig"; \
+	wget -O go.tgz "$url" --progress=dot:giga; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
+	gpg --batch --import microsoft-managed-lang-compiler.asc; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	if [ -n "$build" ]; then \
+		savedAptMark="$(apt-mark showmanual)"; \
+		apt-get update; \
+		apt-get install -y --no-install-recommends golang-go; \
+		\
+		export GOCACHE='/tmp/gocache'; \
+		\
+		( \
+			cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+			./make.bash; \
+		); \
+		\
+		apt-mark auto '.*' > /dev/null; \
+		apt-mark manual $savedAptMark > /dev/null; \
+		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+		rm -rf /var/lib/apt/lists/*; \
+		\
+# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
+		rm -rf \
+			/usr/local/go/pkg/*/cmd \
+			/usr/local/go/pkg/bootstrap \
+			/usr/local/go/pkg/obj \
+			/usr/local/go/pkg/tool/*/api \
+			/usr/local/go/pkg/tool/*/go_bootstrap \
+			/usr/local/go/src/cmd/dist/dist \
+			"$GOCACHE" \
+		; \
+	fi; \
+	\
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH

--- a/src/microsoft/main/fips-linux/bullseye/Dockerfile
+++ b/src/microsoft/main/fips-linux/bullseye/Dockerfile
@@ -1,0 +1,18 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# This Dockerfile is based on our non-FIPS Dockerfile, but then adds a layer that enables the
+# OpenSSL-backed FIPS mode by default.
+#
+# The ARG default values are here for anyone who builds this repository without the .NET Docker
+# build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
+# The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
+ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
+ARG FROM_TAG=main-bullseye
+
+FROM $REPO:$FROM_TAG
+
+ENV GOEXPERIMENT opensslcrypto

--- a/src/microsoft/main/fips-linux/buster/Dockerfile
+++ b/src/microsoft/main/fips-linux/buster/Dockerfile
@@ -1,0 +1,18 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# This Dockerfile is based on our non-FIPS Dockerfile, but then adds a layer that enables the
+# OpenSSL-backed FIPS mode by default.
+#
+# The ARG default values are here for anyone who builds this repository without the .NET Docker
+# build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
+# The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
+ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
+ARG FROM_TAG=main-buster
+
+FROM $REPO:$FROM_TAG
+
+ENV GOEXPERIMENT opensslcrypto

--- a/src/microsoft/main/fips-linux/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/main/fips-linux/cbl-mariner1.0/Dockerfile
@@ -1,0 +1,18 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# This Dockerfile is based on our non-FIPS Dockerfile, but then adds a layer that enables the
+# OpenSSL-backed FIPS mode by default.
+#
+# The ARG default values are here for anyone who builds this repository without the .NET Docker
+# build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
+# The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
+ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
+ARG FROM_TAG=main-cbl-mariner1.0
+
+FROM $REPO:$FROM_TAG
+
+ENV GOEXPERIMENT opensslcrypto

--- a/src/microsoft/main/fips-linux/stretch/Dockerfile
+++ b/src/microsoft/main/fips-linux/stretch/Dockerfile
@@ -1,0 +1,18 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# This Dockerfile is based on our non-FIPS Dockerfile, but then adds a layer that enables the
+# OpenSSL-backed FIPS mode by default.
+#
+# The ARG default values are here for anyone who builds this repository without the .NET Docker
+# build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
+# The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
+ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
+ARG FROM_TAG=main-stretch
+
+FROM $REPO:$FROM_TAG
+
+ENV GOEXPERIMENT opensslcrypto

--- a/src/microsoft/main/stretch/Dockerfile
+++ b/src/microsoft/main/stretch/Dockerfile
@@ -1,0 +1,109 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM buildpack-deps:stretch-scm
+
+# install cgo-related dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION main
+
+RUN set -eux; \
+	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+	url=; \
+	case "$arch" in \
+		'amd64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.linux-amd64.tar.gz'; \
+			sha256='12b1a5d4bf89cefef2cd921c65ba9ddb818b15eea5ee0b180db79ee9bc165b1f'; \
+			;; \
+		'armhf') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.linux-armv6l.tar.gz'; \
+			sha256='f9042b01220bd6ae7adb3e09717569443a3a99507f6941c205cae277e3cad22c'; \
+			;; \
+		'arm64') \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.linux-arm64.tar.gz'; \
+			sha256='9b4a78aa4395d6a724261ec822c452c07f96d7af9d52b5d04d0f5b71e0e5a283'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	build=; \
+	if [ -z "$url" ]; then \
+# https://github.com/golang/go/issues/38536#issuecomment-616897960
+		build=1; \
+		url=null; \
+		sha256=null; \
+		echo >&2; \
+		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
+		echo >&2; \
+	fi; \
+	\
+	wget -O go.tgz.asc "$url.sig"; \
+	wget -O go.tgz "$url" --progress=dot:giga; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
+	gpg --batch --import microsoft-managed-lang-compiler.asc; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	if [ -n "$build" ]; then \
+		savedAptMark="$(apt-mark showmanual)"; \
+		apt-get update; \
+		apt-get install -y --no-install-recommends golang-go; \
+		\
+		export GOCACHE='/tmp/gocache'; \
+		\
+		( \
+			cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+			./make.bash; \
+		); \
+		\
+		apt-mark auto '.*' > /dev/null; \
+		apt-mark manual $savedAptMark > /dev/null; \
+		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+		rm -rf /var/lib/apt/lists/*; \
+		\
+# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
+		rm -rf \
+			/usr/local/go/pkg/*/cmd \
+			/usr/local/go/pkg/bootstrap \
+			/usr/local/go/pkg/obj \
+			/usr/local/go/pkg/tool/*/api \
+			/usr/local/go/pkg/tool/*/go_bootstrap \
+			/usr/local/go/src/cmd/dist/dist \
+			"$GOCACHE" \
+		; \
+	fi; \
+	\
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH

--- a/src/microsoft/main/windows/nanoserver-1809/Dockerfile
+++ b/src/microsoft/main/windows/nanoserver-1809/Dockerfile
@@ -1,0 +1,36 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
+# It's easy to download Go and install it in server core, but not nanoserver. So, to build
+# nanoserver, copy over the server core installation.
+ARG DOWNLOADER_TAG=main-windowsservercore-1809
+FROM $REPO:$DOWNLOADER_TAG AS downloader
+
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+SHELL ["cmd", "/S", "/C"]
+
+# no Git installed (intentionally)
+#  -- Nano Server is "Windows Slim"
+
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+USER ContainerAdministrator
+RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
+USER ContainerUser
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION main
+
+# Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
+COPY --from=downloader ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]
+RUN go version
+
+WORKDIR $GOPATH

--- a/src/microsoft/main/windows/nanoserver-ltsc2022/Dockerfile
+++ b/src/microsoft/main/windows/nanoserver-ltsc2022/Dockerfile
@@ -1,0 +1,36 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
+# It's easy to download Go and install it in server core, but not nanoserver. So, to build
+# nanoserver, copy over the server core installation.
+ARG DOWNLOADER_TAG=main-windowsservercore-ltsc2022
+FROM $REPO:$DOWNLOADER_TAG AS downloader
+
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+
+SHELL ["cmd", "/S", "/C"]
+
+# no Git installed (intentionally)
+#  -- Nano Server is "Windows Slim"
+
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+USER ContainerAdministrator
+RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
+USER ContainerUser
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION main
+
+# Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
+COPY --from=downloader ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]
+RUN go version
+
+WORKDIR $GOPATH

--- a/src/microsoft/main/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/main/windows/windowsservercore-1809/Dockerfile
@@ -1,0 +1,84 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:1809
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# install MinGit (especially for "go get")
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
+ENV GIT_VERSION 2.23.0
+ENV GIT_TAG v${GIT_VERSION}.windows.1
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
+ENV GIT_DOWNLOAD_SHA256 8f65208f92c0b4c3ae4c0cf02d4b5f6791d539cd1a07b2df62b7116467724735
+# steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
+RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
+	if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive -Path git.zip -DestinationPath C:\git\.; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item git.zip -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ("git version") ...'; \
+	git version; \
+	\
+	Write-Host 'Complete.';
+
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION main
+
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.windows-amd64.zip'; \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
+	\
+	$sha256 = 'd0f207282aedb80236251c4e443793164c5445bf922223e9631f49b233491ef9'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Moving ...'; \
+	Move-Item -Path C:\go -Destination 'C:\Program Files\Go'; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Complete.';
+
+WORKDIR $GOPATH

--- a/src/microsoft/main/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/src/microsoft/main/windows/windowsservercore-ltsc2016/Dockerfile
@@ -1,0 +1,84 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# install MinGit (especially for "go get")
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
+ENV GIT_VERSION 2.23.0
+ENV GIT_TAG v${GIT_VERSION}.windows.1
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
+ENV GIT_DOWNLOAD_SHA256 8f65208f92c0b4c3ae4c0cf02d4b5f6791d539cd1a07b2df62b7116467724735
+# steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
+RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
+	if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive -Path git.zip -DestinationPath C:\git\.; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item git.zip -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ("git version") ...'; \
+	git version; \
+	\
+	Write-Host 'Complete.';
+
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION main
+
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.windows-amd64.zip'; \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
+	\
+	$sha256 = 'd0f207282aedb80236251c4e443793164c5445bf922223e9631f49b233491ef9'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Moving ...'; \
+	Move-Item -Path C:\go -Destination 'C:\Program Files\Go'; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Complete.';
+
+WORKDIR $GOPATH

--- a/src/microsoft/main/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/main/windows/windowsservercore-ltsc2022/Dockerfile
@@ -1,0 +1,84 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# install MinGit (especially for "go get")
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
+ENV GIT_VERSION 2.23.0
+ENV GIT_TAG v${GIT_VERSION}.windows.1
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
+ENV GIT_DOWNLOAD_SHA256 8f65208f92c0b4c3ae4c0cf02d4b5f6791d539cd1a07b2df62b7116467724735
+# steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
+RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
+	if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive -Path git.zip -DestinationPath C:\git\.; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item git.zip -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ("git version") ...'; \
+	git version; \
+	\
+	Write-Host 'Complete.';
+
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION main
+
+RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.windows-amd64.zip'; \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
+	\
+	$sha256 = 'd0f207282aedb80236251c4e443793164c5445bf922223e9631f49b233491ef9'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Moving ...'; \
+	Move-Item -Path C:\go -Destination 'C:\Program Files\Go'; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Complete.';
+
+WORKDIR $GOPATH

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -201,5 +201,63 @@
     "preferredMinor": true,
     "preferredVariant": "cbl-mariner1.0",
     "branchSuffix": "-fips"
+  },
+  "main": {
+    "arches": {
+      "amd64": {
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "linux"
+        },
+        "sha256": "12b1a5d4bf89cefef2cd921c65ba9ddb818b15eea5ee0b180db79ee9bc165b1f",
+        "supported": true,
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.linux-amd64.tar.gz"
+      },
+      "arm32v7": {
+        "env": {
+          "GOARCH": "arm",
+          "GOARM": "7",
+          "GOOS": "linux"
+        },
+        "sha256": "f9042b01220bd6ae7adb3e09717569443a3a99507f6941c205cae277e3cad22c",
+        "supported": true,
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.linux-armv6l.tar.gz"
+      },
+      "arm64v8": {
+        "env": {
+          "GOARCH": "arm64",
+          "GOOS": "linux"
+        },
+        "sha256": "9b4a78aa4395d6a724261ec822c452c07f96d7af9d52b5d04d0f5b71e0e5a283",
+        "supported": true,
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.linux-arm64.tar.gz"
+      },
+      "windows-amd64": {
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "windows"
+        },
+        "sha256": "d0f207282aedb80236251c4e443793164c5445bf922223e9631f49b233491ef9",
+        "supported": true,
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/main/20220530.1/go.20220530.1.windows-amd64.zip"
+      }
+    },
+    "variants": [
+      "bullseye",
+      "buster",
+      "stretch",
+      "cbl-mariner1.0",
+      "fips-linux/bullseye",
+      "fips-linux/buster",
+      "fips-linux/stretch",
+      "fips-linux/cbl-mariner1.0",
+      "windows/windowsservercore-ltsc2022",
+      "windows/windowsservercore-1809",
+      "windows/windowsservercore-ltsc2016",
+      "windows/nanoserver-ltsc2022",
+      "windows/nanoserver-1809"
+    ],
+    "version": "main",
+    "preferredVariant": "bullseye"
   }
 }


### PR DESCRIPTION
Add microsoft/go `main` builds to the microsoft/go-images `microsoft/nightly` branch. Add FIPS tags that build on top of them and set `GOEXPERIMENT=opensslcrypto` by default.

* For proper manifest.json generation, depends on: https://github.com/microsoft/go-infra/pull/45
* Part of https://github.com/microsoft/go/issues/501

The plan is to only build `main` tags in this repo's `microsoft/nightly` branch, not the MAR/MCR-targeting `microsoft/main` branch. Builds that come out of microsoft/go's `microsoft/main` branch never belong on MAR, only in our public ACR for evaluation purposes.

Once 1.19 is released and there's a release branch, the FIPS tags will be included in MAR builds.

Having go-images produce nightly builds based on `microsoft/main` will help us make sure our `microsoft/main` changes are ready for the coming 1.19 release. In the future it will help with 1.20, etc.

Review tips:
* The Dockerfile diffs are not loaded by default because they're generated--I suggest taking a peek at one from each `variant` type to see the templates in action.
* The `manifest.json` is generated from `versions.json`. https://github.com/microsoft/go-infra/pull/45 has more context on the details in this file.

Example internal build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1806155&view=results