### PR TITLE
More general SPDX golang package CredScan suppression

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -4,8 +4,8 @@
   "tool": "Credential Scanner",
   "suppressions": [
     {
-      "placeholder": "pkg:golang/cloud.google.com/go/apikeys@h1:*",
-      "_justification": "False positive. This string found in SPDX files is the checksum of a Go package used to manipulate API keys and is not an API key."
+      "placeholder": "pkg:golang/*@h1:*",
+      "_justification": "False positive. This string found in SPDX files is the checksum of a Go package. The package name may make it appear to CredScan that a secret value follows, but it doesn't."
     }
   ]
 }


### PR DESCRIPTION
* Adds onto https://github.com/microsoft/go-images/pull/298

Attempt to fix this new false positive by generalizing the rule to apply to any Go package:

```
"referenceLocator": "pkg:golang/modernc.org/token@h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM="
```

https://dev.azure.com/dnceng/internal/_build/results?buildId=2441795&view=logs&j=d0655b31-4114-5ece-d5b2-aae266c14734&t=2dc45d43-df50-5f35-efef-f28beb242e22&l=18443

For future reference: the error message doesn't show which platform the file is from, but I have a consistent way to track it down now. Copy the hash part of the file path, go to the `Download Build Artifact(s)` step, and search the logs for that hash. That shows the name of the artifact to download so you can find the file/line it's pointing at. (Unfortunately, I haven't been able to directly repro the results using a local copy of CredScan yet to actually be able to try out the suppression file without a full build + luck.)