### PR TITLE
[nightly] Add CBL-Mariner 2.0 images

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -265,6 +265,34 @@
           ]
         },
         {
+          "productVersion": "1.17",
+          "sharedTags": {
+            "1.17-fips-cbl-mariner2.0": {},
+            "1.17.11-1-fips-cbl-mariner2.0": {},
+            "1.17.11-fips-cbl-mariner2.0": {}
+          },
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/1.17-fips/cbl-mariner2.0",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "1.17.11-1-fips-cbl-mariner2.0-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/microsoft/1.17-fips/cbl-mariner2.0",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "1.17.11-1-fips-cbl-mariner2.0-arm64v8": {}
+              }
+            }
+          ]
+        },
+        {
           "productVersion": "1.18",
           "sharedTags": {
             "1": {},
@@ -534,6 +562,35 @@
               "osVersion": "cbl-mariner1.0",
               "tags": {
                 "1.18.3-1-fips-cbl-mariner1.0-arm64v8": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "1.18",
+          "sharedTags": {
+            "1-fips-cbl-mariner2.0": {},
+            "1.18-fips-cbl-mariner2.0": {},
+            "1.18.3-1-fips-cbl-mariner2.0": {},
+            "1.18.3-fips-cbl-mariner2.0": {}
+          },
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/1.18-fips/cbl-mariner2.0",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "1.18.3-1-fips-cbl-mariner2.0-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "dockerfile": "src/microsoft/1.18-fips/cbl-mariner2.0",
+              "os": "linux",
+              "osVersion": "cbl-mariner2.0",
+              "tags": {
+                "1.18.3-1-fips-cbl-mariner2.0-arm64v8": {}
               }
             }
           ]

--- a/patches/0002-Add-Mariner-support-with-FIPS-dependency-flag.patch
+++ b/patches/0002-Add-Mariner-support-with-FIPS-dependency-flag.patch
@@ -4,11 +4,11 @@ Date: Fri, 11 Feb 2022 18:07:18 -0600
 Subject: [PATCH] Add Mariner support with FIPS dependency flag
 
 ---
- Dockerfile-linux.template | 48 +++++++++++++++++++++++++++++++++++++++
- 1 file changed, 48 insertions(+)
+ Dockerfile-linux.template | 56 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 56 insertions(+)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index a79ec02..106f1d0 100644
+index 1b0639f..9130e4f 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
 @@ -4,6 +4,16 @@
@@ -28,7 +28,7 @@ index a79ec02..106f1d0 100644
  -}}
  {{ if is_alpine then ( -}}
  FROM alpine:{{ alpine_version }}
-@@ -14,6 +24,27 @@ RUN apk add --no-cache ca-certificates
+@@ -14,6 +24,29 @@ RUN apk add --no-cache ca-certificates
  # - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
  # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
  RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
@@ -40,8 +40,10 @@ index a79ec02..106f1d0 100644
 +		gcc \
 +		glibc \
 +		glibc-devel \
-+		kernel-headers \
 +		iana-etc \
++		kernel-headers \
++		tar \
++		wget \
 +{{
 +	if is_fips then (
 +-}}
@@ -56,7 +58,7 @@ index a79ec02..106f1d0 100644
  {{ ) else ( -}}
  FROM buildpack-deps:{{ env.variant }}-scm
  
-@@ -26,6 +57,14 @@ RUN set -eux; \
+@@ -26,6 +59,14 @@ RUN set -eux; \
  		libc6-dev \
  		make \
  		pkg-config \
@@ -71,7 +73,7 @@ index a79ec02..106f1d0 100644
  	; \
  	rm -rf /var/lib/apt/lists/*
  {{ ) end -}}
-@@ -46,6 +85,13 @@ ENV GOLANG_VERSION {{ .version }}
+@@ -46,6 +87,13 @@ ENV GOLANG_VERSION {{ .version }}
  				ppc64le: "ppc64le",
  				s390x: "s390x",
  			}
@@ -85,7 +87,7 @@ index a79ec02..106f1d0 100644
  		else
  			{
  				amd64: "amd64",
-@@ -63,6 +109,8 @@ RUN set -eux; \
+@@ -63,6 +111,8 @@ RUN set -eux; \
  {{ if is_alpine then ( -}}
  	apk add --no-cache --virtual .fetch-deps gnupg; \
  	arch="$(apk --print-arch)"; \
@@ -94,3 +96,20 @@ index a79ec02..106f1d0 100644
  {{ ) else ( -}}
  	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
  {{ ) end -}}
+@@ -117,10 +167,16 @@ RUN set -eux; \
+ 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+ 	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
+ 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
++{{ if is_cbl_mariner then ( -}}
++# Mariner 2.0 doesn't include dirmngr, which is required for keyserver import. Skipping keyserver
++# import. In microsoft/go-images, we use a manually imported key anyway.
++# See https://github.com/microsoft/CBL-Mariner/issues/3142
++{{ ) else ( -}}
+ # https://www.google.com/linuxrepositories/
+ 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+ # let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+ 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
++{{ ) end -}}
+ 	gpg --batch --verify go.tgz.asc go.tgz; \
+ 	gpgconf --kill all; \
+ 	rm -rf "$GNUPGHOME" go.tgz.asc; \

--- a/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner1.0/Dockerfile
@@ -11,8 +11,10 @@ RUN tdnf install -y \
 		gcc \
 		glibc \
 		glibc-devel \
-		kernel-headers \
 		iana-etc \
+		kernel-headers \
+		tar \
+		wget \
 		# Install OpenSSL for headers when building a FIPS-compatible app with Go.
 		openssl-devel \
 	; \
@@ -56,10 +58,9 @@ RUN set -eux; \
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
 	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
-# https://www.google.com/linuxrepositories/
-	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
-# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
-	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+# Mariner 2.0 doesn't include dirmngr, which is required for keyserver import. Skipping keyserver
+# import. In microsoft/go-images, we use a manually imported key anyway.
+# See https://github.com/microsoft/CBL-Mariner/issues/3142
 	gpg --batch --verify go.tgz.asc go.tgz; \
 	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" go.tgz.asc; \

--- a/src/microsoft/1.17-fips/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.17-fips/cbl-mariner2.0/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM cblmariner.azurecr.io/base/core:1.0
+FROM cblmariner.azurecr.io/base/core:2.0
 
 RUN tdnf install -y \
 		binutils \
@@ -23,19 +23,19 @@ RUN tdnf install -y \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.18.3
+ENV GOLANG_VERSION 1.17.11
 
 RUN set -eux; \
 	arch="$(uname -m)"; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220602.6/go.20220602.6.linux-amd64.tar.gz'; \
-			sha256='48c7751dde281bdbf83224c7cb20381a4b3b9e1c7948d096dc1a9cdce8422f84'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220602.4/go.20220602.4.linux-amd64.tar.gz'; \
+			sha256='20f5466978a739fb8c6672fedbd47ef1602511367860869915ebbdbdb0ded741'; \
 			;; \
 		'aarch64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220602.6/go.20220602.6.linux-arm64.tar.gz'; \
-			sha256='0e3888b6a4cd1a9148344f8d6f3f1568c240d1e829c00c7dc154af293db5690e'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.17/20220602.4/go.20220602.4.linux-arm64.tar.gz'; \
+			sha256='c2b392b9fe30ecef3d545b11cb4e7fafcf4c704fccab9e5fe67f7a40fc942e1c'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.18-fips/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.18-fips/cbl-mariner2.0/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM cblmariner.azurecr.io/base/core:1.0
+FROM cblmariner.azurecr.io/base/core:2.0
 
 RUN tdnf install -y \
 		binutils \

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -92,7 +92,8 @@
       }
     },
     "variants": [
-      "cbl-mariner1.0"
+      "cbl-mariner1.0",
+      "cbl-mariner2.0"
     ],
     "version": "1.17.11",
     "revision": "1",
@@ -194,7 +195,8 @@
       }
     },
     "variants": [
-      "cbl-mariner1.0"
+      "cbl-mariner1.0",
+      "cbl-mariner2.0"
     ],
     "version": "1.18.3",
     "revision": "1",


### PR DESCRIPTION
Add CBL-Mariner 2.0 images, keeping 1.0 images.

* For https://github.com/microsoft/go/issues/462

A few patch changes to accommodate 2.0, nothing major:

* Explicitly add some package dependencies that are no longer included by default in Mariner 2.0. Luckily all the package names are available in 1.0, so I didn't need to add any new conditions here.
* Remove use of `gpg --batch --keyserver keyserver.ubuntu.com` because it no longer works in 2.0:
  https://github.com/microsoft/CBL-Mariner/issues/3142

A tooling change (microsoft/go-infra) is needed to generate the manifest.json properly:

* https://github.com/microsoft/go-infra/pull/47

Test build/images seem fine to me. FIPS mode still works with a [simple test program](https://github.com/microsoft/go/issues/548#issuecomment-1139160775) in the Mariner 2.0 image.
https://dev.azure.com/dnceng/internal/_build/results?buildId=1816190&view=logs&j=739bb7ec-7296-5b40-7dff-ee3297bfdaa4&t=ed040f87-8030-5678-c9e0-051ac03fdf46&l=249

```
golangpublicimages.azurecr.io/nightly/oss/go/microsoft/golang:1.17-fips-cbl-mariner1.0
golangpublicimages.azurecr.io/nightly/oss/go/microsoft/golang:1.17-fips-cbl-mariner2.0
golangpublicimages.azurecr.io/nightly/oss/go/microsoft/golang:1.18-fips-cbl-mariner1.0
golangpublicimages.azurecr.io/nightly/oss/go/microsoft/golang:1.18-fips-cbl-mariner2.0
```

* (Created this on top of https://github.com/microsoft/go-images/pull/128 to get the latest build of Go. Will switch base branch once that merges.)

Once this goes in, my plan is to merge into `microsoft/main`, then queue build+publish for mariner2.0 specifically. This will put mariner 2.0 up on MAR without updating any other tags/manifests (yet).
