### PR TITLE
Update from upstream and fix missing `set -eux`

### DIFF
--- a/patches/0001-Check-signature-of-microsoft-go-builds.patch
+++ b/patches/0001-Check-signature-of-microsoft-go-builds.patch
@@ -10,12 +10,12 @@ public key from an https Microsoft URL to check the signature against.
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index cde43a9..c300098 100644
+index 1bfd5d4910a837..1c8c549b281edc 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
-@@ -109,12 +109,14 @@ RUN set -eux; \
- {{ ) end -}}
- 	fi; \
+@@ -87,12 +87,14 @@ RUN set -eux; \
+ 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+ 	esac; \
  	\
 -	wget -O go.tgz.asc "$url.asc"; \
 +	wget -O go.tgz.asc "$url.sig"; \

--- a/patches/0002-Add-Mariner-FIPS-package-upgrade.patch
+++ b/patches/0002-Add-Mariner-FIPS-package-upgrade.patch
@@ -1,14 +1,14 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: microsoft-golang-bot <microsoft-golang-bot@users.noreply.github.com>
 Date: Fri, 11 Feb 2022 18:07:18 -0600
-Subject: [PATCH] Add Mariner support with FIPS dependency flag
+Subject: [PATCH] Add Mariner, FIPS, package upgrade
 
 ---
- Dockerfile-linux.template | 62 +++++++++++++++++++++++++++++++++++++++
- 1 file changed, 62 insertions(+)
+ Dockerfile-linux.template | 66 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 66 insertions(+)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index 1c8c549b281edc..cda83dcbfcdea4 100644
+index 1c8c549b281edc..58392a2e0d3205 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
 @@ -4,9 +4,21 @@
@@ -73,14 +73,16 @@ index 1c8c549b281edc..cda83dcbfcdea4 100644
  	gpg --batch --verify go.tgz.asc go.tgz; \
  	gpgconf --kill all; \
  	rm -rf "$GNUPGHOME" go.tgz.asc; \
-@@ -142,6 +169,33 @@ RUN set -eux; \
+@@ -142,18 +169,57 @@ RUN set -eux; \
  FROM alpine:{{ alpine_version }}
  
  RUN apk add --no-cache ca-certificates
 +{{ ) elif is_cbl_mariner then ( -}}
 +FROM mcr.microsoft.com/cbl-mariner/base/core:{{ cbl_mariner_version }}
 +
-+RUN tdnf update -y; \
++RUN set -eux; \
++# Upgrade all packages per https://eng.ms/docs/more/containers-secure-supply-chain/updating
++	tdnf update -y; \
 +	tdnf install -y \
 +		binutils \
 +		gcc \
@@ -107,7 +109,14 @@ index 1c8c549b281edc..cda83dcbfcdea4 100644
  {{ ) else ( -}}
  FROM buildpack-deps:{{ env.variant }}-scm
  
-@@ -154,6 +208,14 @@ RUN set -eux; \
+ # install cgo-related dependencies
+ RUN set -eux; \
+ 	apt-get update; \
++# Upgrade all packages per https://eng.ms/docs/more/containers-secure-supply-chain/updating
++	apt-get upgrade -y; \
+ 	apt-get install -y --no-install-recommends \
+ 		g++ \
+ 		gcc \
  		libc6-dev \
  		make \
  		pkg-config \

--- a/patches/0002-Add-Mariner-FIPS-package-upgrade.patch
+++ b/patches/0002-Add-Mariner-FIPS-package-upgrade.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Add Mariner, FIPS, package upgrade
  1 file changed, 66 insertions(+)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index 1c8c549b281edc..58392a2e0d3205 100644
+index 1c8c549b281edc..148a7866d0ea32 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
 @@ -4,9 +4,21 @@
@@ -29,7 +29,7 @@ index 1c8c549b281edc..58392a2e0d3205 100644
  {{ if is_alpine then ( -}}
  FROM alpine:{{ alpine_version }} AS build
 +{{ ) elif is_cbl_mariner then ( -}}
-+FROM mcr.microsoft.com/cbl-mariner/base/core:{{ cbl_mariner_version }}
++FROM mcr.microsoft.com/cbl-mariner/base/core:{{ cbl_mariner_version }} AS build
  {{ ) else ( -}}
  FROM buildpack-deps:{{ env.variant }}-scm AS build
  {{ ) end -}}

--- a/patches/0002-Add-Mariner-FIPS-package-upgrade.patch
+++ b/patches/0002-Add-Mariner-FIPS-package-upgrade.patch
@@ -4,14 +4,14 @@ Date: Fri, 11 Feb 2022 18:07:18 -0600
 Subject: [PATCH] Add Mariner, FIPS, package upgrade
 
 ---
- Dockerfile-linux.template | 66 +++++++++++++++++++++++++++++++++++++++
- 1 file changed, 66 insertions(+)
+ Dockerfile-linux.template | 76 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 76 insertions(+)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index 1c8c549b281edc..148a7866d0ea32 100644
+index 1c8c549b281edc..b8849cc2142d76 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
-@@ -4,9 +4,21 @@
+@@ -4,9 +4,31 @@
  	;
  	def alpine_version:
  		env.variant | ltrimstr("alpine")
