### PR TITLE
Update eng/common to dotnet/dotnet-docker@d2797c0003: fix SBOM signing

### DIFF
--- a/eng/common/templates/1es-official.yml
+++ b/eng/common/templates/1es-official.yml
@@ -1,0 +1,54 @@
+# When extending this template, pipelines using a repository resource containing versions files for image caching must
+# do the following:
+#
+# - Do not rely on any source code from the versions repo so as to not circumvent SDL and CG guidelines
+# - The versions repo resource must be named `InternalVersionsRepo` or `PublicVersionsRepo` to avoid SDL scans
+# - The versions repo must be checked out to `$(Build.SourcesDirectory)/versions` to avoid CG scans
+#
+# If the pipeline is not using a separate repository resource, ensure that there is no source code checked out in
+# `$(Build.SourcesDirectory)/versions`, as it will not be scanned.
+#
+# The `cgDryRun` parameter will run CG but not submit the results, for testing purposes.
+
+parameters:
+- name: cgDryRun
+  type: boolean
+  default: false
+- name: stages
+  type: stageList
+  default: []
+- name: pool
+  type: object
+  default:
+    name: NetCore1ESPool-Internal
+    image: 1es-ubuntu-2204
+    os: linux
+- name: sourceAnalysisPool
+  type: object
+  default:
+    name: NetCore1ESPool-Internal
+    image: 1es-windows-2022
+    os: windows
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool: ${{ parameters.pool }}
+    sdl:
+      componentgovernance:
+        ignoreDirectories: $(Build.SourcesDirectory)/versions
+        whatIf: ${{ parameters.cgDryRun }}
+        showAlertLink: true
+      sourceRepositoriesToScan:
+        exclude:
+        - repository: InternalVersionsRepo
+        - repository: PublicVersionsRepo
+      sourceAnalysisPool: ${{ parameters.sourceAnalysisPool }}
+    stages: ${{ parameters.stages }}

--- a/eng/common/templates/1es-unofficial.yml
+++ b/eng/common/templates/1es-unofficial.yml
@@ -1,0 +1,51 @@
+# This unofficial template will always run CG in "what if" mode, which will not submit results to the CG. SDL tools may
+# also be disabled for testing purposes.
+#
+# When extending this template, pipelines using a repository resource containing versions files for image caching must
+# do the following:
+#
+# - Do not rely on any source code from the versions repo so as to not circumvent SDL and CG guidelines
+# - The versions repo resource must be named `InternalVersionsRepo` or `PublicVersionsRepo` to avoid SDL scans
+# - The versions repo must be checked out to `$(Build.SourcesDirectory)/versions` to avoid CG scans
+#
+# If the pipeline is not using a separate repository resource, ensure that there is no source code checked out in
+# `$(Build.SourcesDirectory)/versions`, as it will not be scanned.
+
+parameters:
+- name: disableSDL
+  type: boolean
+  default: false
+  displayName: Disable SDL
+- name: stages
+  type: stageList
+  default: []
+  # 1ES Pipeline Template parameters
+- name: pool
+  type: object
+  default:
+    name: NetCore1ESPool-Internal
+    image: 1es-windows-2022
+    os: windows
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool: ${{ parameters.pool }}
+    sdl:
+      enableAllTools: ${{ not(parameters.disableSDL) }}
+      componentgovernance:
+        ignoreDirectories: $(Build.SourcesDirectory)/versions
+        whatIf: true
+        showAlertLink: true
+      sourceRepositoriesToScan:
+        exclude:
+        - repository: InternalVersionsRepo
+        - repository: PublicVersionsRepo
+    stages: ${{ parameters.stages }}

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -134,13 +134,8 @@ jobs:
       internalProjectName: ${{ parameters.internalProjectName }}
       publicProjectName: ${{ parameters.publicProjectName }}
   - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-      # Define the task here to load it into the agent so that we can invoke the tool manually
