### PR TITLE
Implement 1ES PT for production pipelines

### DIFF
--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -40,7 +40,7 @@ if (!(Test-Path $DotnetInstallScriptPath)) {
     & "$PSScriptRoot/Invoke-WithRetry.ps1" "Invoke-WebRequest 'https://dot.net/v1/$DotnetInstallScript' -OutFile $DotnetInstallScriptPath"
 }
 
-$DotnetChannel = "7.0"
+$DotnetChannel = "8.0"
 
 $InstallFailed = $false
 if ($IsRunningOnUnix) {

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -75,9 +75,9 @@ jobs:
       }
       echo "##vso[task.setvariable variable=baseContainerRepoPath]$baseContainerRepoPath"
     displayName: Set Base Container Repo Path
-  - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}
+  - template: /eng/common/templates/jobs/${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}@self
   - ${{ parameters.customInitSteps }}
-  - template: ../steps/set-image-info-path-var.yml
+  - template: /eng/common/templates/steps/set-image-info-path-var.yml@self
     parameters:
       publicSourceBranch: $(publicSourceBranch)
   - powershell: echo "##vso[task.setvariable variable=imageBuilderBuildArgs]"
@@ -121,9 +121,13 @@ jobs:
       $(imageBuilderBuildArgs)
     name: BuildImages
     displayName: Build Images
-  - publish: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
-    artifact: $(legName)-image-info-$(System.JobAttempt)
-    displayName: Publish Image Info File Artifact
+  - template: /eng/common/templates/steps/publish-artifact.yml@self
+    parameters:
+      path: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
+      artifactName: $(legName)-image-info-$(System.JobAttempt)
+      displayName: Publish Image Info File Artifact
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
   - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
       # Define the task here to load it into the agent so that we can invoke the tool manually
       # TODO: Revert the build-specific pinned version when https://github.com/dotnet/docker-tools/issues/1152 is fixed
@@ -135,14 +139,19 @@ jobs:
     - powershell: |
         $images = "$(BuildImages.builtImages)"
         if (-not $images) { return 0 }
+
         # There can be leftover versions of the task left on the agent if it's not fresh. So find the latest version.
         $taskDir = $(Get-ChildItem -Recurse -Directory -Filter "ManifestGeneratorTask*" -Path '$(Agent.WorkFolder)')[-1].FullName
-        $manifestToolDllPath = $(Get-ChildItem -Recurse -File -Filter "Microsoft.ManifestTool.dll" -Path $taskDir).FullName
+
+        # There may be multiple version directories within the task directory. Use the latest.
+        $taskVersionDir = $(Get-ChildItem -Directory $taskDir | Sort-Object)[-1].FullName
+
+        $manifestToolDllPath = $(Get-ChildItem -Recurse -File -Filter "Microsoft.ManifestTool.dll" -Path $taskVersionDir).FullName
 
         # Check whether the manifest task installed its own version of .NET.
         # To be more robust, we'll handle varying implementations that it's had.
         # First check for a dotnet folder in the task location
-        $dotnetDir = $(Get-ChildItem -Recurse -Directory -Filter "dotnet-*" -Path $taskDir).FullName
+        $dotnetDir = $(Get-ChildItem -Recurse -Directory -Filter "dotnet-*" -Path $taskVersionDir).FullName
         if (-not $dotnetDir) {
           # If it's not there, check in the agent tools location
           $dotnetDir = $(Get-ChildItem -Recurse -Directory -Filter "*dotnet-*" -Path "$(Agent.ToolsDirectory)").FullName
@@ -177,12 +186,16 @@ jobs:
       displayName: Generate SBOMs
       condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))
   - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-    - template: ${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}
+    - template: /eng/common/templates/jobs/${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}@self
       parameters:
         condition: ne(variables.testScriptPath, '')
-  - template: ${{ format('../steps/cleanup-docker-{0}.yml', parameters.dockerClientOS) }}
+  - template: /eng/common/templates/jobs/${{ format('../steps/cleanup-docker-{0}.yml', parameters.dockerClientOS) }}@self
   - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-    - publish: $(sbomDirectory)