@@ -30,10 +30,20 @@ index 1c8c549b281edc..148a7866d0ea32 100644
  FROM alpine:{{ alpine_version }} AS build
 +{{ ) elif is_cbl_mariner then ( -}}
 +FROM mcr.microsoft.com/cbl-mariner/base/core:{{ cbl_mariner_version }} AS build
++
++# Dependencies needed to get the Go tarball. We never build Go from source in this Dockerfile.
++RUN set -eux; \
++# Upgrade all packages per https://eng.ms/docs/more/containers-secure-supply-chain/updating
++	tdnf update -y; \
++	tdnf install -y \
++		tar \
++		wget \
++	; \
++	tdnf clean all
  {{ ) else ( -}}
  FROM buildpack-deps:{{ env.variant }}-scm AS build
  {{ ) end -}}
-@@ -30,6 +42,13 @@ ENV GOLANG_VERSION {{ .version }}
+@@ -30,6 +52,13 @@ ENV GOLANG_VERSION {{ .version }}
  				riscv64: "riscv64",
  				s390x: "s390x",
  			}
@@ -47,7 +57,7 @@ index 1c8c549b281edc..148a7866d0ea32 100644
  		else
  			{
  				# https://salsa.debian.org/dpkg-team/dpkg/-/blob/main/data/cputable
-@@ -59,6 +78,8 @@ RUN set -eux; \
+@@ -59,6 +88,8 @@ RUN set -eux; \
  		tar \
  	; \
  	arch="$(apk --print-arch)"; \
@@ -56,7 +66,7 @@ index 1c8c549b281edc..148a7866d0ea32 100644
  {{ ) else ( -}}
  	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
  {{ ) end -}}
-@@ -95,10 +116,16 @@ RUN set -eux; \
+@@ -95,10 +126,16 @@ RUN set -eux; \
  	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
  	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
  	gpg --batch --import microsoft-managed-lang-compiler.asc; \
@@ -73,7 +83,7 @@ index 1c8c549b281edc..148a7866d0ea32 100644
  	gpg --batch --verify go.tgz.asc go.tgz; \
  	gpgconf --kill all; \
  	rm -rf "$GNUPGHOME" go.tgz.asc; \
-@@ -142,18 +169,57 @@ RUN set -eux; \
+@@ -142,18 +179,57 @@ RUN set -eux; \
  FROM alpine:{{ alpine_version }}
  
  RUN apk add --no-cache ca-certificates

--- a/patches/0002-Add-Mariner-support-with-FIPS-dependency-flag.patch
+++ b/patches/0002-Add-Mariner-support-with-FIPS-dependency-flag.patch
@@ -4,14 +4,14 @@ Date: Fri, 11 Feb 2022 18:07:18 -0600
 Subject: [PATCH] Add Mariner support with FIPS dependency flag
 
 ---
- Dockerfile-linux.template | 60 +++++++++++++++++++++++++++++++++++++++
- 1 file changed, 60 insertions(+)
+ Dockerfile-linux.template | 62 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 62 insertions(+)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index 3d8ddc4235a658..4430ee28c990cb 100644
+index 1c8c549b281edc..cda83dcbfcdea4 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
-@@ -4,11 +4,48 @@
+@@ -4,9 +4,21 @@
  	;
  	def alpine_version:
  		env.variant | ltrimstr("alpine")
@@ -27,6 +27,53 @@ index 3d8ddc4235a658..4430ee28c990cb 100644
 +		(.branchSuffix // "") | contains("fips")
  -}}
  {{ if is_alpine then ( -}}
+ FROM alpine:{{ alpine_version }} AS build
++{{ ) elif is_cbl_mariner then ( -}}
++FROM mcr.microsoft.com/cbl-mariner/base/core:{{ cbl_mariner_version }}
+ {{ ) else ( -}}
+ FROM buildpack-deps:{{ env.variant }}-scm AS build
+ {{ ) end -}}
+@@ -30,6 +42,13 @@ ENV GOLANG_VERSION {{ .version }}
+ 				riscv64: "riscv64",
+ 				s390x: "s390x",
+ 			}
++		elif is_cbl_mariner then
++			{
++				amd64: "x86_64",
++				arm32v6: "armhf",
++				arm32v7: "armv7",
++				arm64v8: "aarch64",
++			}
+ 		else
+ 			{
+ 				# https://salsa.debian.org/dpkg-team/dpkg/-/blob/main/data/cputable
+@@ -59,6 +78,8 @@ RUN set -eux; \
+ 		tar \
+ 	; \
+ 	arch="$(apk --print-arch)"; \
++{{ ) elif is_cbl_mariner then ( -}}
++	arch="$(uname -m)"; \
+ {{ ) else ( -}}
+ 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+ {{ ) end -}}
+@@ -95,10 +116,16 @@ RUN set -eux; \
+ 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+ 	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
+ 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
++{{ if is_cbl_mariner then ( -}}
++# Mariner 2.0 doesn't include dirmngr, which is required for keyserver import. Skipping keyserver
++# import. In microsoft/go-images, we use a manually imported key anyway.
++# See https://github.com/microsoft/CBL-Mariner/issues/3142
++{{ ) else ( -}}
+ # https://www.google.com/linuxrepositories/
+ 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+ # let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+ 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
++{{ ) end -}}
+ 	gpg --batch --verify go.tgz.asc go.tgz; \
+ 	gpgconf --kill all; \
+ 	rm -rf "$GNUPGHOME" go.tgz.asc; \
+@@ -142,6 +169,33 @@ RUN set -eux; \
  FROM alpine:{{ alpine_version }}
  
  RUN apk add --no-cache ca-certificates
