### PR TITLE
Update shared secret variable group

### DIFF
--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -54,7 +54,7 @@ variables:
   - ${{ if eq(parameters.nightly, true) }}:
     - group: go-docker-common-nightly
   - group: go-docker-secrets
-  - group: go-docker-shared-DotNet-Docker-Secrets
+  - group: Dotnet-Docker-Secrets-WIF
 
 - name: acr.password
   ${{ if eq(parameters.nightly, false) }}:


### PR DESCRIPTION
Update the shared Docker secrets to use a variable group actively maintained by .NET Docker (on their advisement) rather than our own with duplicated access. Fixes https://dev.azure.com/dnceng/internal/_build/results?buildId=2462722&view=results