-      artifact: $(legName)-sboms
-      displayName: Publish SBOM
-      condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))
+    - template: /eng/common/templates/steps/publish-artifact.yml@self
+      parameters:
+        path: $(sbomDirectory)
+        artifactName: $(legName)-sboms
+        displayName: Publish SBOM
+        internalProjectName: ${{ parameters.internalProjectName }}
+        publicProjectName: ${{ parameters.publicProjectName }}
+        condition: ne(variables['BuildImages.builtImages'], '')

--- a/eng/common/templates/jobs/cg-detection.yml
+++ b/eng/common/templates/jobs/cg-detection.yml
@@ -3,10 +3,13 @@ jobs:
   pool:
     vmImage: $(defaultLinuxAmd64PoolImage)
   steps:
+  - powershell: >
+      ./eng/common/Install-DotNetSdk.ps1 /usr/share/.dotnet
+    displayName: Run Dotnet Install Script
   - task: CodeQL3000Init@0
     displayName: CodeQL Initialize
   - script: >
-      find . -name '*.csproj' | grep $(cgBuildGrepArgs) | xargs -n 1 dotnet build
+      find . -name '*.csproj' | grep $(cgBuildGrepArgs) | xargs -n 1 /usr/share/.dotnet/dotnet build
     displayName: Build Projects
   - task: CodeQL3000Finalize@0
     displayName: CodeQL Finalize

--- a/eng/common/templates/jobs/copy-base-images.yml
+++ b/eng/common/templates/jobs/copy-base-images.yml
@@ -4,16 +4,16 @@ parameters:
   additionalOptions: null
   publicProjectName: null
   customInitSteps: []
-  
+
 jobs:
 - job: ${{ parameters.name }}
   pool: ${{ parameters.pool }}
   steps:
-  - template: ../steps/init-docker-linux.yml
+  - template: /eng/common/templates/steps/init-docker-linux.yml@self
   - ${{ parameters.customInitSteps }}
-  - template: ../steps/copy-base-images.yml
+  - template: /eng/common/templates/steps/copy-base-images.yml@self
     parameters:
       additionalOptions: ${{ parameters.additionalOptions }}
       publicProjectName: ${{ parameters.publicProjectName }}
       continueOnError: true
-  - template: ../steps/cleanup-docker-linux.yml
+  - template: /eng/common/templates/steps/cleanup-docker-linux.yml@self

--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -10,13 +10,13 @@ jobs:
 - job: ${{ parameters.name }}
   pool: ${{ parameters.pool }}
   steps:
-  - template: ../steps/retain-build.yml
-  - template: ../steps/init-docker-linux.yml
-  - template: ../steps/validate-branch.yml
+  - template: /eng/common/templates/steps/retain-build.yml@self
+  - template: /eng/common/templates/steps/init-docker-linux.yml@self
+  - template: /eng/common/templates/steps/validate-branch.yml@self
     parameters:
       internalProjectName: ${{ parameters.internalProjectName }}
   - ${{ if eq(parameters.isTestStage, true) }}:
-    - template: ../steps/download-build-artifact.yml
+    - template: /eng/common/templates/steps/download-build-artifact.yml@self
       parameters:
         targetPath: $(Build.ArtifactStagingDirectory)
         artifactName: image-info
@@ -38,4 +38,4 @@ jobs:
       $(additionalGenerateBuildMatrixOptions)
     displayName: Generate ${{ parameters.matrixType }} Matrix
     name: matrix
-  - template: ../steps/cleanup-docker-linux.yml
+  - template: /eng/common/templates/steps/cleanup-docker-linux.yml@self

--- a/eng/common/templates/jobs/post-build.yml
+++ b/eng/common/templates/jobs/post-build.yml
@@ -1,5 +1,7 @@
 parameters:
   pool: {}
+  internalProjectName: null
+  publicProjectName: null
 
 jobs:
 - job: Build
@@ -8,8 +10,8 @@ jobs:
     imageInfosSubDir: "/image-infos"
     sbomSubDir: "/sbom"
   steps:
-  - template: ../steps/init-docker-linux.yml
-  - template: ../steps/download-build-artifact.yml
+  - template: /eng/common/templates/steps/init-docker-linux.yml@self
+  - template: /eng/common/templates/steps/download-build-artifact.yml@self
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
   - powershell: |