@@ -60,7 +107,7 @@ index 3d8ddc4235a658..4430ee28c990cb 100644
  {{ ) else ( -}}
  FROM buildpack-deps:{{ env.variant }}-scm
  
-@@ -21,6 +58,14 @@ RUN set -eux; \
+@@ -154,6 +208,14 @@ RUN set -eux; \
  		libc6-dev \
  		make \
  		pkg-config \
@@ -75,43 +122,3 @@ index 3d8ddc4235a658..4430ee28c990cb 100644
  	; \
  	rm -rf /var/lib/apt/lists/*
  {{ ) end -}}
-@@ -41,6 +86,13 @@ ENV GOLANG_VERSION {{ .version }}
- 				ppc64le: "ppc64le",
- 				s390x: "s390x",
- 			}
-+		elif is_cbl_mariner then
-+			{
-+				amd64: "x86_64",
-+				arm32v6: "armhf",
-+				arm32v7: "armv7",
-+				arm64v8: "aarch64",
-+			}
- 		else
- 			{
- 				amd64: "amd64",
-@@ -58,6 +110,8 @@ RUN set -eux; \
- {{ if is_alpine then ( -}}
- 	apk add --no-cache --virtual .fetch-deps gnupg; \
- 	arch="$(apk --print-arch)"; \
-+{{ ) elif is_cbl_mariner then ( -}}
-+	arch="$(uname -m)"; \
- {{ ) else ( -}}
- 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
- {{ ) end -}}
-@@ -112,10 +166,16 @@ RUN set -eux; \
- 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
- 	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
- 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
-+{{ if is_cbl_mariner then ( -}}
-+# Mariner 2.0 doesn't include dirmngr, which is required for keyserver import. Skipping keyserver
-+# import. In microsoft/go-images, we use a manually imported key anyway.
-+# See https://github.com/microsoft/CBL-Mariner/issues/3142
-+{{ ) else ( -}}
- # https://www.google.com/linuxrepositories/
- 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
- # let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
- 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
-+{{ ) end -}}
- 	gpg --batch --verify go.tgz.asc go.tgz; \
- 	gpgconf --kill all; \
- 	rm -rf "$GNUPGHOME" go.tgz.asc; \

--- a/patches/0005-Use-MCR-mirror-for-buildpack-deps.patch
+++ b/patches/0005-Use-MCR-mirror-for-buildpack-deps.patch
@@ -8,19 +8,19 @@ Subject: [PATCH] Use MCR mirror for buildpack-deps
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index 148a7866d0ea32..2e94b17bd367bf 100644
+index b8849cc2142d76..d71d53dde7565e 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
-@@ -20,7 +20,7 @@ FROM alpine:{{ alpine_version }} AS build
- {{ ) elif is_cbl_mariner then ( -}}
- FROM mcr.microsoft.com/cbl-mariner/base/core:{{ cbl_mariner_version }} AS build
+@@ -30,7 +30,7 @@ RUN set -eux; \
+ 	; \
+ 	tdnf clean all
  {{ ) else ( -}}
 -FROM buildpack-deps:{{ env.variant }}-scm AS build
 +FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:{{ env.variant }}-scm AS build
  {{ ) end -}}
  
  ENV PATH /usr/local/go/bin:$PATH
-@@ -199,7 +199,7 @@ RUN set -eux; \
+@@ -209,7 +209,7 @@ RUN set -eux; \
  	tdnf clean all
  
  {{ ) else ( -}}

--- a/patches/0005-Use-MCR-mirror-for-buildpack-deps.patch
+++ b/patches/0005-Use-MCR-mirror-for-buildpack-deps.patch
@@ -8,12 +8,12 @@ Subject: [PATCH] Use MCR mirror for buildpack-deps
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index 58392a2e0d3205..0e95c066e38cec 100644
+index 148a7866d0ea32..2e94b17bd367bf 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
 @@ -20,7 +20,7 @@ FROM alpine:{{ alpine_version }} AS build
  {{ ) elif is_cbl_mariner then ( -}}
- FROM mcr.microsoft.com/cbl-mariner/base/core:{{ cbl_mariner_version }}
+ FROM mcr.microsoft.com/cbl-mariner/base/core:{{ cbl_mariner_version }} AS build
  {{ ) else ( -}}
 -FROM buildpack-deps:{{ env.variant }}-scm AS build
 +FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:{{ env.variant }}-scm AS build

--- a/patches/0005-Use-MCR-mirror-for-buildpack-deps.patch
+++ b/patches/0005-Use-MCR-mirror-for-buildpack-deps.patch
@@ -4,14 +4,23 @@ Date: Fri, 3 Jun 2022 12:26:05 -0500
 Subject: [PATCH] Use MCR mirror for buildpack-deps
 
 ---
- Dockerfile-linux.template | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ Dockerfile-linux.template | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index e83d5ab..f661a6b 100644
+index 58392a2e0d3205..0e95c066e38cec 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
-@@ -46,7 +46,7 @@ RUN tdnf install -y \
+@@ -20,7 +20,7 @@ FROM alpine:{{ alpine_version }} AS build
+ {{ ) elif is_cbl_mariner then ( -}}
+ FROM mcr.microsoft.com/cbl-mariner/base/core:{{ cbl_mariner_version }}
+ {{ ) else ( -}}
+-FROM buildpack-deps:{{ env.variant }}-scm AS build
++FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:{{ env.variant }}-scm AS build
+ {{ ) end -}}
+ 
+ ENV PATH /usr/local/go/bin:$PATH
+@@ -199,7 +199,7 @@ RUN set -eux; \
  	tdnf clean all
  
  {{ ) else ( -}}

--- a/patches/0006-Remove-link-not-known-by-builder.patch
+++ b/patches/0006-Remove-link-not-known-by-builder.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Thu, 4 Apr 2024 10:57:18 -0500
+Subject: [PATCH] Remove "--link" not known by builder
+
+Fix this error in our build:
+
+  dockerfile parse error line 101: Unknown flag: link
+
+This is ok to remove: "--link" in combination with using a multi-stage
+Dockerfile allows upstream to enable smart reuse of image layers, but our build
+infrastructure isn't set up to take advantage of this.
+---
+ Dockerfile-linux.template | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
+index 0e95c066e38cec..39b40e297e05b1 100644
+--- a/Dockerfile-linux.template
++++ b/Dockerfile-linux.template
+@@ -232,6 +232,6 @@ ENV GOTOOLCHAIN=local
+ 
+ ENV GOPATH /go
+ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+-COPY --from=build --link /usr/local/go/ /usr/local/go/
++COPY --from=build /usr/local/go/ /usr/local/go/
+ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
+ WORKDIR $GOPATH

--- a/src/microsoft/1.21/bookworm/Dockerfile
+++ b/src/microsoft/1.21/bookworm/Dockerfile
@@ -4,19 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm
-
-# install cgo-related dependencies
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		g++ \
-		gcc \
-		libc6-dev \
-		make \
-		pkg-config \
-	; \
-	rm -rf /var/lib/apt/lists/*
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm AS build
 
 ENV PATH /usr/local/go/bin:$PATH
 
@@ -40,16 +28,6 @@ RUN set -eux; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
-	build=; \
-	if [ -z "$url" ]; then \
-# https://github.com/golang/go/issues/38536#issuecomment-616897960
-		build=1; \
-		url=null; \
-		sha256=null; \
-		echo >&2; \
-		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
-		echo >&2; \
-	fi; \
 	\
 	wget -O go.tgz.asc "$url.sig"; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
@@ -70,40 +48,56 @@ RUN set -eux; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
-	if [ -n "$build" ]; then \
-		savedAptMark="$(apt-mark showmanual)"; \
-		apt-get update; \
-		apt-get install -y --no-install-recommends golang-go; \
-		\
-		export GOCACHE='/tmp/gocache'; \
-		\
-		( \
-			cd /usr/local/go/src; \
-# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
-			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
-			./make.bash; \
-		); \
-		\
-		apt-mark auto '.*' > /dev/null; \
-		apt-mark manual $savedAptMark > /dev/null; \
-		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-		rm -rf /var/lib/apt/lists/*; \
-		\
-# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
-		rm -rf \
-			/usr/local/go/pkg/*/cmd \
-			/usr/local/go/pkg/bootstrap \
-			/usr/local/go/pkg/obj \
-			/usr/local/go/pkg/tool/*/api \
-			/usr/local/go/pkg/tool/*/go_bootstrap \
-			/usr/local/go/src/cmd/dist/dist \
-			"$GOCACHE" \
-		; \
+# save the timestamp from the tarball so we can restore it for reproducibility, if necessary (see below)
+	SOURCE_DATE_EPOCH="$(stat -c '%Y' /usr/local/go)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
+	\
+	if [ "$arch" = 'armhf' ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != '7' ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo 'GOARM=7'; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = '7' ]; \
+# (re-)clamp timestamp for reproducibility (allows "COPY --link" to be more clever/useful)
+		date="$(date -d "@$SOURCE_DATE_EPOCH" '+%Y%m%d%H%M.%S')"; \
+		touch -t "$date" /usr/local/go/go.env /usr/local/go; \
 	fi; \
 	\