-      # TODO: Revert the build-specific pinned version when https://github.com/dotnet/docker-tools/issues/1152 is fixed
-    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0.197.56
-      inputs:
-        BuildDropPath: $(Build.ArtifactStagingDirectory)
-      displayName: Load Manifest Generator
-      condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))
+    # The following task depends on the SBOM Manifest Generator task installed on the agent.
+    # This task is auto-injected by 1ES Pipeline Templates so we don't need to install it ourselves.
     - powershell: |
         $images = "$(BuildImages.builtImages)"
         if (-not $images) { return 0 }

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -100,7 +100,7 @@ jobs:
       publicProjectName: ${{ parameters.publicProjectName }}
   - template: /eng/common/templates/steps/wait-for-mcr-image-ingestion.yml@self
     parameters:
-      imageInfoPath: '$(artifactsPath)/image-info.json'
+      imageInfoPath: '$(imageinfoContainerDir)/image-info.json'
       minQueueTime: $(imageQueueTime)
       dryRunArg: $(dryRunArg)
       condition: succeeded()

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -76,20 +76,20 @@ stages:
     linuxArm64Pool:
       os: linux
       hostArchitecture: Arm64
+      image: Mariner-2-Docker-ARM64
       ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
         name: Docker-Linux-Arm-Public
       ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-        image: Mariner-2-Docker-ARM64
         name: Docker-Linux-Arm-Internal
 
     # Linux Arm32
     linuxArm32Pool:
       os: linux
       hostArchitecture: Arm64
+      image: Mariner-2-Docker-ARM64
       ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
         name: Docker-Linux-Arm-Public
       ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-        image: Mariner-2-Docker-ARM64
         name: Docker-Linux-Arm-Internal
 
     # Windows Server 2016
@@ -100,19 +100,15 @@ stages:
         image: Server2016-NESDockerBuilds-PT
 
     # Windows Server 2019 (1809)
-    ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-      windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
-    ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-      windows1809Pool:
-        name: NetCore1ESPool-Internal
-        image: 1es-windows-2019
-        os: windows
+    windows1809Pool:
+      os: windows
+      name: Docker-1809-${{ variables['System.TeamProject'] }}
+      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        image: Server2019-1809-NESDockerBuilds-1ESPT
 
     # Windows Server 2022
-    ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-      windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}
-    ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-      windows2022Pool:
-        name: NetCore1ESPool-Internal
-        image: 1es-windows-2022
-        os: windows
+    windows2022Pool:
+      os: windows
+      name: Docker-2022-${{ variables['System.TeamProject'] }}
+      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        image: Server2022-NESDockerBuilds-1ESPT

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -73,21 +73,16 @@ steps:
     displayName: Docker logout
     condition: and(always(), ${{ parameters.condition }})
     continueOnError: true
-- powershell: |
-    $hasTestResults = Test-Path $(Common.TestResultsDirectory)/$(testResultsDirectory)
-    echo "##vso[task.setvariable variable=hasTestResults]$hasTestResults"
-    if ($hasTestResults) {
-      docker cp $(testRunner.container):/repo/$(testResultsDirectory) $(Common.TestResultsDirectory)/.
-    }
-    else {
-      echo "There were no test outputs in $(Common.TestResultsDirectory)/$(testResultsDirectory). Skipping test result publishing."
-    }
+- powershell: >
+    docker cp
+    $(testRunner.container):/repo/$(testResultsDirectory)
+    $(Common.TestResultsDirectory)/.
   displayName: Copy Test Results
   condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
 - task: PublishTestResults@2
   displayName: Publish Test Results
-  condition: and(always(), ${{ parameters.condition }}, eq(variables['hasTestResults'], 'True'))
+  condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
   inputs:
     testRunner: vSTest

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -55,3 +55,11 @@ variables:
   value: windows-2019
 - name: defaultWindows2022PoolImage
   value: windows-2022
+
+# Define these as placeholder values to allow string validation to succeed since we don't have the
+# variable group with the actual values in public builds. For internal builds, the variable group
+# will cause these values to be overridden with the real values.
+- name: acr.servicePrincipalTenant
+  value: 00000000-0000-0000-0000-000000000000
+- name: acr.subscription
+  value: 00000000-0000-0000-0000-000000000000

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2405989
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2437925
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner2.0-docker-testrunner


### PR DESCRIPTION
Update eng/common to dotnet/dotnet-docker@d2797c0003 (latest) to get a fix for SBOM signing in our official build. (https://github.com/dotnet/docker-tools/pull/1283)

Example failure: https://dev.azure.com/dnceng/internal/_build/results?buildId=2457289&view=results

Successful test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2457652&view=results