@@ -23,7 +25,7 @@ jobs:
       New-Item -ItemType Directory -Path $(Build.ArtifactStagingDirectory)$(sbomSubDir)
       Get-ChildItem -Directory -Filter "*-sboms" $(Build.ArtifactStagingDirectory) |
         ForEach-Object {
-          Get-ChildItem $_ -Directory | Move-Item -Verbose -Destination $(Build.ArtifactStagingDirectory)$(sbomSubDir)
+          Get-ChildItem $_ -Directory | Move-Item -Force -Verbose -Destination $(Build.ArtifactStagingDirectory)$(sbomSubDir)
         }
     displayName: Consolidate SBOMs to Single Directory
   - powershell: |
@@ -53,9 +55,17 @@ jobs:
       $(artifactsPath)$(imageInfosSubDir)/image-info.json
       $(manifestVariables)
     displayName: Merge Image Info Files
-  - publish: $(Build.ArtifactStagingDirectory)$(sbomSubDir)
-    artifact: sboms
-    displayName: Publish SBOM Artifact
-  - publish: $(Build.ArtifactStagingDirectory)$(imageInfosSubDir)/image-info.json
-    artifact: image-info
-    displayName: Publish Image Info File Artifact
+  - template: /eng/common/templates/steps/publish-artifact.yml@self
+    parameters:
+      path: $(Build.ArtifactStagingDirectory)$(sbomSubDir)
+      artifactName: sboms
+      displayName: Publish SBOM Artifact
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
+  - template: /eng/common/templates/steps/publish-artifact.yml@self
+    parameters:
+      path: $(Build.ArtifactStagingDirectory)$(imageInfosSubDir)/image-info.json
+      artifactName: image-info
+      displayName: Publish Image Info File Artifact
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -23,29 +23,33 @@ jobs:
       value: $[ replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', '') ]
   - ${{ parameters.customPublishVariables }}
   steps:
-  - template: ../steps/retain-build.yml
-  - template: ../steps/init-docker-linux.yml
+  - template: /eng/common/templates/steps/retain-build.yml@self
+  - template: /eng/common/templates/steps/init-docker-linux.yml@self
   - pwsh: |
       $azdoOrgName = Split-Path -Leaf $Env:SYSTEM_COLLECTIONURI
       echo "##vso[task.setvariable variable=azdoOrgName]$azdoOrgName"
     displayName: Set Publish Variables
   - ${{ parameters.customInitSteps }}
-  - template: ../steps/validate-branch.yml
+  - template: /eng/common/templates/steps/validate-branch.yml@self
     parameters:
       internalProjectName: ${{ parameters.internalProjectName }}
-  - template: ../steps/download-build-artifact.yml
+  - template: /eng/common/templates/steps/download-build-artifact.yml@self
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
       artifactName: image-info
-  - template: ../steps/set-image-info-path-var.yml
+  - template: /eng/common/templates/steps/set-image-info-path-var.yml@self
     parameters:
       publicSourceBranch: $(publicSourceBranch)
-  - template: ../steps/set-dry-run.yml
+  - template: /eng/common/templates/steps/set-dry-run.yml@self
   - script: echo $(sourceBuildId) > $(Build.ArtifactStagingDirectory)/source-build-id.txt
     displayName: Write Source Build ID to File
-  - publish: $(Build.ArtifactStagingDirectory)/source-build-id.txt
-    artifact: source-build-id
-    displayName: Publish Source Build ID Artifact
+  - template: /eng/common/templates/steps/publish-artifact.yml@self
+    parameters:
+      path: $(Build.ArtifactStagingDirectory)/source-build-id.txt
+      artifactName: source-build-id
+      displayName: Publish Source Build ID Artifact
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
   - script: echo "##vso[task.setvariable variable=imageQueueTime]$(date --rfc-2822)"
     displayName: Set Publish Variables
   - script: >
@@ -79,16 +83,20 @@ jobs:
       $(imageBuilder.pathArgs)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Manifest
-  - publish: $(Build.ArtifactStagingDirectory)/image-info.json
-    artifact: image-info-final-$(System.JobAttempt)
-    displayName: Publish Image Info File Artifact
-  - template: ../steps/wait-for-mcr-image-ingestion.yml
+  - template: /eng/common/templates/steps/publish-artifact.yml@self
+    parameters:
+      path: $(Build.ArtifactStagingDirectory)/image-info.json
+      artifactName: image-info-final-$(System.JobAttempt)
+      displayName: Publish Image Info File Artifact
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
+  - template: /eng/common/templates/steps/wait-for-mcr-image-ingestion.yml@self
     parameters:
       imageInfoPath: '$(artifactsPath)/image-info.json'
       minQueueTime: $(imageQueueTime)
       dryRunArg: $(dryRunArg)
       condition: succeeded()
-  - template: ../steps/publish-readmes.yml
+  - template: /eng/common/templates/steps/publish-readmes.yml@self
     parameters:
       dryRunArg: $(dryRunArg)
       condition: and(succeeded(), eq(variables['publishReadme'], 'true'))
@@ -146,4 +154,4 @@ jobs:
       $(imageBuilder.commonCmdArgs)
     displayName: Post Publish Notification
     condition: and(always(), eq(variables['publishNotificationsEnabled'], 'true'))
-  - template: ../steps/cleanup-docker-linux.yml
+  - template: /eng/common/templates/steps/cleanup-docker-linux.yml@self

--- a/eng/common/templates/jobs/test-images-linux-client.yml
+++ b/eng/common/templates/jobs/test-images-linux-client.yml
@@ -19,7 +19,7 @@ jobs:
   pool: ${{ parameters.pool }}
   timeoutInMinutes: ${{ parameters.testJobTimeout }}
   steps:
-  - template: ../steps/test-images-linux-client.yml
+  - template: /eng/common/templates/steps/test-images-linux-client.yml@self
     parameters:
       preBuildValidation: ${{ parameters.preBuildValidation }}
       internalProjectName: ${{ parameters.internalProjectName }}

--- a/eng/common/templates/jobs/test-images-windows-client.yml
+++ b/eng/common/templates/jobs/test-images-windows-client.yml
@@ -15,7 +15,7 @@ jobs:
     matrix: $[ ${{ parameters.matrix }} ]
   timeoutInMinutes: ${{ parameters.testJobTimeout }}
   steps:
-  - template: ../steps/test-images-windows-client.yml
+  - template: /eng/common/templates/steps/test-images-windows-client.yml@self
     parameters:
       internalProjectName: ${{ parameters.internalProjectName }}
       customInitSteps: ${{ parameters.customInitSteps }}

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -46,7 +46,7 @@ stages:
 - stage: Build
   condition: and(succeeded(), contains(variables['stages'], 'build'))
   jobs:
-  - template: ../jobs/test-images-linux-client.yml
+  - template: /eng/common/templates/jobs/test-images-linux-client.yml@self
     parameters:
       name: PreBuildValidation
       pool: ${{ parameters.linuxAmd64Pool }}
@@ -64,14 +64,14 @@ stages:
             echo "##vso[task.setvariable variable=osVersions]"
             echo "##vso[task.setvariable variable=architecture]"
           displayName: Initialize Test Variables
-  - template: ../jobs/copy-base-images.yml
+  - template: /eng/common/templates/jobs/copy-base-images.yml@self
     parameters:
       name: CopyBaseImages
       pool: ${{ parameters.linuxAmd64Pool }}
       additionalOptions: "--manifest '$(manifest)' $(imageBuilder.pathArgs) $(manifestVariables)"
       publicProjectName: ${{ parameters.publicProjectName }}
       customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps}}