-	go version
+# smoke test
+	go version; \
+# make sure our reproducibile timestamp is probably still correct (best-effort inline reproducibility test)
+	epoch="$(stat -c '%Y' /usr/local/go)"; \
+	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]
+
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm
+
+# install cgo-related dependencies
+RUN set -eux; \
+	apt-get update; \
+# Upgrade all packages per https://eng.ms/docs/more/containers-secure-supply-chain/updating
+	apt-get upgrade -y; \
+	apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV GOLANG_VERSION 1.21.9
+
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
 
 ENV GOPATH /go
-ENV PATH $GOPATH/bin:$PATH
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+COPY --from=build --link /usr/local/go/ /usr/local/go/
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.21/bookworm/Dockerfile
+++ b/src/microsoft/1.21/bookworm/Dockerfile
@@ -98,6 +98,6 @@ ENV GOTOOLCHAIN=local
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-COPY --from=build --link /usr/local/go/ /usr/local/go/
+COPY --from=build /usr/local/go/ /usr/local/go/
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.21/bullseye/Dockerfile
+++ b/src/microsoft/1.21/bullseye/Dockerfile
@@ -4,19 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm
-
-# install cgo-related dependencies
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		g++ \
-		gcc \
-		libc6-dev \
-		make \
-		pkg-config \
-	; \
-	rm -rf /var/lib/apt/lists/*
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm AS build
 
 ENV PATH /usr/local/go/bin:$PATH
 
@@ -40,16 +28,6 @@ RUN set -eux; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
-	build=; \
-	if [ -z "$url" ]; then \
-# https://github.com/golang/go/issues/38536#issuecomment-616897960
-		build=1; \
-		url=null; \
-		sha256=null; \
-		echo >&2; \
-		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
-		echo >&2; \
-	fi; \
 	\
 	wget -O go.tgz.asc "$url.sig"; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
@@ -70,46 +48,56 @@ RUN set -eux; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
-	if [ -n "$build" ]; then \
-		savedAptMark="$(apt-mark showmanual)"; \
-# add backports for newer go version for bootstrap build: https://github.com/golang/go/issues/44505
-		( \
-			. /etc/os-release; \
-			echo "deb https://deb.debian.org/debian $VERSION_CODENAME-backports main" > /etc/apt/sources.list.d/backports.list; \
-			\
-			apt-get update; \
-			apt-get install -y --no-install-recommends -t "$VERSION_CODENAME-backports" golang-go; \
-		); \
-		\
-		export GOCACHE='/tmp/gocache'; \
-		\
-		( \
-			cd /usr/local/go/src; \
-# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
-			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
-			./make.bash; \
-		); \
-		\
-		apt-mark auto '.*' > /dev/null; \
-		apt-mark manual $savedAptMark > /dev/null; \
-		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-		rm -rf /var/lib/apt/lists/*; \
-		\
-# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
-		rm -rf \
-			/usr/local/go/pkg/*/cmd \
-			/usr/local/go/pkg/bootstrap \
-			/usr/local/go/pkg/obj \
-			/usr/local/go/pkg/tool/*/api \
-			/usr/local/go/pkg/tool/*/go_bootstrap \
-			/usr/local/go/src/cmd/dist/dist \
-			"$GOCACHE" \
-		; \
+# save the timestamp from the tarball so we can restore it for reproducibility, if necessary (see below)
+	SOURCE_DATE_EPOCH="$(stat -c '%Y' /usr/local/go)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
+	\
+	if [ "$arch" = 'armhf' ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != '7' ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo 'GOARM=7'; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = '7' ]; \
+# (re-)clamp timestamp for reproducibility (allows "COPY --link" to be more clever/useful)
+		date="$(date -d "@$SOURCE_DATE_EPOCH" '+%Y%m%d%H%M.%S')"; \
+		touch -t "$date" /usr/local/go/go.env /usr/local/go; \
 	fi; \
 	\
