### PR TITLE
[main] Add Debian bookworm, remove buster

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,15 +14,56 @@
           "productVersion": "1.19",
           "sharedTags": {
             "1": {},
-            "1-bullseye": {},
+            "1-bookworm": {},
             "1.19": {},
-            "1.19-bullseye": {},
+            "1.19-bookworm": {},
             "1.19.10": {},
             "1.19.10-1": {},
+            "1.19.10-1-bookworm": {},
+            "1.19.10-bookworm": {},
+            "bookworm": {},
+            "latest": {}
+          },
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/1.19/bookworm",
+              "os": "linux",
+              "osVersion": "bookworm",
+              "tags": {
+                "1.19.10-1-bookworm-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.19/bookworm",
+              "os": "linux",
+              "osVersion": "bookworm",
+              "tags": {
+                "1.19.10-1-bookworm-arm64v8": {}
+              }
+            },
+            {
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/1.19/bookworm",
+              "os": "linux",
+              "osVersion": "bookworm",
+              "tags": {
+                "1.19.10-1-bookworm-arm32v7": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "1.19",
+          "sharedTags": {
+            "1-bullseye": {},
+            "1.19-bullseye": {},
             "1.19.10-1-bullseye": {},
             "1.19.10-bullseye": {},
-            "bullseye": {},
-            "latest": {}
+            "bullseye": {}
           },
           "platforms": [
             {
@@ -52,47 +93,6 @@
               "osVersion": "bullseye",
               "tags": {
                 "1.19.10-1-bullseye-arm32v7": {}
-              }
-            }
-          ]
-        },
-        {
-          "productVersion": "1.19",
-          "sharedTags": {
-            "1-buster": {},
-            "1.19-buster": {},
-            "1.19.10-1-buster": {},
-            "1.19.10-buster": {},
-            "buster": {}
-          },
-          "platforms": [
-            {
-              "architecture": "amd64",
-              "dockerfile": "src/microsoft/1.19/buster",
-              "os": "linux",
-              "osVersion": "buster",
-              "tags": {
-                "1.19.10-1-buster-amd64": {}
-              }
-            },
-            {
-              "architecture": "arm64",
-              "variant": "v8",
-              "dockerfile": "src/microsoft/1.19/buster",
-              "os": "linux",
-              "osVersion": "buster",
-              "tags": {
-                "1.19.10-1-buster-arm64v8": {}
-              }
-            },
-            {
-              "architecture": "arm",
-              "variant": "v7",
-              "dockerfile": "src/microsoft/1.19/buster",
-              "os": "linux",
-              "osVersion": "buster",
-              "tags": {
-                "1.19.10-1-buster-arm32v7": {}
               }
             }
           ]
@@ -162,6 +162,59 @@
         {
           "productVersion": "1.19",
           "sharedTags": {
+            "1-fips-bookworm": {},
+            "1.19-fips-bookworm": {},
+            "1.19.10-1-fips-bookworm": {},
+            "1.19.10-fips-bookworm": {},
+            "fips-bookworm": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "FROM_TAG": "1.19.10-1-bookworm-amd64",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/1.19/fips-linux/bookworm",
+              "os": "linux",
+              "osVersion": "bookworm",
+              "tags": {
+                "1.19.10-1-fips-bookworm-amd64": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "FROM_TAG": "1.19.10-1-bookworm-arm64v8",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.19/fips-linux/bookworm",
+              "os": "linux",
+              "osVersion": "bookworm",
+              "tags": {
+                "1.19.10-1-fips-bookworm-arm64v8": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "FROM_TAG": "1.19.10-1-bookworm-arm32v7",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/1.19/fips-linux/bookworm",
+              "os": "linux",
+              "osVersion": "bookworm",
+              "tags": {
+                "1.19.10-1-fips-bookworm-arm32v7": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "1.19",
+          "sharedTags": {
             "1-fips-bullseye": {},
             "1.19-fips-bullseye": {},
             "1.19.10-1-fips-bullseye": {},
@@ -208,59 +261,6 @@
               "osVersion": "bullseye",
               "tags": {
                 "1.19.10-1-fips-bullseye-arm32v7": {}
-              }
-            }
-          ]
-        },
-        {
-          "productVersion": "1.19",
-          "sharedTags": {
-            "1-fips-buster": {},
-            "1.19-fips-buster": {},
-            "1.19.10-1-fips-buster": {},
-            "1.19.10-fips-buster": {},
-            "fips-buster": {}
-          },
-          "platforms": [
-            {
-              "buildArgs": {
-                "FROM_TAG": "1.19.10-1-buster-amd64",
-                "REPO": "$(Repo:golang)"
-              },
-              "architecture": "amd64",
-              "dockerfile": "src/microsoft/1.19/fips-linux/buster",
-              "os": "linux",
-              "osVersion": "buster",
-              "tags": {
-                "1.19.10-1-fips-buster-amd64": {}
-              }
-            },
-            {
-              "buildArgs": {
-                "FROM_TAG": "1.19.10-1-buster-arm64v8",
-                "REPO": "$(Repo:golang)"
-              },
-              "architecture": "arm64",
-              "variant": "v8",
-              "dockerfile": "src/microsoft/1.19/fips-linux/buster",
-              "os": "linux",
-              "osVersion": "buster",
-              "tags": {
-                "1.19.10-1-fips-buster-arm64v8": {}
-              }
-            },
-            {
-              "buildArgs": {
-                "FROM_TAG": "1.19.10-1-buster-arm32v7",
-                "REPO": "$(Repo:golang)"
-              },
-              "architecture": "arm",
-              "variant": "v7",
-              "dockerfile": "src/microsoft/1.19/fips-linux/buster",
-              "os": "linux",
-              "osVersion": "buster",
-              "tags": {
-                "1.19.10-1-fips-buster-arm32v7": {}
               }
             }
           ]
@@ -460,9 +460,48 @@
           "productVersion": "1.20",
           "sharedTags": {
             "1.20": {},
-            "1.20-bullseye": {},
+            "1.20-bookworm": {},
             "1.20.5": {},
             "1.20.5-1": {},
+            "1.20.5-1-bookworm": {},
+            "1.20.5-bookworm": {}
+          },
+          "platforms": [
+            {
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/1.20/bookworm",
+              "os": "linux",
+              "osVersion": "bookworm",
+              "tags": {
+                "1.20.5-1-bookworm-amd64": {}
+              }
+            },
+            {
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.20/bookworm",
+              "os": "linux",
+              "osVersion": "bookworm",
+              "tags": {
+                "1.20.5-1-bookworm-arm64v8": {}
+              }
+            },
+            {
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/1.20/bookworm",
+              "os": "linux",
+              "osVersion": "bookworm",
+              "tags": {
+                "1.20.5-1-bookworm-arm32v7": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "1.20",
+          "sharedTags": {
+            "1.20-bullseye": {},
             "1.20.5-1-bullseye": {},
             "1.20.5-bullseye": {}
           },
@@ -494,45 +533,6 @@
               "osVersion": "bullseye",
               "tags": {
                 "1.20.5-1-bullseye-arm32v7": {}
-              }
-            }
-          ]
-        },
-        {
-          "productVersion": "1.20",
-          "sharedTags": {
-            "1.20-buster": {},
-            "1.20.5-1-buster": {},
-            "1.20.5-buster": {}
-          },
-          "platforms": [
-            {
-              "architecture": "amd64",
-              "dockerfile": "src/microsoft/1.20/buster",
-              "os": "linux",
-              "osVersion": "buster",
-              "tags": {
-                "1.20.5-1-buster-amd64": {}
-              }
-            },
-            {
-              "architecture": "arm64",
-              "variant": "v8",
-              "dockerfile": "src/microsoft/1.20/buster",
-              "os": "linux",
-              "osVersion": "buster",
-              "tags": {
-                "1.20.5-1-buster-arm64v8": {}
-              }
-            },
-            {
-              "architecture": "arm",
-              "variant": "v7",
-              "dockerfile": "src/microsoft/1.20/buster",
-              "os": "linux",
-              "osVersion": "buster",
-              "tags": {
-                "1.20.5-1-buster-arm32v7": {}
               }
             }
           ]
@@ -598,6 +598,57 @@
         {
           "productVersion": "1.20",
           "sharedTags": {
+            "1.20-fips-bookworm": {},
+            "1.20.5-1-fips-bookworm": {},
+            "1.20.5-fips-bookworm": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "FROM_TAG": "1.20.5-1-bookworm-amd64",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "amd64",
+              "dockerfile": "src/microsoft/1.20/fips-linux/bookworm",
+              "os": "linux",
+              "osVersion": "bookworm",
+              "tags": {
+                "1.20.5-1-fips-bookworm-amd64": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "FROM_TAG": "1.20.5-1-bookworm-arm64v8",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "arm64",
+              "variant": "v8",
+              "dockerfile": "src/microsoft/1.20/fips-linux/bookworm",
+              "os": "linux",
+              "osVersion": "bookworm",
+              "tags": {
+                "1.20.5-1-fips-bookworm-arm64v8": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "FROM_TAG": "1.20.5-1-bookworm-arm32v7",
+                "REPO": "$(Repo:golang)"
+              },
+              "architecture": "arm",
+              "variant": "v7",
+              "dockerfile": "src/microsoft/1.20/fips-linux/bookworm",
+              "os": "linux",
+              "osVersion": "bookworm",
+              "tags": {
+                "1.20.5-1-fips-bookworm-arm32v7": {}
+              }
+            }
+          ]
+        },
+        {
+          "productVersion": "1.20",
+          "sharedTags": {
             "1.20-fips-bullseye": {},
             "1.20.5-1-fips-bullseye": {},
             "1.20.5-fips-bullseye": {}
@@ -642,57 +693,6 @@
               "osVersion": "bullseye",
               "tags": {
                 "1.20.5-1-fips-bullseye-arm32v7": {}
-              }
-            }
-          ]
-        },
-        {
-          "productVersion": "1.20",
-          "sharedTags": {
-            "1.20-fips-buster": {},
-            "1.20.5-1-fips-buster": {},
-            "1.20.5-fips-buster": {}
-          },
-          "platforms": [
-            {
-              "buildArgs": {
-                "FROM_TAG": "1.20.5-1-buster-amd64",
-                "REPO": "$(Repo:golang)"
-              },
-              "architecture": "amd64",
-              "dockerfile": "src/microsoft/1.20/fips-linux/buster",
-              "os": "linux",
-              "osVersion": "buster",
-              "tags": {
-                "1.20.5-1-fips-buster-amd64": {}
-              }
-            },
-            {
-              "buildArgs": {
-                "FROM_TAG": "1.20.5-1-buster-arm64v8",
-                "REPO": "$(Repo:golang)"
-              },
-              "architecture": "arm64",
-              "variant": "v8",
-              "dockerfile": "src/microsoft/1.20/fips-linux/buster",
-              "os": "linux",
-              "osVersion": "buster",
-              "tags": {
-                "1.20.5-1-fips-buster-arm64v8": {}
-              }
-            },
-            {
-              "buildArgs": {
-                "FROM_TAG": "1.20.5-1-buster-arm32v7",
-                "REPO": "$(Repo:golang)"
-              },
-              "architecture": "arm",
-              "variant": "v7",
-              "dockerfile": "src/microsoft/1.20/fips-linux/buster",
-              "os": "linux",
-              "osVersion": "buster",
-              "tags": {
-                "1.20.5-1-fips-buster-arm32v7": {}
               }
             }
           ]

--- a/patches/0002-Add-Mariner-support-with-FIPS-dependency-flag.patch
+++ b/patches/0002-Add-Mariner-support-with-FIPS-dependency-flag.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] Add Mariner support with FIPS dependency flag
  1 file changed, 59 insertions(+)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index 291f460f8981e0..9202f97701231e 100644
+index 3d8ddc4235a658..0bc708016e8b10 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
-@@ -4,6 +4,16 @@
+@@ -4,11 +4,47 @@
  	;
  	def alpine_version:
  		env.variant | ltrimstr("alpine")
@@ -28,10 +28,8 @@ index 291f460f8981e0..9202f97701231e 100644
  -}}
  {{ if is_alpine then ( -}}
  FROM alpine:{{ alpine_version }}
-@@ -14,6 +24,32 @@ RUN apk add --no-cache ca-certificates
- # - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
- # - docker run --rm debian grep '^hosts:' /etc/nsswitch.conf
- RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+ 
+ RUN apk add --no-cache ca-certificates
 +{{ ) elif is_cbl_mariner then ( -}}
 +FROM mcr.microsoft.com/cbl-mariner/base/core:{{ cbl_mariner_version }}
 +
@@ -61,7 +59,7 @@ index 291f460f8981e0..9202f97701231e 100644
  {{ ) else ( -}}
  FROM buildpack-deps:{{ env.variant }}-scm
  
-@@ -26,6 +62,14 @@ RUN set -eux; \
+@@ -21,6 +57,14 @@ RUN set -eux; \
  		libc6-dev \
  		make \
  		pkg-config \
@@ -76,7 +74,7 @@ index 291f460f8981e0..9202f97701231e 100644
  	; \
  	rm -rf /var/lib/apt/lists/*
  {{ ) end -}}
-@@ -46,6 +90,13 @@ ENV GOLANG_VERSION {{ .version }}
+@@ -41,6 +85,13 @@ ENV GOLANG_VERSION {{ .version }}
  				ppc64le: "ppc64le",
  				s390x: "s390x",
  			}
@@ -90,7 +88,7 @@ index 291f460f8981e0..9202f97701231e 100644
  		else
  			{
  				amd64: "amd64",
-@@ -63,6 +114,8 @@ RUN set -eux; \
+@@ -58,6 +109,8 @@ RUN set -eux; \
  {{ if is_alpine then ( -}}
  	apk add --no-cache --virtual .fetch-deps gnupg; \
  	arch="$(apk --print-arch)"; \
@@ -99,7 +97,7 @@ index 291f460f8981e0..9202f97701231e 100644
  {{ ) else ( -}}
  	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
  {{ ) end -}}
-@@ -117,10 +170,16 @@ RUN set -eux; \
+@@ -112,10 +165,16 @@ RUN set -eux; \
  	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
  	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
  	gpg --batch --import microsoft-managed-lang-compiler.asc; \

--- a/src/microsoft/1.19/bookworm/Dockerfile
+++ b/src/microsoft/1.19/bookworm/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:buster-scm
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm
 
 # install cgo-related dependencies
 RUN set -eux; \
@@ -20,23 +20,23 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.20.5
+ENV GOLANG_VERSION 1.19.10
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.20/20230606.4/go.20230606.4.linux-amd64.tar.gz'; \
-			sha256='7d83def2ad5e7c0db918e9a5770866475759b3bd1e490b9faff4ade9eb9449e2'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/go.20230606.2.linux-amd64.tar.gz'; \
+			sha256='bacc82f5ee5b38f47cde06e965404bcdd1502372e806af0acb9a5bcdc80b7fa1'; \
 			;; \
 		'armhf') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.20/20230606.4/go.20230606.4.linux-armv6l.tar.gz'; \
-			sha256='59acb9727a3ad00e2a48738eb8707d1f40e3da9fc9d0642341fa7321b38f5a92'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/go.20230606.2.linux-armv6l.tar.gz'; \
+			sha256='3122b80f4c9073abb83f83ba0ea569024bac33205fd3a63a3ad4092bc6ae09e9'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.20/20230606.4/go.20230606.4.linux-arm64.tar.gz'; \
-			sha256='ed17e766f95cabefeca2affecb1f6e0622552eb88050183005c3cdfdea4eafc1'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/go.20230606.2.linux-arm64.tar.gz'; \
+			sha256='c204b86edfcb1c134a6cf4c803aa5f577dd759cb4266a3bab93ce83ef0c4f4d8'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
@@ -105,5 +105,5 @@ RUN set -eux; \
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.19/bullseye/Dockerfile
+++ b/src/microsoft/1.19/bullseye/Dockerfile
@@ -105,5 +105,5 @@ RUN set -eux; \
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.19/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.19/cbl-mariner1.0/Dockerfile
@@ -108,5 +108,5 @@ RUN set -eux; \
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.19/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.19/cbl-mariner2.0/Dockerfile
@@ -108,5 +108,5 @@ RUN set -eux; \
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.19/fips-linux/bookworm/Dockerfile
+++ b/src/microsoft/1.19/fips-linux/bookworm/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.20.5-1-buster
+ARG FROM_TAG=1.19.10-1-bookworm
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/1.20/bookworm/Dockerfile
+++ b/src/microsoft/1.20/bookworm/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:buster-scm
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm
 
 # install cgo-related dependencies
 RUN set -eux; \
@@ -20,23 +20,23 @@ RUN set -eux; \
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.19.10
+ENV GOLANG_VERSION 1.20.5
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/go.20230606.2.linux-amd64.tar.gz'; \
-			sha256='bacc82f5ee5b38f47cde06e965404bcdd1502372e806af0acb9a5bcdc80b7fa1'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.20/20230606.4/go.20230606.4.linux-amd64.tar.gz'; \
+			sha256='7d83def2ad5e7c0db918e9a5770866475759b3bd1e490b9faff4ade9eb9449e2'; \
 			;; \
 		'armhf') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/go.20230606.2.linux-armv6l.tar.gz'; \
-			sha256='3122b80f4c9073abb83f83ba0ea569024bac33205fd3a63a3ad4092bc6ae09e9'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.20/20230606.4/go.20230606.4.linux-armv6l.tar.gz'; \
+			sha256='59acb9727a3ad00e2a48738eb8707d1f40e3da9fc9d0642341fa7321b38f5a92'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/go.20230606.2.linux-arm64.tar.gz'; \
-			sha256='c204b86edfcb1c134a6cf4c803aa5f577dd759cb4266a3bab93ce83ef0c4f4d8'; \
+			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.20/20230606.4/go.20230606.4.linux-arm64.tar.gz'; \
+			sha256='ed17e766f95cabefeca2affecb1f6e0622552eb88050183005c3cdfdea4eafc1'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
@@ -105,5 +105,5 @@ RUN set -eux; \
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.20/bullseye/Dockerfile
+++ b/src/microsoft/1.20/bullseye/Dockerfile
@@ -72,8 +72,14 @@ RUN set -eux; \
 	\
 	if [ -n "$build" ]; then \
 		savedAptMark="$(apt-mark showmanual)"; \
-		apt-get update; \
-		apt-get install -y --no-install-recommends golang-go; \
+# add backports for newer go version for bootstrap build: https://github.com/golang/go/issues/44505
+		( \
+			. /etc/os-release; \
+			echo "deb https://deb.debian.org/debian $VERSION_CODENAME-backports main" > /etc/apt/sources.list.d/backports.list; \
+			\
+			apt-get update; \
+			apt-get install -y --no-install-recommends -t "$VERSION_CODENAME-backports" golang-go; \
+		); \
 		\
 		export GOCACHE='/tmp/gocache'; \
 		\
@@ -105,5 +111,5 @@ RUN set -eux; \
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.20/cbl-mariner1.0/Dockerfile
+++ b/src/microsoft/1.20/cbl-mariner1.0/Dockerfile
@@ -108,5 +108,5 @@ RUN set -eux; \
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.20/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.20/cbl-mariner2.0/Dockerfile
@@ -108,5 +108,5 @@ RUN set -eux; \
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.20/fips-linux/bookworm/Dockerfile
+++ b/src/microsoft/1.20/fips-linux/bookworm/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.19.10-1-buster
+ARG FROM_TAG=1.20.5-1-bookworm
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -40,12 +40,12 @@
       }
     },
     "variants": [
+      "bookworm",
       "bullseye",
-      "buster",
       "cbl-mariner1.0",
       "cbl-mariner2.0",
+      "fips-linux/bookworm",
       "fips-linux/bullseye",
-      "fips-linux/buster",
       "fips-linux/cbl-mariner1.0",
       "fips-linux/cbl-mariner2.0",
       "windows/windowsservercore-ltsc2022",
@@ -58,7 +58,7 @@
     "revision": "1",
     "preferredMajor": true,
     "preferredMinor": true,
-    "preferredVariant": "bullseye"
+    "preferredVariant": "bookworm"
   },
   "1.20": {
     "arches": {
@@ -101,12 +101,12 @@
       }
     },
     "variants": [
+      "bookworm",
       "bullseye",
-      "buster",
       "cbl-mariner1.0",
       "cbl-mariner2.0",
+      "fips-linux/bookworm",
       "fips-linux/bullseye",
-      "fips-linux/buster",
       "fips-linux/cbl-mariner1.0",
       "fips-linux/cbl-mariner2.0",
       "windows/windowsservercore-ltsc2022",
@@ -117,6 +117,6 @@
     ],
     "version": "1.20.5",
     "revision": "1",
-    "preferredVariant": "bullseye"
+    "preferredVariant": "bookworm"
   }
 }


### PR DESCRIPTION
For https://github.com/microsoft/go/issues/921. Two commits:

* Update to latest upstream, fix patch (clean 3-way merge). Adjust `src/microsoft/versions.json` to upgrade to bookworm and remove buster.
* Use `dockerupdate -f` to regenerate Dockerfile and manifest.json. (No need to review this.)