### PR TITLE
Update nightly based on main pipeline for 1ES PT

### DIFF
--- a/eng/pipeline/go-docker-nightly-pr-pipeline.yml
+++ b/eng/pipeline/go-docker-nightly-pr-pipeline.yml
@@ -20,3 +20,7 @@ stages:
         publicProjectName: ${{ variables.publicProjectName }}
         buildMatrixType: platformVersionedOs
   - template: stages/check-generation-repeatable.yml
+    parameters:
+      extraParameters:
+        internalProjectName: ${{ variables.internalProjectName }}
+        publicProjectName: ${{ variables.publicProjectName }}

--- a/eng/pipeline/go-docker-nightly-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-nightly-rolling-internal-pipeline.yml
@@ -11,11 +11,26 @@ variables:
     parameters:
       nightly: true
 
-stages:
-  - template: stages/build-test-publish-repo.yml
-    parameters:
-      extraParameters:
-        # "variables.x" template expression only gets the correct value in this pipeline file. In a
-        # stage template, it returns an empty string. So, evaluate it here and pass it through.
-        internalProjectName: ${{ variables.internalProjectName }}
-        publicProjectName: ${{ variables.publicProjectName }}
+resources:
+  repositories:
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: NetCore1ESPool-Svc-Internal
+        image: 1es-windows-2022
+        os: windows
+    stages:
+      - template: stages/build-test-publish-repo.yml
+        parameters:
+          extraParameters:
+            # "variables.x" template expression only gets the correct value in this pipeline file. In a
+            # stage template, it returns an empty string. So, evaluate it here and pass it through.
+            internalProjectName: ${{ variables.internalProjectName }}
+            publicProjectName: ${{ variables.publicProjectName }}


### PR DESCRIPTION
Make the nightly pipeline use the unofficial templates by copying over some yml from the main pipeline.

https://dev.azure.com/dnceng/internal/_build/results?buildId=2419535&view=results

This change is made to microsoft/main and then merged into microsoft/nightly so that we preserve zero diff between the branches.

(We don't currently use nightly for anything important, but it isn't hard to maintain for now.)