-	go version
+# smoke test
+	go version; \
+# make sure our reproducibile timestamp is probably still correct (best-effort inline reproducibility test)
+	epoch="$(stat -c '%Y' /usr/local/go)"; \
+	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]
+
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm
+
+# install cgo-related dependencies
+RUN set -eux; \
+	apt-get update; \
+# Upgrade all packages per https://eng.ms/docs/more/containers-secure-supply-chain/updating
+	apt-get upgrade -y; \
+	apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV GOLANG_VERSION 1.21.9
+
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
 
 ENV GOPATH /go
-ENV PATH $GOPATH/bin:$PATH
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+COPY --from=build --link /usr/local/go/ /usr/local/go/
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.21/bullseye/Dockerfile
+++ b/src/microsoft/1.21/bullseye/Dockerfile
@@ -98,6 +98,6 @@ ENV GOTOOLCHAIN=local
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-COPY --from=build --link /usr/local/go/ /usr/local/go/
+COPY --from=build /usr/local/go/ /usr/local/go/
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
@@ -102,6 +102,6 @@ ENV GOTOOLCHAIN=local
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-COPY --from=build --link /usr/local/go/ /usr/local/go/
+COPY --from=build /usr/local/go/ /usr/local/go/
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
@@ -6,6 +6,16 @@
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS build
 
+# Dependencies needed to get the Go tarball. We never build Go from source in this Dockerfile.
+RUN set -eux; \
+# Upgrade all packages per https://eng.ms/docs/more/containers-secure-supply-chain/updating
+	tdnf update -y; \
+	tdnf install -y \
+		tar \
+		wget \
+	; \
+	tdnf clean all
+
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.21.9

--- a/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
@@ -6,23 +6,6 @@
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
-RUN tdnf update -y; \
-	tdnf install -y \
-		binutils \
-		gcc \
-		glibc \
-		glibc-devel \
-		iana-etc \
-		kernel-headers \
-		tar \
-		wget \
-		# To reduce image size, CBL-Mariner image doesn't include full ca-certificates: https://github.com/microsoft/CBL-Mariner/issues/3563
-		# Full certs are expected in a builder-style image (e.g. to fetch dependencies), so install them.
-		ca-certificates \
-	; \
-	tdnf clean all
-
-
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.21.9
@@ -45,16 +28,6 @@ RUN set -eux; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
-	build=; \
-	if [ -z "$url" ]; then \
-# https://github.com/golang/go/issues/38536#issuecomment-616897960
-		build=1; \
-		url=null; \
-		sha256=null; \
-		echo >&2; \
-		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
-		echo >&2; \
-	fi; \
 	\
 	wget -O go.tgz.asc "$url.sig"; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
