### PR TITLE
[main] Update README and detailed tag doc after 1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Docker images containing the Microsoft build of Go
 
-This repository creates Docker images that contain the Microsoft build of Go produced by the [microsoft/go](https://github.com/microsoft/go) repository. The tags are published on the Microsoft Container Registry (MCR) in the `oss/go/microsoft/golang` repository.
+This repository creates Docker images that contain the Microsoft build of Go produced by the [microsoft/go](https://github.com/microsoft/go) repository. The tags are published on the Microsoft Artifact Registry (MAR), formerly Microsoft Container Registry (MCR), in the `oss/go/microsoft/golang` repository.
 
-In general, the microsoft/go-images tag names match those available for the [Docker Hub golang official image](https://hub.docker.com/_/golang). To switch from the official image to one on MCR, it may be possible to simply prepend `mcr.microsoft.com/oss/go/microsoft/` to the official image you would normally use.
+The images produced by this repository are for general use within Microsoft and to produce FIPS-compliant Go apps. For other purposes, we recommend using the [Docker Hub golang official images](https://hub.docker.com/_/golang).
+
+For more information about building FIPS-compatible Go apps with the Microsoft Go tools, visit the [FIPS readme] and [user guide](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/fips/UserGuide.md) in the microsoft/go repository.
+
+## Recommended tags
+
+In general, the microsoft/go-images tag names match those available for the official images. To switch from the official image to one on MCR, it may be possible to simply prepend `mcr.microsoft.com/oss/go/microsoft/` to the official image you would normally use.
 
 This tag is recommended for general build scenarios:
 
@@ -10,22 +16,24 @@ This tag is recommended for general build scenarios:
 mcr.microsoft.com/oss/go/microsoft/golang:1.19-bullseye
 ```
 
-If you need to build a FIPS-compatible app, use a `fips` tag, such as:
+If you need to build a FIPS-compliant app, use a `fips` tag, such as:
 
 ```
 mcr.microsoft.com/oss/go/microsoft/golang:1.19-fips-cbl-mariner1.0
 ```
 
-For more information about building FIPS-compatible Go apps with the Microsoft Go tools, visit [the FIPS readme](https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips) and [user guide](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/fips/UserGuide.md) in the microsoft/go repository.
+When building a containerized FIPS-compliant app, in general we recommend using a [multi-stage Dockerfile](https://docs.docker.com/develop/develop-images/multistage-build/) that uses our `fips` tag in the builder stage and copies the built Go app into a minimal CBL-Mariner container to produce the final image.
 
-To view the full list of available Go tags in MCR:
+To view the full list of available Go tags in MAR:
 
-* Use the [Microsoft Container Registry API](https://mcr.microsoft.com/v2/oss/go/microsoft/golang/tags/list)
-  * The full tag URL is `mcr.microsoft.com/{name}:{tag}`
 * Visit the [AZCU Indexer](https://azcuindexer.azurewebsites.net/repositories/oss/go/microsoft/golang) (*Microsoft internal auth required*)
   * Click on a tag name to copy the full tag URL to your clipboard
+* Use the [Microsoft Artifact Registry API](https://mcr.microsoft.com/v2/oss/go/microsoft/golang/tags/list)
+  * The full tag URL is `mcr.microsoft.com/{name}:{tag}`
 
-See [Tags of microsoft/go-images](docs/tags.md) for more information about tag names and support.
+See [Tags of microsoft/go-images](docs/tags.md) for more information about tag support, more tag names, and the purpose of each image.
+
+> We don't build any Alpine images. See [microsoft/go#446](https://github.com/microsoft/go/issues/446).
 
 ## Is this repository a fork?
 
@@ -54,3 +62,5 @@ trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
+
+[FIPS readme]: https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -8,27 +8,31 @@ See [.NET Supported Tags](https://github.com/dotnet/dotnet-docker/blob/main/docu
 
 In go-images, a *simple tag* references the image for a specific version of Go, on a specific OS, on a specific platform. The only way to be more specific about a Go image is to use a digest instead of a tag.
 
-In general, these shouldn't be used in Dockerfile `FROM` statements. It would prevent auto-update to the latest, patched, images. It also prevents the Dockerfile from working on multiple architectures (`amd64`/`arm64`) when it otherwise might.
+In general, we don't recommend using these in Dockerfile `FROM` statements. It prevents auto-update to the latest, patched, images. It also prevents the Dockerfile from working on multiple architectures (`amd64`/`arm64`) when it otherwise might.
 
 Examples:
 
-* `1.17.7-1-bullseye-amd64`
-* `1.17.7-1-fips-cbl-mariner1.0-amd64`
+* `1.19.7-1-bullseye-amd64`
+* `1.19.7-1-fips-cbl-mariner1.0-amd64`
 
-> This document uses `1.17.7-1` as a placeholder for *the most recent release of Microsoft Go*. Check MCR for the actual latest tag versions and available OS/Distros.
+> This document uses `1.19.7-1` as a placeholder for *the most recent release of Microsoft Go*. Check MAR for the actual latest tag versions and available OS/Distros.
 
 # Shared tags
 
-A *shared tag* references images for multiple platforms. The Go shared tags have these characteristics:
+A *shared tag* references images for multiple platforms. When used in a Dockerfile or a Docker command, Docker downloads the correct image for the current platform from the list of images pointed to by the shared tag. Shared tags are generally manifest tags.
 
-* Include all architectures that are available in microsoft/go-images.
+In some cases there is no single correct choice: the `1.19` tag could download a CBL-Mariner image or a Debian Bullseye image, and could download `1.19.7-1` or `1.19.2-1`. The shared tags represent our recommendation for that particular tag name.
+
+The Go shared tags have these characteristics:
+
+* Include all architectures that we build.
 * When no OS/Distro is specified in the tag, use the most recent Debian distribution.
 * When a part of the version number is omitted, the most recent matching version is used.
 
 Examples:
 
-* `1.17-bullseye`
-* `1.17-fips-cbl-mariner1.0`
+* `1.19-bullseye`
+* `1.19-fips-cbl-mariner1.0`
 * `1`
 
 # Tag parts
@@ -38,25 +42,36 @@ Examples:
   * `revision` is the Microsoft revision of Go.
     * This is incremented when Microsoft needs to release a new microsoft/go build but upstream hasn't released a new version yet.
     * This is *not* incremented when there are Dockerfile-specific changes, base images change, or when platforms are added and removed.
-  * `extra` specifies that the image is specialized for a particular scenario.
-    * `-fips` is a only `extra` as of writing. It indicates the image is capable of building FIPS-compatible Go apps.
+  * `extra` is optional, indicating the image is specialized for a particular scenario.
+    * `-fips` is the only `extra` as of writing.
   * `os/distro` is the OS or Linux distribution of the base image.
   * `architecture` is the platform architecture of the image, e.g. `amd64`.
 
+## What is `-fips`?
+
+If a tag includes `-fips`, that indicates that Go build commands inside the container will set the `GOEXPERIMENT` environment variable to use a FIPS-compatible crypto backend by default. Be careful: this isn't the only step necessary to build a FIPS-compliant app. See the [FIPS readme] for more information about `GOEXPERIMENT` and FIPS.
+
+You don't need to use a `-fips` tag to build a FIPS-compliant app: you can use the non`-fips` image and set `GOEXPERIMENT` yourself. The Go toolset is the same in both images. We provide a `-fips` tag to minimize the changes necessary to make an existing Dockerfile build a FIPS-compliant app.
+
+**In Go 1.18 and earlier**, the `-fips` image contained a different branch of Go that was capable of building FIPS-compliant apps, and non`-fips` tags weren't able to build FIPS-compliant apps. `GOEXPERIMENT` was not involved in producing FIPS apps at this time. See the [FIPS readme] for more details.
+
 # Tag lifecycle
 
-The Go versions supported by this repo follow the support lifecycle of [microsoft/go](https://github.com/microsoft/go), which generates the Go binaries used in this repository. OS versions are supported until the OS is EOL. When a tag's Go support or OS support ends, the tag is no longer supported.
+The Go versions supported by this repo follow the support lifecycle of [microsoft/go](https://github.com/microsoft/go), which generates the Go binaries used in this repository. OS versions are supported until the OS is EOL. When a tag's Go support or OS support ends, the tag is no longer supported and we delete the Dockerfile when it's convenient to do so.
 
 The microsoft/go-images repository has two active branches:
 
 * `microsoft/main`
-  * This branch is updated when there is a new, stable release of microsoft/go, the underlying OS has a change that is important to users of the Microsoft Go images, or the Dockerfile itself is updated.
-  * Tags produced by this branch are published to MCR. 
+  * Tags produced by this branch are published to MAR.
+  * This branch is built when there is a new, stable release of microsoft/go, the underlying OS has a change that is important to users of the Microsoft Go images, or the Dockerfile itself is updated. When it's feasible, we only publish tag updates when the image content needs to be updated, to avoid unnecessary build churn downstream.
+  * The Dockerfiles in this branch will normally match the images available on MAR, but this may not always the case. Before a release, we need to check in changes to `microsoft/main` before we can officially build them. We also may check in changes further in advance of a release so they are included when the next release eventually happens.
 * `microsoft/nightly`
+  * Tags produced by this branch are published to an ACR we maintain, not MAR.
   * This branch is frequently updated to new non-production-quality builds of Go. For example, the branch may contain bugfixes that have been committed to a Go release branch, even though the commits aren't part of any release yet. 
   * Actual rate of updates varies: not necessarily nightly. `nightly` is just terminology borrowed from .NET, used to indicate this is not the stable branch.
-  * The tags produced by this branch are not published to MCR.
 
 ## Policy Changes
 
 In the event that a change is needed to the tagging patterns we use, all tags for the previous pattern will continue to be supported for their original lifetime.
+
+[FIPS readme]: https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips


### PR DESCRIPTION
Update 1.17 -> 1.19 in examples for clarity, clarify what `-fips` means in 1.19+, update MCR -> MAR, include multi-stage Dockerfile recommendation, and touch up various sections.

https://github.com/dagood/go-images/blob/dev/dagood/update-docs/README.md
https://github.com/dagood/go-images/blob/dev/dagood/update-docs/docs/tags.md