-  - template: ../jobs/generate-matrix.yml
+  - template: /eng/common/templates/jobs/generate-matrix.yml@self
     parameters:
       matrixType: ${{ parameters.buildMatrixType }}
       name: GenerateBuildMatrix
@@ -80,7 +80,7 @@ stages:
       internalProjectName: ${{ parameters.internalProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
+  - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Linux_amd64
       pool: ${{ parameters.linuxAmd64Pool }}
@@ -93,7 +93,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
+  - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Linux_arm64
       pool: ${{ parameters.linuxArm64Pool }}
@@ -106,7 +106,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
+  - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Linux_arm32
       pool: ${{ parameters.linuxArm32Pool }}
@@ -119,7 +119,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
+  - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Windows1809_amd64
       pool: ${{ parameters.windows1809Pool }}
@@ -132,7 +132,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
+  - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Windows2022_amd64
       pool: ${{ parameters.windows2022Pool }}
@@ -145,7 +145,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
+  - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: WindowsLtsc2016_amd64
       pool: ${{ parameters.windows2016Pool }}
@@ -166,9 +166,11 @@ stages:
   dependsOn: Build
   condition: and(succeeded(), contains(variables['stages'], 'build'))
   jobs:
-  - template: ../jobs/post-build.yml
+  - template: /eng/common/templates/jobs/post-build.yml@self
     parameters:
       pool: ${{ parameters.linuxAmd64Pool }}
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
 
 ################################################################################
 # Test Images
@@ -187,7 +189,7 @@ stages:
               contains(variables['stages'], 'build')),
             not(contains(variables['stages'], 'build')))))"
     jobs:
-    - template: ../jobs/generate-matrix.yml
+    - template: /eng/common/templates/jobs/generate-matrix.yml@self
       parameters:
         matrixType: ${{ parameters.testMatrixType }}
         name: GenerateTestMatrix
@@ -196,8 +198,7 @@ stages:
         isTestStage: true
         internalProjectName: ${{ parameters.internalProjectName }}
         publicProjectName: ${{ parameters.publicProjectName }}
-
-    - template: ../jobs/test-images-linux-client.yml
+    - template: /eng/common/templates/jobs/test-images-linux-client.yml@self
       parameters:
         name: Linux_amd64
         pool: ${{ parameters.linuxAmd64Pool }}
@@ -205,7 +206,7 @@ stages:
         testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
         customInitSteps: ${{ parameters.customTestInitSteps }}
-    - template: ../jobs/test-images-linux-client.yml
+    - template: /eng/common/templates/jobs/test-images-linux-client.yml@self
       parameters:
         name: Linux_arm64
         pool: ${{ parameters.linuxArm64Pool }}
@@ -213,7 +214,7 @@ stages:
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
         customInitSteps: ${{ parameters.customTestInitSteps }}
-    - template: ../jobs/test-images-linux-client.yml
+    - template: /eng/common/templates/jobs/test-images-linux-client.yml@self
       parameters:
         name: Linux_arm32
         pool: ${{ parameters.linuxArm32Pool }}
@@ -221,7 +222,7 @@ stages:
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
         customInitSteps: ${{ parameters.customTestInitSteps }}
-    - template: ../jobs/test-images-windows-client.yml
+    - template: /eng/common/templates/jobs/test-images-windows-client.yml@self
       parameters:
         name: Windows1809_amd64
         pool: ${{ parameters.windows1809Pool }}
@@ -229,7 +230,7 @@ stages:
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
         customInitSteps: ${{ parameters.customTestInitSteps }}
-    - template: ../jobs/test-images-windows-client.yml
+    - template: /eng/common/templates/jobs/test-images-windows-client.yml@self
       parameters:
         name: Windows2022_amd64
         pool: ${{ parameters.windows2022Pool }}
@@ -237,7 +238,7 @@ stages:
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
         customInitSteps: ${{ parameters.customTestInitSteps }}
-    - template: ../jobs/test-images-windows-client.yml
+    - template: /eng/common/templates/jobs/test-images-windows-client.yml@self
       parameters:
         name: WindowsLtsc2016_amd64
         pool: ${{ parameters.windows2016Pool }}
@@ -284,7 +285,7 @@ stages:
               contains(variables['stages'], 'build'),
               contains(variables['stages'], 'test'))))))"
   jobs:
-  - template: ../jobs/publish.yml
+  - template: /eng/common/templates/jobs/publish.yml@self
     parameters:
       pool: ${{ parameters.linuxAmd64Pool }}
       internalProjectName: ${{ parameters.internalProjectName }}

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -19,7 +19,7 @@ parameters:
   testMatrixType: platformVersionedOs
 
 stages:
-- template: ../build-test-publish-repo.yml
+- template: /eng/common/templates/stages/build-test-publish-repo.yml@self
   parameters:
     noCache: ${{ parameters.noCache }}
     internalProjectName: ${{ parameters.internalProjectName }}