@@ -74,40 +47,61 @@ RUN set -eux; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
-	if [ -n "$build" ]; then \
-		savedAptMark="$(apt-mark showmanual)"; \
-		apt-get update; \
-		apt-get install -y --no-install-recommends golang-go; \
-		\
-		export GOCACHE='/tmp/gocache'; \
-		\
-		( \
-			cd /usr/local/go/src; \
-# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
-			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
-			./make.bash; \
-		); \
-		\
-		apt-mark auto '.*' > /dev/null; \
-		apt-mark manual $savedAptMark > /dev/null; \
-		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-		rm -rf /var/lib/apt/lists/*; \
-		\
-# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
-		rm -rf \
-			/usr/local/go/pkg/*/cmd \
-			/usr/local/go/pkg/bootstrap \
-			/usr/local/go/pkg/obj \
-			/usr/local/go/pkg/tool/*/api \
-			/usr/local/go/pkg/tool/*/go_bootstrap \
-			/usr/local/go/src/cmd/dist/dist \
-			"$GOCACHE" \
-		; \
+# save the timestamp from the tarball so we can restore it for reproducibility, if necessary (see below)
+	SOURCE_DATE_EPOCH="$(stat -c '%Y' /usr/local/go)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
+	\
+	if [ "$arch" = 'armv7' ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != '7' ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo 'GOARM=7'; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = '7' ]; \
+# (re-)clamp timestamp for reproducibility (allows "COPY --link" to be more clever/useful)
+		date="$(date -d "@$SOURCE_DATE_EPOCH" '+%Y%m%d%H%M.%S')"; \
+		touch -t "$date" /usr/local/go/go.env /usr/local/go; \
 	fi; \
 	\
-	go version
+# smoke test
+	go version; \
+# make sure our reproducibile timestamp is probably still correct (best-effort inline reproducibility test)
+	epoch="$(stat -c '%Y' /usr/local/go)"; \
+	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]
+
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+
+RUN set -eux; \
+# Upgrade all packages per https://eng.ms/docs/more/containers-secure-supply-chain/updating
+	tdnf update -y; \
+	tdnf install -y \
+		binutils \
+		gcc \
+		glibc \
+		glibc-devel \
+		iana-etc \
+		kernel-headers \
+		tar \
+		wget \
+		# To reduce image size, CBL-Mariner image doesn't include full ca-certificates: https://github.com/microsoft/CBL-Mariner/issues/3563
+		# Full certs are expected in a builder-style image (e.g. to fetch dependencies), so install them.
+		ca-certificates \
+	; \
+	tdnf clean all
+
+
+ENV GOLANG_VERSION 1.21.9
+
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
 
 ENV GOPATH /go
-ENV PATH $GOPATH/bin:$PATH
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+COPY --from=build --link /usr/local/go/ /usr/local/go/
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS build
 
 ENV PATH /usr/local/go/bin:$PATH
 

--- a/src/microsoft/1.22/bookworm/Dockerfile
+++ b/src/microsoft/1.22/bookworm/Dockerfile
@@ -4,19 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm
-
-# install cgo-related dependencies
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		g++ \
-		gcc \
-		libc6-dev \
-		make \
-		pkg-config \
-	; \
-	rm -rf /var/lib/apt/lists/*
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm AS build
 
 ENV PATH /usr/local/go/bin:$PATH
 
@@ -40,16 +28,6 @@ RUN set -eux; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
-	build=; \
-	if [ -z "$url" ]; then \
-# https://github.com/golang/go/issues/38536#issuecomment-616897960
-		build=1; \
-		url=null; \
-		sha256=null; \
-		echo >&2; \
-		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
-		echo >&2; \
-	fi; \
 	\
 	wget -O go.tgz.asc "$url.sig"; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
@@ -70,40 +48,56 @@ RUN set -eux; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
-	if [ -n "$build" ]; then \
-		savedAptMark="$(apt-mark showmanual)"; \
-		apt-get update; \
-		apt-get install -y --no-install-recommends golang-go; \
-		\
-		export GOCACHE='/tmp/gocache'; \
-		\
-		( \
-			cd /usr/local/go/src; \
-# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
-			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
-			./make.bash; \
-		); \
-		\
-		apt-mark auto '.*' > /dev/null; \
-		apt-mark manual $savedAptMark > /dev/null; \
-		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-		rm -rf /var/lib/apt/lists/*; \
-		\
-# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
-		rm -rf \
-			/usr/local/go/pkg/*/cmd \
-			/usr/local/go/pkg/bootstrap \
-			/usr/local/go/pkg/obj \
-			/usr/local/go/pkg/tool/*/api \
-			/usr/local/go/pkg/tool/*/go_bootstrap \
-			/usr/local/go/src/cmd/dist/dist \
-			"$GOCACHE" \
-		; \
+# save the timestamp from the tarball so we can restore it for reproducibility, if necessary (see below)
+	SOURCE_DATE_EPOCH="$(stat -c '%Y' /usr/local/go)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
+	\
+	if [ "$arch" = 'armhf' ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != '7' ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo 'GOARM=7'; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = '7' ]; \
+# (re-)clamp timestamp for reproducibility (allows "COPY --link" to be more clever/useful)
+		date="$(date -d "@$SOURCE_DATE_EPOCH" '+%Y%m%d%H%M.%S')"; \
+		touch -t "$date" /usr/local/go/go.env /usr/local/go; \
 	fi; \
 	\
