### PR TITLE
[main] Update jq-template.awk: massive perf improvement

### DIFF
--- a/src/microsoft/README.md
+++ b/src/microsoft/README.md
@@ -8,12 +8,20 @@ version. For more information, see [/eng/README.md](/eng/README.md).
 
 ### `jq-template.awk`
 A checked-in copy of a file containing utility `awk` code. It's downloaded from
-the internet by the root `/apply-templates.sh` script. To avoid this network
+the internet by upstream's `apply-templates.sh` script. To avoid this network
 dependency while running an update, we check in the file, instead.
 
-To update `jq-template.awk`, run `/apply-templates.sh`, then copy
-`/.jq-template.awk` to `/src/microsoft/jq-template.awk`. The symptoms of this
-file falling out of date are not known, as of writing.
+To update `jq-template.awk`, make sure the submodule is up to date and run this
+from the root of this repository:
+
+```
+cd go
+./apply-templates.sh
+cp .jq-template.awk ../src/microsoft/jq-template.awk
+```
+
+The symptoms of this file falling out of date are not well-defined. In one case,
+updating it dramatically improved Dockerfile generation performance.
 
 ### `versions.json`
 Contains information about the Microsoft builds of Go in the format

--- a/src/microsoft/jq-template.awk
+++ b/src/microsoft/jq-template.awk
@@ -3,18 +3,13 @@
 # see https://github.com/docker-library/php or https://github.com/docker-library/golang for examples of usage ("apply-templates.sh")
 
 # escape an arbitrary string for passing back to jq as program input
-function jq_escape(str,          # parameters
-                   prog, e, out) # locals
-{
-	prog = "jq --raw-input --slurp ."
-	printf "%s", str |& prog
-	close(prog, "to")
-	prog |& getline out
-	e = close(prog)
-	if (e != 0) {
-		exit(e)
-	}
-	return out
+function jq_escape(str) {
+	gsub(/\\/, "\\\\", str)
+	gsub(/\n/, "\\n", str)
+	gsub(/\r/, "\\r", str)
+	gsub(/\t/, "\\t", str)
+	gsub(/"/, "\\\"", str)
+	return "\"" str "\""
 }
 
 # return the number of times needle appears in haystack


### PR DESCRIPTION
Upstream downloads this file from the internet during template reevaluation. We have a checked-in copy to avoid the network dependency in our own release process. We haven't had any problems from keeping the same version of the file around, but I noticed a change upstream that massively improves template evaluation performance. That affects `dockerupdate` perf. (The slowness of that command has always annoyed me during dev work.)

Before:

```
$ time dockerupdate -f
Generating '/home/dagood/git/go-images/manifest.json' based on '/home/dagood/git/go-images/src/microsoft/versions.json'...
Generating Dockerfiles...
...
processing 1.20/windows/nanoserver-ltsc2022 ...
processing 1.20/windows/nanoserver-1809 ...

Success.

real    0m11.681s
```

After:

```
real    0m0.882s
```

13x faster, and now `dockerupdate -f` runs essentially instantly as far as dev work is concerned. Thanks, upstream! 🎉 

Also update the doc that describes how to update the file. It was out of date vs. the move to a submodule-based fork.