### PR TITLE
[main] Switch Windows Server 2022 CI legs to 1ES hosted pools

### DIFF
--- a/eng/pipeline/stages/build-test-publish-repo.yml
+++ b/eng/pipeline/stages/build-test-publish-repo.yml
@@ -29,10 +29,10 @@ stages:
       windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
       windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
       windows2022Pool:
-        ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+        ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
           name: NetCore-Public
           demands: ImageOverride -equals 1es-windows-2022-open
-        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
           name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals 1es-windows-2022
 

--- a/eng/pipeline/stages/build-test-publish-repo.yml
+++ b/eng/pipeline/stages/build-test-publish-repo.yml
@@ -28,7 +28,13 @@ stages:
       # https://github.com/dotnet/docker-tools/issues/905
       windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
       windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
-      windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}
+      windows2022Pool:
+        ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+          name: NetCore-Public
+          demands: ImageOverride -equals 1es-windows-2022-open
+        ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals 1es-windows-2022
 
       ${{ each pair in parameters.extraParameters }}:
         ${{ pair.key }}: ${{ pair.value }}


### PR DESCRIPTION
* Copy upstream: https://github.com/dotnet/docker-tools/pull/1163
* Should fix CI timeouts seen in https://github.com/microsoft/go-images/pull/237
* The Docker-2022 pools are preferred: https://github.com/dotnet/docker-tools/issues/1164