-	go version
+# smoke test
+	go version; \
+# make sure our reproducibile timestamp is probably still correct (best-effort inline reproducibility test)
+	epoch="$(stat -c '%Y' /usr/local/go)"; \
+	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]
+
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm
+
+# install cgo-related dependencies
+RUN set -eux; \
+	apt-get update; \
+# Upgrade all packages per https://eng.ms/docs/more/containers-secure-supply-chain/updating
+	apt-get upgrade -y; \
+	apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV GOLANG_VERSION 1.22.2
+
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
 
 ENV GOPATH /go
-ENV PATH $GOPATH/bin:$PATH
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+COPY --from=build --link /usr/local/go/ /usr/local/go/
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.22/bookworm/Dockerfile
+++ b/src/microsoft/1.22/bookworm/Dockerfile
@@ -98,6 +98,6 @@ ENV GOTOOLCHAIN=local
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-COPY --from=build --link /usr/local/go/ /usr/local/go/
+COPY --from=build /usr/local/go/ /usr/local/go/
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.22/bullseye/Dockerfile
+++ b/src/microsoft/1.22/bullseye/Dockerfile
@@ -4,19 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm
-
-# install cgo-related dependencies
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		g++ \
-		gcc \
-		libc6-dev \
-		make \
-		pkg-config \
-	; \
-	rm -rf /var/lib/apt/lists/*
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm AS build
 
 ENV PATH /usr/local/go/bin:$PATH
 
@@ -40,16 +28,6 @@ RUN set -eux; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
-	build=; \
-	if [ -z "$url" ]; then \
-# https://github.com/golang/go/issues/38536#issuecomment-616897960
-		build=1; \
-		url=null; \
-		sha256=null; \
-		echo >&2; \
-		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
-		echo >&2; \
-	fi; \
 	\
 	wget -O go.tgz.asc "$url.sig"; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
@@ -70,46 +48,56 @@ RUN set -eux; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
-	if [ -n "$build" ]; then \
-		savedAptMark="$(apt-mark showmanual)"; \
-# add backports for newer go version for bootstrap build: https://github.com/golang/go/issues/44505
-		( \
-			. /etc/os-release; \
-			echo "deb https://deb.debian.org/debian $VERSION_CODENAME-backports main" > /etc/apt/sources.list.d/backports.list; \
-			\
-			apt-get update; \
-			apt-get install -y --no-install-recommends -t "$VERSION_CODENAME-backports" golang-go; \
-		); \
-		\
-		export GOCACHE='/tmp/gocache'; \
-		\
-		( \
-			cd /usr/local/go/src; \
-# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
-			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
-			./make.bash; \
-		); \
-		\
-		apt-mark auto '.*' > /dev/null; \
-		apt-mark manual $savedAptMark > /dev/null; \
-		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-		rm -rf /var/lib/apt/lists/*; \
-		\
-# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
-		rm -rf \
-			/usr/local/go/pkg/*/cmd \
-			/usr/local/go/pkg/bootstrap \
-			/usr/local/go/pkg/obj \
-			/usr/local/go/pkg/tool/*/api \
-			/usr/local/go/pkg/tool/*/go_bootstrap \
-			/usr/local/go/src/cmd/dist/dist \
-			"$GOCACHE" \
-		; \
+# save the timestamp from the tarball so we can restore it for reproducibility, if necessary (see below)
+	SOURCE_DATE_EPOCH="$(stat -c '%Y' /usr/local/go)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
+	\
+	if [ "$arch" = 'armhf' ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != '7' ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo 'GOARM=7'; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = '7' ]; \
+# (re-)clamp timestamp for reproducibility (allows "COPY --link" to be more clever/useful)
+		date="$(date -d "@$SOURCE_DATE_EPOCH" '+%Y%m%d%H%M.%S')"; \
+		touch -t "$date" /usr/local/go/go.env /usr/local/go; \
 	fi; \
 	\
-	go version
+# smoke test
+	go version; \
+# make sure our reproducibile timestamp is probably still correct (best-effort inline reproducibility test)
+	epoch="$(stat -c '%Y' /usr/local/go)"; \
+	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]
+
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm
+
+# install cgo-related dependencies
+RUN set -eux; \
+	apt-get update; \
+# Upgrade all packages per https://eng.ms/docs/more/containers-secure-supply-chain/updating
+	apt-get upgrade -y; \
+	apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV GOLANG_VERSION 1.22.2
+
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
 
 ENV GOPATH /go
