### PR TITLE
[main] Revert "[main] Switch Windows Server 2022 CI legs to 1ES hosted pools"

### DIFF
--- a/eng/pipeline/stages/build-test-publish-repo.yml
+++ b/eng/pipeline/stages/build-test-publish-repo.yml
@@ -28,13 +28,7 @@ stages:
       # https://github.com/dotnet/docker-tools/issues/905
       windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
       windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
-      windows2022Pool:
-        ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
-          name: NetCore-Public
-          demands: ImageOverride -equals 1es-windows-2022-open
-        ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
-          name: NetCore1ESPool-Svc-Internal
-          demands: ImageOverride -equals 1es-windows-2022
+      windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}
 
       ${{ each pair in parameters.extraParameters }}:
         ${{ pair.key }}: ${{ pair.value }}


### PR DESCRIPTION
Reverts microsoft/go-images#239

The Docker pools are preferred (https://github.com/dotnet/docker-tools/issues/1164) and the .NET Docker team let us know they seem to be working again, so follow their revert (https://github.com/dotnet/docker-tools/pull/1168) with one here.