@@ -61,6 +61,7 @@ stages:
       customPublishVariables:
       - group: DotNet-AllOrgs-Darc-Pats
 
+    # Linux AMD64
     linuxAmd64Pool:
       ${{ if ne(parameters.linuxAmd64Pool, '') }}:
         ${{ parameters.linuxAmd64Pool }}
@@ -68,18 +69,47 @@ stages:
         vmImage: $(defaultLinuxAmd64PoolImage)
       ${{ elseif eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+        image: 1es-ubuntu-2204
+        os: linux
     
+    # Linux Arm64
     linuxArm64Pool:
+      image: Mariner-2-Docker-ARM64
+      os: linux
+      hostArchitecture: Arm64
       ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-        name: DotNetCoreDocker-Public
+        name: Docker-Linux-Arm-Public
       ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
         name: Docker-Linux-Arm-Internal
+
+    # Linux Arm32
     linuxArm32Pool:
+      image: Mariner-2-Docker-ARM64
+      os: linux
+      hostArchitecture: Arm64
       ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-        name: DotNetCoreDocker-Public
+        name: Docker-Linux-Arm-Public
       ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
         name: Docker-Linux-Arm-Internal
+
+    # Windows Server 2016
+    # TODO: Update this to 1ES-compatible pool
     windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
-    windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
-    windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}
+
+    # Windows Server 2019 (1809)
+    ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+      windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
+    ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+      windows1809Pool:
+        name: NetCore1ESPool-Internal
+        image: 1es-windows-2019
+        os: windows
+
+    # Windows Server 2022
+    ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+      windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}
+    ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+      windows2022Pool:
+        name: NetCore1ESPool-Internal
+        image: 1es-windows-2022
+        os: windows

