### PR TITLE
[main] Migrate DotNetCoreDocker-Public to Docker-Linux-Arm-Public

### DIFF
--- a/eng/pipeline/stages/build-test-publish-repo.yml
+++ b/eng/pipeline/stages/build-test-publish-repo.yml
@@ -16,12 +16,12 @@ stages:
       # Specific pools for arm builds.
       linuxArm64Pool:
         ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
-          name: DotNetCoreDocker-Public
+          name: Docker-Linux-Arm-Public
         ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
           name: Docker-Linux-Arm-Internal
       linuxArm32Pool:
         ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
-          name: DotNetCoreDocker-Public
+          name: Docker-Linux-Arm-Public
         ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
           name: Docker-Linux-Arm-Internal
       # On Windows, 'docker login' is incompatible with 'manifest-tool' unless we use these pools.


### PR DESCRIPTION
DotNetCoreDocker-Public is being deprecated in favor of Docker-Linux-Arm-Public. It should be a simple switch, so give it a shot.

* Follows upstream .NET: https://github.com/dotnet/docker-tools/pull/1175

After merging this, we should merge `microsoft/nightly` up to latest so its builds can keep working after the old pool is removed.