### PR TITLE
[main] Update eng/common to dotnet-docker@6da64f3194

### DIFF
--- a/eng/common/Get-ImageBuilder.ps1
+++ b/eng/common/Get-ImageBuilder.ps1
@@ -1,15 +1,13 @@
 #!/usr/bin/env pwsh
 
 # Load common image names
-Get-Content $PSScriptRoot/templates/variables/docker-images.yml |
-Where-Object { $_.Trim() -notlike 'variables:' } |
-ForEach-Object { 
-    $parts = $_.Split(':', 2)
-    Set-Variable -Name $parts[0].Trim() -Value $parts[1].Trim() -Scope Global
+$imageNameVars = & $PSScriptRoot/Get-ImageNameVars.ps1
+foreach ($varName in $imageNameVars.Keys) { 
+    Set-Variable -Name $varName -Value $imageNameVars[$varName] -Scope Global
 }
 
-& docker inspect ${imageNames.imagebuilder} | Out-Null
+& docker inspect ${imageNames.imagebuilderName} | Out-Null
 if (-not $?) {
     Write-Output "Pulling"
-    & $PSScriptRoot/Invoke-WithRetry.ps1 "docker pull ${imageNames.imagebuilder}"
+    & $PSScriptRoot/Invoke-WithRetry.ps1 "docker pull ${imageNames.imagebuilderName}"
 }

--- a/eng/common/Get-ImageNameVars.ps1
+++ b/eng/common/Get-ImageNameVars.ps1
@@ -1,0 +1,12 @@
+# Returns a hashtable of variable name-to-value mapping representing the image name variables
+# used by the common build infrastructure.
+
+$vars = @{}
+Get-Content $PSScriptRoot/templates/variables/docker-images.yml |
+    Where-Object { $_.Trim().Length -gt 0 -and $_.Trim() -notlike 'variables:' -and $_.Trim() -notlike '# *' } |
+    ForEach-Object {
+        $parts = $_.Split(':', 2)
+        $vars[$parts[0].Trim()] = $parts[1].Trim()
+    }
+
+return $vars

--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -40,16 +40,16 @@ if (!(Test-Path $DotnetInstallScriptPath)) {
     & "$PSScriptRoot/Invoke-WithRetry.ps1" "Invoke-WebRequest 'https://dot.net/v1/$DotnetInstallScript' -OutFile $DotnetInstallScriptPath"
 }
 
-$DotnetChannel = "Current"
+$DotnetChannel = "7.0"
 
 $InstallFailed = $false
 if ($IsRunningOnUnix) {
     & chmod +x $DotnetInstallScriptPath
-    & $DotnetInstallScriptPath --channel $DotnetChannel --version "latest" --install-dir $InstallPath
+    & $DotnetInstallScriptPath --channel $DotnetChannel --install-dir $InstallPath
     $InstallFailed = ($LASTEXITCODE -ne 0)
 }
 else {
-    & $DotnetInstallScriptPath -Channel $DotnetChannel -Version "latest" -InstallDir $InstallPath
+    & $DotnetInstallScriptPath -Channel $DotnetChannel -InstallDir $InstallPath
     $InstallFailed = (-not $?)
 }
 

--- a/eng/common/Invoke-CleanupDocker.ps1
+++ b/eng/common/Invoke-CleanupDocker.ps1
@@ -7,16 +7,14 @@ docker volume prune -f
 
 # Preserve the tagged Windows base images and the common eng infra images (e.g. ImageBuilder)
 # to avoid the expense of having to repull continuously.
-$engInfraImages = Get-Content $PSScriptRoot/templates/variables/docker-images.yml |
-    Where-Object { $_.Trim() -notlike 'variables:' } |
-    ForEach-Object { $_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[1] }
+$imageNameVars = & $PSScriptRoot/Get-ImageNameVars.ps1
 
-docker images --format "{{.Repository}}:{{.Tag}} {{.ID}}"|
+docker images --format "{{.Repository}}:{{.Tag}} {{.ID}}" |
     Where-Object {
         $localImage = $_
         $localImage.Contains(":<none> ")`
         -Or -Not ($localImage.StartsWith("mcr.microsoft.com/windows")`
-            -Or ($engInfraImages.Where({ $localImage.StartsWith($_) }, 'First').Count -gt 0)) } |
+            -Or ($imageNameVars.Values.Where({ $localImage.StartsWith($_) }, 'First').Count -gt 0)) } |
     ForEach-Object { $_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[1] } |
     Select-Object -Unique |
     ForEach-Object { docker rmi -f $_ }