--- a/eng/common/templates/steps/copy-base-images.yml
+++ b/eng/common/templates/steps/copy-base-images.yml
@@ -5,7 +5,7 @@ parameters:
   
 steps:
 - ${{ if or(eq(variables['System.TeamProject'], parameters.publicProjectName), eq(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: ../steps/set-dry-run.yml
+  - template: /eng/common/templates/steps/set-dry-run.yml@self
 - script: >
     $(runImageBuilderCmd)
     copyBaseImages

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -5,7 +5,7 @@ parameters:
   condition: true
 
 steps:
-- template: init-common.yml
+- template: /eng/common/templates/steps/init-common.yml@self
   parameters:
     condition: ${{ parameters.condition }}
 - script: echo "##vso[task.setvariable variable=artifactsPath]/artifacts"

--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -3,7 +3,7 @@ parameters:
   condition: true
 
 steps:
-- template: init-common.yml
+- template: /eng/common/templates/steps/init-common.yml@self
   parameters:
     condition: ${{ parameters.condition }}
 - powershell: echo "##vso[task.setvariable variable=artifactsPath]$(Build.ArtifactStagingDirectory)"
@@ -13,7 +13,7 @@ steps:
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
-- template: cleanup-docker-windows.yml
+- template: /eng/common/templates/steps/cleanup-docker-windows.yml@self
   parameters:
     condition: ${{ parameters.condition }}
 

--- a/eng/common/templates/steps/publish-artifact.yml
+++ b/eng/common/templates/steps/publish-artifact.yml
@@ -1,0 +1,28 @@
+parameters:
+- name: path
+  type: string
+- name: artifactName
+  type: string
+- name: displayName
+  type: string
+- name: internalProjectName
+  type: string
+- name: publicProjectName
+  type: string
+- name: condition
+  type: string
+  default: 'true'
+
+steps:
+- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+  - task: 1ES.PublishPipelineArtifact@1
+    inputs:
+      path: ${{ parameters.path }}
+      artifact: ${{ parameters.artifactName }}
+    displayName: ${{ parameters.displayName }}
+    condition: and(succeeded(), ${{ parameters.condition }})
+- ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+  - publish: ${{ parameters.path }}
+    artifact: ${{ parameters.artifactName }}
+    displayName: ${{ parameters.displayName }}
+    condition: and(succeeded(), ${{ parameters.condition }})

--- a/eng/common/templates/steps/publish-readmes.yml
+++ b/eng/common/templates/steps/publish-readmes.yml
@@ -22,7 +22,7 @@ steps:
   name: PublishReadmes
   displayName: Publish Readmes
   condition: ${{ parameters.condition }}
-- template: wait-for-mcr-doc-ingestion.yml
+- template: /eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml@self
   parameters:
     commitDigest: $(PublishReadmes.readmeCommitDigest)
     condition: and(${{ parameters.condition }}, ne(variables['PublishReadmes.readmeCommitDigest'], ''))

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -5,7 +5,7 @@ parameters:
   customInitSteps: []
 
 steps:
-- template: init-docker-linux.yml
+- template: /eng/common/templates/steps/init-docker-linux.yml@self
   parameters:
     setupImageBuilder: false
     setupTestRunner: true
@@ -33,7 +33,8 @@ steps:
     docker run -t -d
     -v /var/run/docker.sock:/var/run/docker.sock
     -v $(Build.ArtifactStagingDirectory):$(artifactsPath)
-    -e RUNNING_TESTS_IN_CONTAINER=true 
+    -e DOCKER_BUILDKIT=1
+    -e RUNNING_TESTS_IN_CONTAINER=true
     --name $(testRunner.container)
     $(imageNames.testRunner.withrepo)
   displayName: Start Test Runner Container
@@ -46,12 +47,12 @@ steps:
     displayName: Docker login
     condition: and(succeeded(), ${{ parameters.condition }})
   - ${{ if eq(parameters.preBuildValidation, 'false') }}:
-    - template: ../steps/download-build-artifact.yml
+    - template: /eng/common/templates/steps/download-build-artifact.yml@self
       parameters:
         targetPath: $(Build.ArtifactStagingDirectory)
         artifactName: image-info
         condition: ${{ parameters.condition }}
-- template: parse-test-arg-arrays.yml
+- template: /eng/common/templates/steps/parse-test-arg-arrays.yml@self
 - powershell: >
     $(test.init);
     docker exec
@@ -96,6 +97,6 @@ steps:
   condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: cleanup-docker-linux.yml
+  - template: /eng/common/templates/steps/cleanup-docker-linux.yml@self
     parameters:
       condition: ${{ parameters.condition }}

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -5,7 +5,7 @@ parameters:
 
 steps:
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: init-docker-windows.yml
+  - template: /eng/common/templates/steps/init-docker-windows.yml@self
     parameters:
       setupImageBuilder: false
       condition: ${{ parameters.condition }}
@@ -29,12 +29,12 @@ steps:
   displayName: Cleanup Old Test Results
   condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: ../steps/download-build-artifact.yml
+  - template: /eng/common/templates/steps/download-build-artifact.yml@self
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
       artifactName: image-info
       condition: ${{ parameters.condition }}
-- template: parse-test-arg-arrays.yml
+- template: /eng/common/templates/steps/parse-test-arg-arrays.yml@self
 - powershell: >
     $(test.init);
     $(testScriptPath)
@@ -59,6 +59,6 @@ steps:
     publishRunAttachments: true
     testRunTitle: $(productVersion) $(osVersionsDisplayName) amd64
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: cleanup-docker-windows.yml
+  - template: /eng/common/templates/steps/cleanup-docker-windows.yml@self
     parameters:
       condition: ${{ parameters.condition }}

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -1,6 +1,6 @@
 variables:
-- template: docker-images.yml
-- template: common-paths.yml
+- template: /eng/common/templates/variables/docker-images.yml@self
+- template: /eng/common/templates/variables/common-paths.yml@self
 - name: stagingRepoPrefix
   value: build-staging/$(sourceBuildId)/
 - name: publishReadme

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,6 +1,6 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2207880
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2401836
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
-  imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-bullseye-slim-docker-testrunner
+  imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner2.0-docker-testrunner
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -1,7 +1,7 @@
 # Common variables for building/testing/publishing in the .NET team's pipelines
 
 variables:
-- template: common.yml
+- template: /eng/common/templates/variables/dotnet/common.yml@self
 
 - name: commonVersionsImageInfoPath
   value: build-info/docker

--- a/eng/common/templates/variables/dotnet/common.yml
+++ b/eng/common/templates/variables/dotnet/common.yml
@@ -1,5 +1,5 @@
 variables:
-- template: ../common.yml
+- template: /eng/common/templates/variables/common.yml@self
 - name: publicProjectName
   value: public
 - name: internalProjectName

--- a/eng/compliance/tsaoptions.json
+++ b/eng/compliance/tsaoptions.json
@@ -1,0 +1,14 @@
+{
+    "codebaseName": "Go",
+    "notificationAliases": [
+      "golangdev@microsoft.com"
+    ],
+    "codebaseAdmins": [
+      "redmond\\golangdev"
+    ],
+    "instanceUrl": "https://devdiv.visualstudio.com/",
+    "projectName": "DEVDIV",
+    "areaPath": "DevDiv\\NET Compilers\\GoLang",
+    "iterationPath": "DevDiv",
+    "allTools": true
+  }

--- a/eng/pipeline/go-docker-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline.yml
@@ -4,11 +4,29 @@ pr: none
 variables:
   - template: variables/common.yml
 
-stages:
-  - template: stages/build-test-publish-repo.yml
-    parameters:
-      extraParameters:
-        # "variables.x" template expression only gets the correct value in this pipeline file. In a
-        # stage template, it returns an empty string. So, evaluate it here and pass it through.
-        internalProjectName: ${{ variables.internalProjectName }}
-        publicProjectName: ${{ variables.publicProjectName }}
+resources:
+  repositories:
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: NetCore1ESPool-Svc-Internal
+        image: 1es-windows-2022
+        os: windows
+      tsa:
+        enabled: true
+        configFile: $(Build.SourcesDirectory)/eng/compliance/tsaoptions.json
+    stages:
+      - template: stages/build-test-publish-repo.yml
+        parameters:
+          extraParameters:
+            # "variables.x" template expression only gets the correct value in this pipeline file. In a
+            # stage template, it returns an empty string. So, evaluate it here and pass it through.
+            internalProjectName: ${{ variables.internalProjectName }}
+            publicProjectName: ${{ variables.publicProjectName }}

--- a/eng/pipeline/stages/build-test-publish-repo.yml
+++ b/eng/pipeline/stages/build-test-publish-repo.yml
@@ -15,11 +15,17 @@ stages:
         - template: ../../../pipeline/steps/set-public-source-branch-var.yml
       # Specific pools for arm builds.
       linuxArm64Pool:
+        image: Mariner-2-Docker-ARM64
+        os: linux
+        hostArchitecture: Arm64
         ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
           name: Docker-Linux-Arm-Public
         ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
           name: Docker-Linux-Arm-Internal
       linuxArm32Pool:
+        image: Mariner-2-Docker-ARM64
+        os: linux
+        hostArchitecture: Arm64
         ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
           name: Docker-Linux-Arm-Public
         ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
@@ -27,8 +33,20 @@ stages:
       # On Windows, 'docker login' is incompatible with 'manifest-tool' unless we use these pools.
       # https://github.com/dotnet/docker-tools/issues/905
       windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
-      windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
-      windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}
+      ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
+        windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
+      ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
+        windows1809Pool:
+          name: NetCore1ESPool-Internal
+          image: 1es-windows-2019
+          os: windows
+      ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
+        windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}
+      ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
+        windows2022Pool:
+          name: NetCore1ESPool-Internal
+          image: 1es-windows-2022
+          os: windows
       # Use 1ES pools to avoid contention in AzDO hosted pools.
       linuxAmd64Pool:
         ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:
@@ -36,7 +54,8 @@ stages:
           demands: ImageOverride -equals build.ubuntu.2204.amd64.open
         ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.internalProjectName) }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals build.ubuntu.2204.amd64
+          image: 1es-ubuntu-2204
+          os: linux
 
       ${{ each pair in parameters.extraParameters }}:
         ${{ pair.key }}: ${{ pair.value }}


### PR DESCRIPTION
Add 1ES PT to the production pipelines.

Execution example: https://dev.azure.com/dnceng/internal/_build/results?buildId=2405257&view=results.
I've already reported the warning to the dotnet team: https://github.com/dotnet/docker-tools/pull/1215#issuecomment-1999394055.

There is a known non-blocking issue while generating SBoM artifacts tracked in https://github.com/dotnet/docker-tools/issues/1216.