-ENV PATH $GOPATH/bin:$PATH
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+COPY --from=build --link /usr/local/go/ /usr/local/go/
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.22/bullseye/Dockerfile
+++ b/src/microsoft/1.22/bullseye/Dockerfile
@@ -98,6 +98,6 @@ ENV GOTOOLCHAIN=local
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-COPY --from=build --link /usr/local/go/ /usr/local/go/
+COPY --from=build /usr/local/go/ /usr/local/go/
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
@@ -102,6 +102,6 @@ ENV GOTOOLCHAIN=local
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-COPY --from=build --link /usr/local/go/ /usr/local/go/
+COPY --from=build /usr/local/go/ /usr/local/go/
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
@@ -6,23 +6,6 @@
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
-RUN tdnf update -y; \
-	tdnf install -y \
-		binutils \
-		gcc \
-		glibc \
-		glibc-devel \
-		iana-etc \
-		kernel-headers \
-		tar \
-		wget \
-		# To reduce image size, CBL-Mariner image doesn't include full ca-certificates: https://github.com/microsoft/CBL-Mariner/issues/3563
-		# Full certs are expected in a builder-style image (e.g. to fetch dependencies), so install them.
-		ca-certificates \
-	; \
-	tdnf clean all
-
-
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.22.2
@@ -45,16 +28,6 @@ RUN set -eux; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
-	build=; \
-	if [ -z "$url" ]; then \
-# https://github.com/golang/go/issues/38536#issuecomment-616897960
-		build=1; \
-		url=null; \
-		sha256=null; \
-		echo >&2; \
-		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
-		echo >&2; \
-	fi; \
 	\
 	wget -O go.tgz.asc "$url.sig"; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
@@ -74,40 +47,61 @@ RUN set -eux; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
-	if [ -n "$build" ]; then \
-		savedAptMark="$(apt-mark showmanual)"; \
-		apt-get update; \
-		apt-get install -y --no-install-recommends golang-go; \
-		\
-		export GOCACHE='/tmp/gocache'; \
-		\
-		( \
-			cd /usr/local/go/src; \
-# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
-			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
-			./make.bash; \
-		); \
-		\
-		apt-mark auto '.*' > /dev/null; \
-		apt-mark manual $savedAptMark > /dev/null; \
-		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-		rm -rf /var/lib/apt/lists/*; \
-		\
-# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
-		rm -rf \
-			/usr/local/go/pkg/*/cmd \
-			/usr/local/go/pkg/bootstrap \
-			/usr/local/go/pkg/obj \
-			/usr/local/go/pkg/tool/*/api \
-			/usr/local/go/pkg/tool/*/go_bootstrap \
-			/usr/local/go/src/cmd/dist/dist \
-			"$GOCACHE" \
-		; \
+# save the timestamp from the tarball so we can restore it for reproducibility, if necessary (see below)
+	SOURCE_DATE_EPOCH="$(stat -c '%Y' /usr/local/go)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
+	\
+	if [ "$arch" = 'armv7' ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != '7' ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo 'GOARM=7'; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = '7' ]; \
+# (re-)clamp timestamp for reproducibility (allows "COPY --link" to be more clever/useful)
+		date="$(date -d "@$SOURCE_DATE_EPOCH" '+%Y%m%d%H%M.%S')"; \
+		touch -t "$date" /usr/local/go/go.env /usr/local/go; \
 	fi; \
 	\
-	go version
+# smoke test
+	go version; \
+# make sure our reproducibile timestamp is probably still correct (best-effort inline reproducibility test)
+	epoch="$(stat -c '%Y' /usr/local/go)"; \
+	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]
+
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+
+RUN set -eux; \
+# Upgrade all packages per https://eng.ms/docs/more/containers-secure-supply-chain/updating
+	tdnf update -y; \
+	tdnf install -y \
+		binutils \
+		gcc \
+		glibc \
+		glibc-devel \
+		iana-etc \
+		kernel-headers \
+		tar \
+		wget \
+		# To reduce image size, CBL-Mariner image doesn't include full ca-certificates: https://github.com/microsoft/CBL-Mariner/issues/3563
+		# Full certs are expected in a builder-style image (e.g. to fetch dependencies), so install them.
+		ca-certificates \
+	; \
+	tdnf clean all
+
+
+ENV GOLANG_VERSION 1.22.2
+
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
 
 ENV GOPATH /go
-ENV PATH $GOPATH/bin:$PATH
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+COPY --from=build --link /usr/local/go/ /usr/local/go/
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH

--- a/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
@@ -6,6 +6,16 @@
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS build
 
+# Dependencies needed to get the Go tarball. We never build Go from source in this Dockerfile.
+RUN set -eux; \
+# Upgrade all packages per https://eng.ms/docs/more/containers-secure-supply-chain/updating
+	tdnf update -y; \
+	tdnf install -y \
+		tar \
+		wget \
+	; \
+	tdnf clean all
+
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.22.2

--- a/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 AS build
 
 ENV PATH /usr/local/go/bin:$PATH
 


### PR DESCRIPTION
* Update upstream submodule and resolve patch conflicts.
  * Upstream is now using a builder stage, so some things are reordered. They have some infrastructure set up to actually share more work as a result (https://github.com/docker-library/golang/commit/a6fd6eceb0cb26da2fceefb4353768c472f84420) but for us, it doesn't have any meaningful impact.
* Fix a missing `set -eux` that could have caused errors to be improperly ignored. Add a command to upgrade all distro packages for Azure Linux and Debian.
  * https://github.com/microsoft/go-images/pull/290
* Regenerate the Dockerfiles with `dockerupdate -f`.