--- a/eng/common/Invoke-ImageBuilder.ps1
+++ b/eng/common/Invoke-ImageBuilder.ps1
@@ -66,7 +66,7 @@ try {
         if ($ReuseImageBuilderImage -ne $True) {
             & ./eng/common/Get-ImageBuilder.ps1
             Exec ("docker build -t $imageBuilderImageName --build-arg " `
-                + "IMAGE=${imageNames.imagebuilder} -f eng/common/Dockerfile.WithRepo .")
+                + "IMAGE=${imageNames.imageBuilderName} -f eng/common/Dockerfile.WithRepo .")
         }
 
         $imageBuilderCmd = "docker run --name $imageBuilderContainerName -v /var/run/docker.sock:/var/run/docker.sock $imageBuilderImageName"
@@ -78,7 +78,7 @@ try {
         $imageBuilderCmd = [System.IO.Path]::Combine($imageBuilderFolder, "Microsoft.DotNet.ImageBuilder.exe")
         if (-not (Test-Path -Path "$imageBuilderCmd" -PathType Leaf)) {
             & ./eng/common/Get-ImageBuilder.ps1
-            Exec "docker create --name $imageBuilderContainerName ${imageNames.imagebuilder}"
+            Exec "docker create --name $imageBuilderContainerName ${imageNames.imageBuilderName}"
             $containerCreated = $true
             if (Test-Path -Path $imageBuilderFolder)
             {

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -112,6 +112,11 @@ jobs:
       --retry
       --source-repo $(publicGitRepoUri)
       --digests-out-var 'builtImages'
+      --acr-subscription '$(acr.subscription)'
+      --acr-resource-group '$(acr.resourceGroup)'
+      --acr-client-id '$(acr.servicePrincipalName)'
+      --acr-password '$(acr.servicePrincipalPassword)'
+      --acr-tenant '$(acr.servicePrincipalTenant)'
       $(manifestVariables)
       $(imageBuilderBuildArgs)
     name: BuildImages
@@ -121,7 +126,8 @@ jobs:
     displayName: Publish Image Info File Artifact
   - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
       # Define the task here to load it into the agent so that we can invoke the tool manually
-    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+      # TODO: Revert the build-specific pinned version when https://github.com/dotnet/docker-tools/issues/1152 is fixed
+    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0.197.56
       inputs:
         BuildDropPath: $(Build.ArtifactStagingDirectory)
       displayName: Load Manifest Generator

--- a/eng/common/templates/jobs/cg-detection.yml
+++ b/eng/common/templates/jobs/cg-detection.yml
@@ -3,8 +3,12 @@ jobs:
   pool:
     vmImage: $(defaultLinuxAmd64PoolImage)
   steps:
+  - task: CodeQL3000Init@0
+    displayName: CodeQL Initialize
   - script: >
       find . -name '*.csproj' | grep $(cgBuildGrepArgs) | xargs -n 1 dotnet build
     displayName: Build Projects
+  - task: CodeQL3000Finalize@0
+    displayName: CodeQL Finalize
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: Component Detection

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -16,6 +16,11 @@ jobs:
       $(imageBuilder.queueArgs)
   - name: publishNotificationRepoName
     value: $(Build.Repository.Name)
+  - name: branchName
+    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}:
+      value: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
+    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/pull/') }}:
+      value: $[ replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', '') ]
   - ${{ parameters.customPublishVariables }}
   steps:
   - template: ../steps/retain-build.yml
@@ -120,7 +125,7 @@ jobs:
   - script: >
       $(runImageBuilderCmd) postPublishNotification
       '$(publishNotificationRepoName)'
-      '$(Build.SourceBranchName)'
+      '$(branchName)'
       '$(artifactsPath)/image-info.json'
       $(Build.BuildId)
       '$(System.AccessToken)'

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -60,6 +60,7 @@ stages:
         # values aren't actually used for the pre-build tests.
         - powershell: |
             echo "##vso[task.setvariable variable=productVersion]"
+            echo "##vso[task.setvariable variable=imageBuilderPaths]"
             echo "##vso[task.setvariable variable=osVersions]"
             echo "##vso[task.setvariable variable=architecture]"
           displayName: Initialize Test Variables
@@ -67,7 +68,7 @@ stages:
     parameters:
       name: CopyBaseImages
       pool: ${{ parameters.linuxAmd64Pool }}
-      additionalOptions: "--manifest '$(manifest)' $(manifestVariables)"
+      additionalOptions: "--manifest '$(manifest)' $(imageBuilder.pathArgs) $(manifestVariables)"
       publicProjectName: ${{ parameters.publicProjectName }}
       customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps}}
   - template: ../jobs/generate-matrix.yml

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -72,12 +72,12 @@ stages:
     
     linuxArm64Pool:
       ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-        name: DotNetCore-Docker-Public
+        name: DotNetCoreDocker-Public
       ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
         name: Docker-Linux-Arm-Internal
     linuxArm32Pool:
       ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-        name: DotNetCore-Docker-Public
+        name: DotNetCoreDocker-Public
       ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
         name: Docker-Linux-Arm-Internal
     windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}

--- a/eng/common/templates/steps/parse-test-arg-arrays.yml
+++ b/eng/common/templates/steps/parse-test-arg-arrays.yml
@@ -4,8 +4,12 @@ steps:
     $osVersionsDisplayName = '$(osVersions)' -Replace '--os-version ', '' -Replace ' ', '/'
 
     # Defines a PowerShell snippet in string-form that can be used to initialize an array of the OS versions
-    $osVersionsArrayInitStr="@('" + $($osVersionsDisplayName -Replace "/", "', '") + "')"
+    $osVersionsArrayInitStr = "@('" + $($osVersionsDisplayName -Replace "/", "', '") + "')"
     
     echo "##vso[task.setvariable variable=osVersionsDisplayName]$osVersionsDisplayName"
     echo "##vso[task.setvariable variable=osVersionsArrayInitStr]$osVersionsArrayInitStr"
-  displayName: Parse OS Versions
+
+    # Defines a PowerShell snippet in string-form that can be used to initialize an array of the image builder paths
+    $pathInitStr = "@('" + $('$(imageBuilderPaths)' -Replace '--path', '' -Replace " ", "', '") + "')"
+    echo "##vso[task.setvariable variable=imageBuilderPathsArrayInitStr]$pathInitStr"
+  displayName: Parse Test Arg Arrays

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -20,7 +20,7 @@ steps:
       optionalTestArgs="$optionalTestArgs -TestCategories pre-build"
     else
       if [ "${{ variables['System.TeamProject'] }}" == "${{ parameters.internalProjectName }}" ] && [ "${{ variables['Build.Reason'] }}" != "PullRequest" ]; then
-        optionalTestArgs="$optionalTestArgs -PullImages -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
+        optionalTestArgs="$optionalTestArgs -PullImages -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info.json"
       fi
       if [ "$REPOTESTARGS" != "" ]; then
         optionalTestArgs="$optionalTestArgs $REPOTESTARGS"
@@ -49,8 +49,9 @@ steps:
     - template: ../steps/download-build-artifact.yml
       parameters:
         targetPath: $(Build.ArtifactStagingDirectory)
+        artifactName: image-info
         condition: ${{ parameters.condition }}
-- template: parse-os-versions.yml
+- template: parse-test-arg-arrays.yml
 - powershell: >
     $(test.init);
     docker exec
@@ -58,7 +59,7 @@ steps:
     $(testRunner.container)
     pwsh
     -Command "$(testScriptPath)
-    -Version '$(productVersion)'
+    -Paths $(imageBuilderPathsArrayInitStr)
     -OSVersions $(osVersionsArrayInitStr)
     -Architecture '$(architecture)'
     $(optionalTestArgs)"

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -17,7 +17,7 @@ steps:
 - ${{ parameters.customInitSteps }}
 - powershell: |
     if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}" -and "${{ variables['Build.Reason'] }}" -ne "PullRequest") {
-      $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
+      $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
     } 
     if ($env:REPOTESTARGS) {
       $optionalTestArgs += " $env:REPOTESTARGS"
@@ -32,12 +32,13 @@ steps:
   - template: ../steps/download-build-artifact.yml
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
+      artifactName: image-info
       condition: ${{ parameters.condition }}
-- template: parse-os-versions.yml
+- template: parse-test-arg-arrays.yml
 - powershell: >
     $(test.init);
     $(testScriptPath)
-    -Version '$(productVersion)'
+    -Paths $(imageBuilderPathsArrayInitStr)
     -OSVersions $(osVersionsArrayInitStr)
     $(optionalTestArgs)
   displayName: Test Images

--- a/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
@@ -12,6 +12,7 @@ steps:
     '$(mcrStatus.servicePrincipalPassword)'
     '$(mcrStatus.servicePrincipalTenant)'
     --manifest '$(manifest)'
+    --repo-prefix '$(publishRepoPrefix)'
     --min-queue-time '${{ parameters.minQueueTime }}'
     --timeout '$(mcrImageIngestionTimeout)'
     $(manifestVariables)

--- a/eng/common/templates/variables/codeql.yml
+++ b/eng/common/templates/variables/codeql.yml
@@ -1,0 +1,16 @@
+parameters:
+- name: TSAEnabled
+  displayName: Publish CodeQL results to TSA
+  type: boolean
+  default: true
+
+variables:
+  # Force CodeQL enabled so it may be run on any branch
+- name: Codeql.Enabled
+  value: true
+  # Do not let CodeQL 3000 Extension gate scan frequency
+- name: Codeql.Cadence
+  value: 0
+  # CodeQL needs this plumbed along as a variable to enable TSA
+- name: Codeql.TSAEnabled
+  value: ${{ parameters.TSAEnabled }}

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,6 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1948131
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2207880
+  imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
-  imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
+  imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-bullseye-slim-docker-testrunner
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -12,7 +12,7 @@ variables:
 - name: testResultsDirectory
   value: tests/Microsoft.DotNet.Docker.Tests/TestResults/
 - name: officialRepoPrefixes
-  value: public/,private/internal/
+  value: public/,internal/private/
 
 - name: mcrDocsRepoInfo.accessToken
   value: $(BotAccount-dotnet-docker-bot-PAT)


### PR DESCRIPTION
The change I'm interested in to improve build reliability (or make it work at all) is the one in `eng/common/templates/jobs/build-images.yml`, pinning the SBOM generation task version. See https://github.com/dotnet/docker-tools/issues/1152

Running the full set of changes through CI to see if we can simply get up to date.

https://github.com/dotnet/dotnet-docker/tree/6da64f3194