### PR TITLE
Run tdnf update before installing mariner deps

### DIFF
--- a/patches/0002-Add-Mariner-support-with-FIPS-dependency-flag.patch
+++ b/patches/0002-Add-Mariner-support-with-FIPS-dependency-flag.patch
@@ -4,14 +4,14 @@ Date: Fri, 11 Feb 2022 18:07:18 -0600
 Subject: [PATCH] Add Mariner support with FIPS dependency flag
 
 ---
- Dockerfile-linux.template | 59 +++++++++++++++++++++++++++++++++++++++
- 1 file changed, 59 insertions(+)
+ Dockerfile-linux.template | 60 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 60 insertions(+)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index 3d8ddc4235a658..0bc708016e8b10 100644
+index 3d8ddc4235a658..4430ee28c990cb 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
-@@ -4,11 +4,47 @@
+@@ -4,11 +4,48 @@
  	;
  	def alpine_version:
  		env.variant | ltrimstr("alpine")
@@ -33,7 +33,8 @@ index 3d8ddc4235a658..0bc708016e8b10 100644
 +{{ ) elif is_cbl_mariner then ( -}}
 +FROM mcr.microsoft.com/cbl-mariner/base/core:{{ cbl_mariner_version }}
 +
-+RUN tdnf install -y \
++RUN tdnf update -y; \
++	tdnf install -y \
 +		binutils \
 +		gcc \
 +		glibc \
@@ -59,7 +60,7 @@ index 3d8ddc4235a658..0bc708016e8b10 100644
  {{ ) else ( -}}
  FROM buildpack-deps:{{ env.variant }}-scm
  
-@@ -21,6 +57,14 @@ RUN set -eux; \
+@@ -21,6 +58,14 @@ RUN set -eux; \
  		libc6-dev \
  		make \
  		pkg-config \
@@ -74,7 +75,7 @@ index 3d8ddc4235a658..0bc708016e8b10 100644
  	; \
  	rm -rf /var/lib/apt/lists/*
  {{ ) end -}}
-@@ -41,6 +85,13 @@ ENV GOLANG_VERSION {{ .version }}
+@@ -41,6 +86,13 @@ ENV GOLANG_VERSION {{ .version }}
  				ppc64le: "ppc64le",
  				s390x: "s390x",
  			}
@@ -88,7 +89,7 @@ index 3d8ddc4235a658..0bc708016e8b10 100644
  		else
  			{
  				amd64: "amd64",
-@@ -58,6 +109,8 @@ RUN set -eux; \
+@@ -58,6 +110,8 @@ RUN set -eux; \
  {{ if is_alpine then ( -}}
  	apk add --no-cache --virtual .fetch-deps gnupg; \
  	arch="$(apk --print-arch)"; \
@@ -97,7 +98,7 @@ index 3d8ddc4235a658..0bc708016e8b10 100644
  {{ ) else ( -}}
  	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
  {{ ) end -}}
-@@ -112,10 +165,16 @@ RUN set -eux; \
+@@ -112,10 +166,16 @@ RUN set -eux; \
  	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
  	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
  	gpg --batch --import microsoft-managed-lang-compiler.asc; \

--- a/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
@@ -6,7 +6,8 @@
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
-RUN tdnf install -y \
+RUN tdnf update -y; \
+	tdnf install -y \
 		binutils \
 		gcc \
 		glibc \

--- a/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
@@ -6,7 +6,8 @@
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
-RUN tdnf install -y \
+RUN tdnf update -y; \
+	tdnf install -y \
 		binutils \
 		gcc \
 		glibc \


### PR DESCRIPTION
Running `tdnf update` before `tdnf install` on Mariner is recommended in Microsoft's [Containers Secure Supply Chain](https://eng.ms/docs/more/containers-secure-supply-chain/updating) guide. It ensures that we get the latest patches for vulnerabilities that fixes in the package manager but still unfixed in the base image.

In particular, this will help to remediate a S360 alert which reports several of our Mariner images to contain the CVE-2022-4899 vulnerability. It has been fixed in the Mariner package manager but no image has been released yet with the fix. 