### PR TITLE
Fix tasoptions path in validation pipeline

### DIFF
--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -61,7 +61,7 @@ extends:
         suppressionFile: $(Build.SourcesDirectory)/eng/compliance/.gdnsuppress
       tsa:
         enabled: ${{ not(parameters.disableTSA) }}
-        configFile: $(Build.SourcesDirectory)/eng/compliance/tsaoptions.json
+        configFile: $(Build.SourcesDirectory)/.config/tsa/tsaoptions.json
 
     stages:
       - stage: Analyze


### PR DESCRIPTION
PR https://github.com/microsoft/go-images/pull/298 moved this file to the standard location, but didn't update this reference to the same file from a second pipeline.

Fixes https://dev.azure.com/dnceng/internal/_build/results?buildId=2438831&view=results