### PR TITLE
[nightly] Add ca-certificates to CBL-Mariner images

### DIFF
--- a/patches/0002-Add-Mariner-support-with-FIPS-dependency-flag.patch
+++ b/patches/0002-Add-Mariner-support-with-FIPS-dependency-flag.patch
@@ -4,11 +4,11 @@ Date: Fri, 11 Feb 2022 18:07:18 -0600
 Subject: [PATCH] Add Mariner support with FIPS dependency flag
 
 ---
- Dockerfile-linux.template | 56 +++++++++++++++++++++++++++++++++++++++
- 1 file changed, 56 insertions(+)
+ Dockerfile-linux.template | 59 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 59 insertions(+)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index d3edb012fdd768..44297b197089c8 100644
+index 291f460f8981e0..49e7c8ed8ff6f4 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
 @@ -4,6 +4,16 @@
@@ -28,7 +28,7 @@ index d3edb012fdd768..44297b197089c8 100644
  -}}
  {{ if is_alpine then ( -}}
  FROM alpine:{{ alpine_version }}
-@@ -14,6 +24,29 @@ RUN apk add --no-cache ca-certificates
+@@ -14,6 +24,32 @@ RUN apk add --no-cache ca-certificates
  # - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
  # - docker run --rm debian grep '^hosts:' /etc/nsswitch.conf
  RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
@@ -44,6 +44,9 @@ index d3edb012fdd768..44297b197089c8 100644
 +		kernel-headers \
 +		tar \
 +		wget \
++		# To reduce image size, CBL-Mariner image doesn't include full ca-certificates: https://github.com/microsoft/CBL-Mariner/issues/3563
++		# Full certs are expected in a builder-style image (e.g. to fetch dependencies), so install them.
++		ca-certificates \
 +{{
 +	if is_fips then (
 +-}}
@@ -58,7 +61,7 @@ index d3edb012fdd768..44297b197089c8 100644
  {{ ) else ( -}}
  FROM buildpack-deps:{{ env.variant }}-scm
  
-@@ -26,6 +59,14 @@ RUN set -eux; \
+@@ -26,6 +62,14 @@ RUN set -eux; \
  		libc6-dev \
  		make \
  		pkg-config \
@@ -73,7 +76,7 @@ index d3edb012fdd768..44297b197089c8 100644
  	; \
  	rm -rf /var/lib/apt/lists/*
  {{ ) end -}}
-@@ -46,6 +87,13 @@ ENV GOLANG_VERSION {{ .version }}
+@@ -46,6 +90,13 @@ ENV GOLANG_VERSION {{ .version }}
  				ppc64le: "ppc64le",
  				s390x: "s390x",
  			}
@@ -87,7 +90,7 @@ index d3edb012fdd768..44297b197089c8 100644
  		else
  			{
  				amd64: "amd64",
-@@ -63,6 +111,8 @@ RUN set -eux; \
+@@ -63,6 +114,8 @@ RUN set -eux; \
  {{ if is_alpine then ( -}}
  	apk add --no-cache --virtual .fetch-deps gnupg; \
  	arch="$(apk --print-arch)"; \
@@ -96,7 +99,7 @@ index d3edb012fdd768..44297b197089c8 100644
  {{ ) else ( -}}
  	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
  {{ ) end -}}
-@@ -117,10 +167,16 @@ RUN set -eux; \
+@@ -117,10 +170,16 @@ RUN set -eux; \
  	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
  	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
  	gpg --batch --import microsoft-managed-lang-compiler.asc; \

--- a/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.18-fips/cbl-mariner1.0/Dockerfile
@@ -15,6 +15,9 @@ RUN tdnf install -y \
 		kernel-headers \
 		tar \
 		wget \
+		# To reduce image size, CBL-Mariner image doesn't include full ca-certificates: https://github.com/microsoft/CBL-Mariner/issues/3563
+		# Full certs are expected in a builder-style image (e.g. to fetch dependencies), so install them.
+		ca-certificates \
 		# Install OpenSSL for headers when building a FIPS-compatible app with Go.
 		openssl-devel \
 	; \

--- a/src/microsoft/1.18-fips/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.18-fips/cbl-mariner2.0/Dockerfile
@@ -15,6 +15,9 @@ RUN tdnf install -y \
 		kernel-headers \
 		tar \
 		wget \
+		# To reduce image size, CBL-Mariner image doesn't include full ca-certificates: https://github.com/microsoft/CBL-Mariner/issues/3563
+		# Full certs are expected in a builder-style image (e.g. to fetch dependencies), so install them.
+		ca-certificates \
 		# Install OpenSSL for headers when building a FIPS-compatible app with Go.
 		openssl-devel \
 	; \

--- a/src/microsoft/1.19/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.19/cbl-mariner1.0/Dockerfile
@@ -15,6 +15,9 @@ RUN tdnf install -y \
 		kernel-headers \
 		tar \
 		wget \
+		# To reduce image size, CBL-Mariner image doesn't include full ca-certificates: https://github.com/microsoft/CBL-Mariner/issues/3563
+		# Full certs are expected in a builder-style image (e.g. to fetch dependencies), so install them.
+		ca-certificates \
 	; \
 	tdnf clean all
 

--- a/src/microsoft/1.19/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.19/cbl-mariner2.0/Dockerfile
@@ -15,6 +15,9 @@ RUN tdnf install -y \
 		kernel-headers \
 		tar \
 		wget \
+		# To reduce image size, CBL-Mariner image doesn't include full ca-certificates: https://github.com/microsoft/CBL-Mariner/issues/3563
+		# Full certs are expected in a builder-style image (e.g. to fetch dependencies), so install them.
+		ca-certificates \
 	; \
 	tdnf clean all
 

--- a/src/microsoft/main/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/main/cbl-mariner1.0/Dockerfile
@@ -15,6 +15,9 @@ RUN tdnf install -y \
 		kernel-headers \
 		tar \
 		wget \
+		# To reduce image size, CBL-Mariner image doesn't include full ca-certificates: https://github.com/microsoft/CBL-Mariner/issues/3563
+		# Full certs are expected in a builder-style image (e.g. to fetch dependencies), so install them.
+		ca-certificates \
 	; \
 	tdnf clean all
 

--- a/src/microsoft/main/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/main/cbl-mariner2.0/Dockerfile
@@ -15,6 +15,9 @@ RUN tdnf install -y \
 		kernel-headers \
 		tar \
 		wget \
+		# To reduce image size, CBL-Mariner image doesn't include full ca-certificates: https://github.com/microsoft/CBL-Mariner/issues/3563
+		# Full certs are expected in a builder-style image (e.g. to fetch dependencies), so install them.
+		ca-certificates \
 	; \
 	tdnf clean all
 


### PR DESCRIPTION
* For https://github.com/microsoft/go/issues/699

Our Debian base images have this package by default, but CBL-Mariner images don't. It is used to access proxy.golang.org and much more.