### PR TITLE
Add managed identity workload identity federation support

### DIFF
--- a/eng/common/templates/1es-unofficial.yml
+++ b/eng/common/templates/1es-unofficial.yml
@@ -44,6 +44,8 @@ extends:
         ignoreDirectories: $(Build.SourcesDirectory)/versions
         whatIf: true
         showAlertLink: true
+      sbom:
+        enabled: true
       sourceRepositoriesToScan:
         exclude:
         - repository: InternalVersionsRepo

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -97,7 +97,7 @@ jobs:
       New-Item -Path $(imageInfoHostDir) -ItemType Directory -Force
       $imageBuilderBuildArgs = "$env:IMAGEBUILDERBUILDARGS $(imageBuilder.queueArgs) --image-info-output-path $(imageInfoContainerDir)/$(legName)-image-info.json"
       if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.internalProjectName }}" -and $env:BUILD_REASON -ne "PullRequest") {
-        $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push --registry-creds ""$(acr.server)=$(acr.userName);$(acr.password)"""
+        $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push"
       }
 
       # If the pipeline isn't configured to disable the cache and a build variable hasn't been set to disable the cache
@@ -107,25 +107,27 @@ jobs:
 
       echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$imageBuilderBuildArgs"
     displayName: Set Image Builder Build Args
-  - powershell: >
-      $(runImageBuilderCmd) build
-      --manifest $(manifest)
-      $(imageBuilderPaths)
-      $(osVersions)
-      --os-type $(osType)
-      --architecture $(architecture)
-      --retry
-      --source-repo $(publicGitRepoUri)
-      --digests-out-var 'builtImages'
-      --acr-subscription '$(acr.subscription)'
-      --acr-resource-group '$(acr.resourceGroup)'
-      --acr-client-id '$(acr.servicePrincipalName)'
-      --acr-password '$(acr.servicePrincipalPassword)'
-      --acr-tenant '$(acr.servicePrincipalTenant)'
-      $(manifestVariables)
-      $(imageBuilderBuildArgs)
-    name: BuildImages
-    displayName: Build Images
+  - template: /eng/common/templates/steps/run-imagebuilder.yml@self
+    parameters:
+      name: BuildImages
+      displayName: Build Images
+      serviceConnection: $(acr.serviceConnectionName)
+      internalProjectName: ${{ parameters.internalProjectName }}
+      dockerClientOS: ${{ parameters.dockerClientOS }}
+      args: >
+        build
+        --manifest $(manifest)
+        $(imageBuilderPaths)
+        $(osVersions)
+        --os-type $(osType)
+        --architecture $(architecture)
+        --retry
+        --source-repo $(publicGitRepoUri)
+        --digests-out-var 'builtImages'
+        --acr-subscription '$(acr.subscription)'
+        --acr-resource-group '$(acr.resourceGroup)'
+        $(manifestVariables)
+        $(imageBuilderBuildArgs)
   - template: /eng/common/templates/steps/publish-artifact.yml@self
     parameters:
       path: $(imageInfoHostDir)

--- a/eng/common/templates/jobs/copy-base-images.yml
+++ b/eng/common/templates/jobs/copy-base-images.yml
@@ -3,6 +3,7 @@ parameters:
   pool: {}
   additionalOptions: null
   publicProjectName: null
+  internalProjectName: null
   customInitSteps: []
 
 jobs:
@@ -15,4 +16,5 @@ jobs:
     parameters:
       additionalOptions: ${{ parameters.additionalOptions }}
       publicProjectName: ${{ parameters.publicProjectName }}
+      internalProjectName: ${{ parameters.internalProjectName }}
       continueOnError: true

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -64,33 +64,38 @@ jobs:
       $(runImageBuilderCmd) trimUnchangedPlatforms
       '$(imageInfoContainerDir)/image-info.json'
     displayName: Trim Unchanged Images
-  - script: >
-      $(runImageBuilderCmd) copyAcrImages
-      '$(acr.servicePrincipalName)'
-      '$(acr.servicePrincipalPassword)'
-      '$(acr.servicePrincipalTenant)'
-      '$(acr.subscription)'
-      '$(acr.resourceGroup)'
-      '$(stagingRepoPrefix)'
-      --os-type '*'
-      --architecture '*'
-      --repo-prefix '$(publishRepoPrefix)'
-      --image-info '$(imageInfoContainerDir)/image-info.json'
-      $(dryRunArg)
-      $(imageBuilder.pathArgs)
-      $(imageBuilder.commonCmdArgs)
-    displayName: Copy Images
-  - script: >
-      $(runImageBuilderCmd) publishManifest
-      '$(imageInfoContainerDir)/image-info.json'
-      --repo-prefix '$(publishRepoPrefix)'
-      --registry-creds '$(acr.server)=$(acr.userName);$(acr.password)'
-      --os-type '*'
-      --architecture '*'
-      $(dryRunArg)
-      $(imageBuilder.pathArgs)
-      $(imageBuilder.commonCmdArgs)
-    displayName: Publish Manifest
+  - template: /eng/common/templates/steps/run-imagebuilder.yml@self
+    parameters:
+      displayName: Copy Images
+      serviceConnection: $(acr.serviceConnectionName)
+      internalProjectName: ${{ parameters.internalProjectName }}
+      args: >
+        copyAcrImages
+        '$(acr.subscription)'
+        '$(acr.resourceGroup)'
+        '$(stagingRepoPrefix)'
+        --os-type '*'
+        --architecture '*'
+        --repo-prefix '$(publishRepoPrefix)'
+        --image-info '$(imageInfoContainerDir)/image-info.json'
+        $(dryRunArg)
+        $(imageBuilder.pathArgs)
+        $(imageBuilder.commonCmdArgs)
+  - template: /eng/common/templates/steps/run-imagebuilder.yml@self
+    parameters:
+      displayName: Publish Manifest
+      serviceConnection: $(acr.serviceConnectionName)
+      internalProjectName: ${{ parameters.internalProjectName }}
+      dockerClientOS: ${{ parameters.dockerClientOS }}
+      args: >
+        publishManifest
+        '$(imageInfoContainerDir)/image-info.json'
+        --repo-prefix '$(publishRepoPrefix)'
+        --os-type '*'
+        --architecture '*'
+        $(dryRunArg)
+        $(imageBuilder.pathArgs)
+        $(imageBuilder.commonCmdArgs)
   - template: /eng/common/templates/steps/publish-artifact.yml@self
     parameters:
       path: $(imageInfoHostDir)
@@ -122,22 +127,23 @@ jobs:
       $(imageBuilder.commonCmdArgs)
     condition: and(succeeded(), eq(variables['publishImageInfo'], 'true'))
     displayName: Publish Image Info
-  - script: >
-      $(runImageBuilderCmd) ingestKustoImageInfo
-      '$(imageInfoContainerDir)/image-info.json'
-      '$(kusto.cluster)'
-      '$(kusto.database)'
-      '$(kusto.imageTable)'
-      '$(kusto.layerTable)'
-      '$(kusto.servicePrincipalName)'
-      '$(kusto.servicePrincipalPassword)'
-      '$(kusto.servicePrincipalTenant)'
-      --os-type '*'
-      --architecture '*'
-      $(dryRunArg)
-      $(imageBuilder.commonCmdArgs)
-    displayName: Ingest Kusto Image Info
-    condition: and(succeeded(), eq(variables['ingestKustoImageInfo'], 'true'))
+  - template: /eng/common/templates/steps/run-imagebuilder.yml@self
+    parameters:
+      displayName: Ingest Kusto Image Info
+      serviceConnection: $(kusto.serviceConnectionName)
+      internalProjectName: ${{ parameters.internalProjectName }}
+      condition: and(succeeded(), eq(variables['ingestKustoImageInfo'], 'true'))
+      args: >
+        ingestKustoImageInfo
+        '$(imageInfoContainerDir)/image-info.json'
+        '$(kusto.cluster)'
+        '$(kusto.database)'
+        '$(kusto.imageTable)'
+        '$(kusto.layerTable)'
+        --os-type '*'
+        --architecture '*'
+        $(dryRunArg)
+        $(imageBuilder.commonCmdArgs)
   - script: >
       $(runImageBuilderCmd) postPublishNotification
       '$(publishNotificationRepoName)'
@@ -151,13 +157,13 @@ jobs:
       '$(gitHubNotificationsRepoInfo.org)'
       '$(gitHubNotificationsRepoInfo.repo)'
       --repo-prefix '$(publishRepoPrefix)'
-      --task "Copy Images"
-      --task "Publish Manifest"
-      --task "Wait for Image Ingestion"
+      --task "Copy Images (Authenticated)"
+      --task "Publish Manifest (Authenticated)"
+      --task "Wait for Image Ingestion (Authenticated)"
       --task "Publish Readmes"
-      --task "Wait for MCR Doc Ingestion"
+      --task "Wait for MCR Doc Ingestion (Authenticated)"
       --task "Publish Image Info"
-      --task "Ingest Kusto Image Info"
+      --task "Ingest Kusto Image Info (Authenticated)"
       $(dryRunArg)
       $(imageBuilder.commonCmdArgs)
     displayName: Post Publish Notification

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -130,7 +130,8 @@ jobs:
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
       displayName: Ingest Kusto Image Info
-      serviceConnection: $(kusto.serviceConnectionName)
+      # Upstream edit: https://github.com/microsoft/go-lab/issues/78 Remove unused service connection that would be unconditionally checked for validity even though this task never runs in go-images.
+      # serviceConnection: $(kusto.serviceConnectionName)
       internalProjectName: ${{ parameters.internalProjectName }}
       condition: and(succeeded(), eq(variables['ingestKustoImageInfo'], 'true'))
       args: >

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -8,7 +8,7 @@ parameters:
   customTestInitSteps: []
   customPublishInitSteps: []
   customPublishVariables: []
-  
+
   linuxAmdBuildJobTimeout: 60
   linuxArmBuildJobTimeout: 60
   windowsAmdBuildJobTimeout: 60
@@ -70,7 +70,8 @@ stages:
       pool: ${{ parameters.linuxAmd64Pool }}
       additionalOptions: "--manifest '$(manifest)' $(imageBuilder.pathArgs) $(manifestVariables)"
       publicProjectName: ${{ parameters.publicProjectName }}
-      customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps}}
+      internalProjectName: ${{ parameters.internalProjectName }}
+      customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps }}
   - template: /eng/common/templates/jobs/generate-matrix.yml@self
     parameters:
       matrixType: ${{ parameters.buildMatrixType }}

--- a/eng/common/templates/steps/clean-acr-images.yml
+++ b/eng/common/templates/steps/clean-acr-images.yml
@@ -3,17 +3,19 @@ parameters:
   action: null
   age: null
   customArgs: ""
+  internalProjectName: null
 steps:
-  - script: >
-      $(runImageBuilderCmd) cleanAcrImages
-      ${{ parameters.repo }}
-      $(acr.servicePrincipalName)
-      $(app-dotnetdockerbuild-client-secret)
-      $(acr.servicePrincipalTenant)
-      $(acr.subscription)
-      $(acr.resourceGroup)
-      $(acr.server)
-      --action ${{ parameters.action }}
-      --age ${{ parameters.age }}
-      ${{ parameters.customArgs }}
-    displayName: Clean ACR Images - ${{ parameters.repo }}
+  - template: /eng/common/templates/steps/run-imagebuilder.yml@self
+    parameters:
+      displayName: Clean ACR Images - ${{ parameters.repo }}
+      serviceConnection: $(acr.serviceConnectionName)
+      internalProjectName: ${{ parameters.internalProjectName }}
+      args: >
+        cleanAcrImages
+        ${{ parameters.repo }}
+        $(acr.subscription)
+        $(acr.resourceGroup)
+        $(acr.server)
+        --action ${{ parameters.action }}
+        --age ${{ parameters.age }}
+        ${{ parameters.customArgs }}

--- a/eng/common/templates/steps/copy-base-images.yml
+++ b/eng/common/templates/steps/copy-base-images.yml
@@ -1,26 +1,30 @@
 parameters:
   additionalOptions: null
   publicProjectName: null
+  internalProjectName: null
   continueOnError: false
 
 steps:
 - ${{ if or(eq(variables['System.TeamProject'], parameters.publicProjectName), eq(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/steps/set-dry-run.yml@self
-- script: >
-    $(runImageBuilderCmd)
-    copyBaseImages
-    '$(acr.servicePrincipalName)'
-    '$(acr.servicePrincipalPassword)'
-    '$(acr.servicePrincipalTenant)'
-    '$(acr.subscription)'
-    '$(acr.resourceGroup)'
-    $(dockerHubRegistryCreds)
-    $(customCopyBaseImagesArgs)
-    --repo-prefix $(mirrorRepoPrefix)
-    --registry-override '$(acr.server)'
-    --os-type 'linux'
-    --architecture '*'
-    $DRYRUNARG
-    ${{ parameters.additionalOptions }}
-  displayName: Copy Base Images
-  continueOnError: ${{ parameters.continueOnError }}
+- template: /eng/common/templates/steps/run-imagebuilder.yml@self
+  parameters:
+    displayName: Copy Base Images
+    serviceConnection: $(acr.serviceConnectionName)
+    continueOnError: ${{ parameters.continueOnError }}
+    internalProjectName: ${{ parameters.internalProjectName }}
+    # Use environment variable to reference $(dryRunArg). Since $(dryRunArg) might be undefined,
+    # PowerShell will treat the Azure Pipelines variable macro syntax as a command and throw an
+    # error
+    args: >
+      copyBaseImages
+      '$(acr.subscription)'
+      '$(acr.resourceGroup)'
+      $(dockerHubRegistryCreds)
+      $(customCopyBaseImagesArgs)
+      --repo-prefix $(mirrorRepoPrefix)
+      --registry-override '$(acr.server)'
+      --os-type 'linux'
+      --architecture '*'
+      $env:DRYRUNARG
+      ${{ parameters.additionalOptions }}

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -34,16 +34,45 @@ steps:
       -f $(engCommonPath)/Dockerfile.WithRepo .
     displayName: Build Image for Image Builder
     condition: and(succeeded(), ${{ parameters.condition }})
-  - script: >
-      echo "##vso[task.setvariable variable=runImageBuilderCmd]
-      docker run --rm
-      -v /var/run/docker.sock:/var/run/docker.sock
-      -v $(Build.ArtifactStagingDirectory):$(artifactsPath)
-      -w /repo
-      $(imageBuilderDockerRunExtraOptions)
-      $(imageNames.imageBuilder.withrepo)"
-    displayName: Define runImageBuilderCmd Variable
+  - task: PowerShell@2
+    displayName: Define ImageBuilder Command Variables
     condition: and(succeeded(), ${{ parameters.condition }})
+    inputs:
+      targetType: 'inline'
+      script: |
+        $tokenHostPath = '$(Agent.TempDirectory)'
+        $tokenHostFilePath = "${tokenHostPath}/token"
+        $tokenContainerPath = "/tmp"
+        $tokenContainerFilePath = "${tokenContainerPath}/token"
+
+        $dockerRunBaseCmd = @(
+          "docker run --rm"
+        )
+
+        $dockerRunArgs = @(
+          "-v /var/run/docker.sock:/var/run/docker.sock"
+          "-v $(Build.ArtifactStagingDirectory):$(artifactsPath)"
+          "-w /repo"
+          "$(imageBuilderDockerRunExtraOptions)"
+          "$(imageNames.imageBuilder.withrepo)"
+        )
+
+        $authedDockerRunArgs = @(
+          '-e AZURE_TENANT_ID=$env:tenantId'
+          '-e AZURE_CLIENT_ID=$env:servicePrincipalId'
+          "-e AZURE_FEDERATED_TOKEN_FILE=$tokenContainerFilePath"
+          "-v ${tokenHostPath}:${tokenContainerPath}"
+        )
+
+        $dockerRunCmd = $dockerRunBaseCmd + $dockerRunArgs
+        $authedDockerRunCmd = $dockerRunBaseCmd + $authedDockerRunArgs + $dockerRunArgs
+
+        $runImageBuilderCmd = $($dockerRunCmd -join ' ')
+        $runAuthedImageBuilderCmd = $($authedDockerRunCmd -join ' ')
+
+        Write-Host "##vso[task.setvariable variable=runImageBuilderCmd]$runImageBuilderCmd"
+        Write-Host "##vso[task.setvariable variable=runAuthedImageBuilderCmd]$runAuthedImageBuilderCmd"
+        Write-Host "##vso[task.setvariable variable=tokenHostFilePath]$tokenHostFilePath"
 
   ################################################################################
   # Setup Test Runner (Optional)

--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -37,8 +37,26 @@ steps:
     displayName: Cleanup Setup Container
     condition: and(always(), ${{ parameters.condition }})
     continueOnError: true
-  - powershell: >
-      echo "##vso[task.setvariable variable=runImageBuilderCmd]
-      $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe"
-    displayName: Define runImageBuilderCmd Variable
+  - task: PowerShell@2
+    displayName: Define runImageBuilderCmd Variables
     condition: and(succeeded(), ${{ parameters.condition }})
+    inputs:
+      targetType: 'inline'
+      script: |
+        $tokenHostPath = '$(Agent.TempDirectory)'
+        $tokenHostFilePath = "$tokenHostPath\token"
+
+        $runImageBuilderCmd = "$(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe"
+
+        $authedImageBuilderCmds = @(
+          '$env:AZURE_TENANT_ID = $env:tenantId'
+          '$env:AZURE_CLIENT_ID = $env:servicePrincipalId'
+          '$env:AZURE_FEDERATED_TOKEN_FILE' + " = $tokenHostFilePath"
+          $runImageBuilderCmd
+        )
+
+        $runAuthedImageBuilderCmd = $($authedImageBuilderCmds -join "; ")
+
+        Write-Host "##vso[task.setvariable variable=runImageBuilderCmd]$runImageBuilderCmd"
+        Write-Host "##vso[task.setvariable variable=runAuthedImageBuilderCmd]$runAuthedImageBuilderCmd"
+        Write-Host "##vso[task.setvariable variable=tokenHostFilePath]$tokenHostFilePath"

--- a/eng/common/templates/steps/run-imagebuilder.yml
+++ b/eng/common/templates/steps/run-imagebuilder.yml
@@ -1,0 +1,52 @@
+parameters:
+- name: name
+  type: string
+  default: ""
+- name: displayName
+  type: string
+  default: "Run ImageBuilder"
+- name: serviceConnection
+  type: string
+  default: ""
+- name: internalProjectName
+  type: string
+  default: null
+- name: args
+  type: string
+  default: null
+- name: condition
+  type: string
+  default: succeeded()
+- name: continueOnError
+  type: boolean
+  default: false
+- name: dockerClientOS
+  type: string
+  default: "linux"
+
+steps:
+- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest'), ne(parameters.serviceConnection, '')) }}:
+  - template: /eng/common/templates/steps/run-pwsh-with-auth.yml@self
+    parameters:
+      ${{ if ne(parameters.name, '') }}:
+        name: ${{ parameters.name }}
+      displayName: ${{ parameters.displayName }}
+      serviceConnection: ${{ parameters.serviceConnection }}
+      continueOnError: ${{ parameters.continueOnError }}
+      dockerClientOS: ${{ parameters.dockerClientOS }}
+      condition: ${{ parameters.condition }}
+      command: >
+        $env:idToken | Out-File -FilePath $(tokenHostFilePath);
+        $(runAuthedImageBuilderCmd) ${{ parameters.args }};
+        Remove-Item -Path $(tokenHostFilePath) -Force
+- ${{ else }}:
+  - task: PowerShell@2
+    ${{ if ne(parameters.name, '') }}:
+      name: ${{ parameters.name }}
+    displayName: ${{ parameters.displayName }}
+    continueOnError: ${{ parameters.continueOnError }}
+    condition: ${{ parameters.condition }}
+    inputs:
+      targetType: 'inline'
+      script: >
+        $(runImageBuilderCmd) ${{ parameters.args }}

--- a/eng/common/templates/steps/run-pwsh-with-auth.yml
+++ b/eng/common/templates/steps/run-pwsh-with-auth.yml
@@ -1,0 +1,39 @@
+parameters:
+- name: name
+  type: string
+  default: ""
+- name: displayName
+  type: string
+  default: "Run PowerShell"
+- name: serviceConnection
+  type: string
+  default: ""
+- name: command
+  type: string
+  default: null
+- name: continueOnError
+  type: boolean
+  default: false
+- name: dockerClientOS
+  type: string
+  default: "linux"
+- name: condition
+  type: string
+  default: true
+
+steps:
+- task: AzureCLI@2
+  ${{ if ne(parameters.name, '') }}:
+    name: ${{ parameters.name }}
+  displayName: ${{ parameters.displayName }} (Authenticated)
+  continueOnError: ${{ parameters.continueOnError }}
+  condition: and(succeeded(), ${{ parameters.condition }})
+  inputs:
+    azureSubscription: ${{ parameters.serviceConnection }}
+    addSpnToEnvironment: true
+    ${{ if eq(parameters.dockerClientOS, 'windows') }}:
+      scriptType: 'ps'
+    ${{ else }}:
+      scriptType: 'pscore'
+    scriptLocation: 'inlineScript'
+    inlineScript: ${{ parameters.command }};

--- a/eng/common/templates/steps/set-dry-run.yml
+++ b/eng/common/templates/steps/set-dry-run.yml
@@ -5,7 +5,7 @@ steps:
     if (-not "$(officialRepoPrefixes)".Split(',').Contains("$(publishRepoPrefix)") `
         -or "$(System.TeamProject)" -eq "$(publicProjectName)")
     {
-      $dryRunArg=" --dry-run"
+      $dryRunArg="--dry-run"
     }
     echo "##vso[task.setvariable variable=dryRunArg]$dryRunArg"
   displayName: Set dry-run arg for non-prod

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -42,12 +42,16 @@ steps:
   displayName: Start Test Runner Container
   condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - script: >
-      docker exec $(testRunner.container) pwsh
-      -File $(engCommonRelativePath)/Invoke-WithRetry.ps1
-      "docker login -u $(acr.userName) -p $(acr.password) $(acr.server)"
-    displayName: Docker login
-    condition: and(succeeded(), ${{ parameters.condition }})
+  - template: /eng/common/templates/steps/run-pwsh-with-auth.yml@self
+    parameters:
+      displayName: Docker login
+      serviceConnection: $(acr.serviceConnectionName)
+      condition: and(succeeded(), ${{ parameters.condition }})
+      command: >
+        $azLoginArgs = '--service-principal --tenant $env:AZURE_TENANT_ID -u $env:AZURE_CLIENT_ID --federated-token $env:AZURE_FEDERATED_TOKEN';
+        docker exec -e AZURE_TENANT_ID=$env:tenantId -e AZURE_CLIENT_ID=$env:servicePrincipalId -e AZURE_FEDERATED_TOKEN=$env:idToken $(testRunner.container) pwsh
+        -File $(engCommonRelativePath)/Invoke-WithRetry.ps1
+        "az login $azLoginArgs; az acr login -n $(acr.server)"
   - ${{ if eq(parameters.preBuildValidation, 'false') }}:
     - template: /eng/common/templates/steps/download-build-artifact.yml@self
       parameters:

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -10,11 +10,16 @@ steps:
       cleanupDocker: true
       setupImageBuilder: false
       condition: ${{ parameters.condition }}
-  - powershell: >
-      $(engCommonPath)/Invoke-WithRetry.ps1
-      "cmd /c 'docker login -u $(acr.userName) --password $(acr.password) $(acr.server) 2>&1'"
-    displayName: Docker login
-    condition: and(succeeded(), ${{ parameters.condition }})
+  - template: /eng/common/templates/steps/run-pwsh-with-auth.yml@self
+    parameters:
+      displayName: Docker login
+      serviceConnection: $(acr.serviceConnectionName)
+      dockerClientOS: windows
+      condition: and(succeeded(), ${{ parameters.condition }})
+      command: >
+        az login --service-principal --tenant $env:tenantId -u $env:servicePrincipalId --federated-token $env:idToken;
+        $accessToken = $(az acr login -n $(acr.server) --expose-token --query accessToken --output tsv);
+        docker login $(acr.server) -u 00000000-0000-0000-0000-000000000000 -p $accessToken
 - ${{ parameters.customInitSteps }}
 - powershell: |
     if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}" -and "${{ variables['Build.Reason'] }}" -ne "PullRequest") {

--- a/eng/common/templates/steps/validate-branch.yml
+++ b/eng/common/templates/steps/validate-branch.yml
@@ -4,11 +4,25 @@ parameters:
 steps:
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - powershell: |
-      if (-not "$(officialBranches)".Split(',').Contains("$(sourceBranch)") `
-          -and "$(officialBranches)".Split(',').Contains("$(publishRepoPrefix)") `
-          -and "$(overrideOfficialBranchValidation)" -ne "true")
+      if ("$(officialBranches)".Split(',').Contains("$(sourceBranch)") `
+          -and "$(officialRepoPrefixes)".Split(',').Contains("$(publishRepoPrefix)"))
       {
-        echo "##vso[task.logissue type=error]Official builds must be done from an official branch: $(officialBranches)"
-        exit 1
+        echo "Conditions met for official build, continuing..."
+        exit 0
       }
+
+      if (-not "$(officialRepoPrefixes)".Split(',').Contains("$(publishRepoPrefix)"))
+      {
+        echo "This build is a test build, continuing..."
+        exit 0
+      }
+
+      if ("$(overrideOfficialBranchValidation)" -eq "true")
+      {
+        echo "Variable overrideOfficialBranchValidation is set to true, continuing..."
+        exit 0
+      }
+
+      echo "##vso[task.logissue type=error]Official builds must be done from an official branch ($(officialBranches)) and repo prefix ($(officialRepoPrefixes))."
+      exit 1
     displayName: Validate Branch

--- a/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
@@ -4,13 +4,14 @@ parameters:
   dryRunArg: ""
 
 steps:
-- script: >
-    $(runImageBuilderCmd) waitForMcrDocIngestion
-    '${{ parameters.commitDigest }}'
-    '$(mcrStatus.servicePrincipalName)'
-    '$(mcrStatus.servicePrincipalPassword)'
-    '$(mcrStatus.servicePrincipalTenant)'
-    --timeout '$(mcrDocIngestionTimeout)'
-    ${{ parameters.dryRunArg }}
-  displayName: Wait for MCR Doc Ingestion
-  condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))
+- template: /eng/common/templates/steps/run-imagebuilder.yml@self
+  parameters:
+    displayName: Wait for MCR Doc Ingestion
+    condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))
+    serviceConnection: $(marStatus.serviceConnectionName)
+    internalProjectName: 'internal'
+    args: >
+      waitForMcrDocIngestion
+      '${{ parameters.commitDigest }}'
+      --timeout '$(mcrDocIngestionTimeout)'
+      ${{ parameters.dryRunArg }}

--- a/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
@@ -8,7 +8,8 @@ steps:
   parameters:
     displayName: Wait for MCR Doc Ingestion
     condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))
-    serviceConnection: $(marStatus.serviceConnectionName)
+    # Upstream edit: https://github.com/microsoft/go-lab/issues/78 Remove unused service connection that would be unconditionally checked for validity even though this task never runs in go-images.
+    # serviceConnection: $(marStatus.serviceConnectionName)
     internalProjectName: 'internal'
     args: >
       waitForMcrDocIngestion

--- a/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
@@ -5,17 +5,18 @@ parameters:
   dryRunArg: ""
 
 steps:
-- script: >
-    $(runImageBuilderCmd) waitForMcrImageIngestion
-    '${{ parameters.imageInfoPath }}'
-    '$(mcrStatus.servicePrincipalName)'
-    '$(mcrStatus.servicePrincipalPassword)'
-    '$(mcrStatus.servicePrincipalTenant)'
-    --manifest '$(manifest)'
-    --repo-prefix '$(publishRepoPrefix)'
-    --min-queue-time '${{ parameters.minQueueTime }}'
-    --timeout '$(mcrImageIngestionTimeout)'
-    $(manifestVariables)
-    ${{ parameters.dryRunArg }}
-  displayName: Wait for Image Ingestion
-  condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))
+- template: /eng/common/templates/steps/run-imagebuilder.yml@self
+  parameters:
+    displayName: Wait for Image Ingestion
+    condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))
+    serviceConnection: $(marStatus.serviceConnectionName)
+    internalProjectName: 'internal'
+    args: >
+      waitForMcrImageIngestion
+      '${{ parameters.imageInfoPath }}'
+      --manifest '$(manifest)'
+      --repo-prefix '$(publishRepoPrefix)'
+      --min-queue-time '${{ parameters.minQueueTime }}'
+      --timeout '$(mcrImageIngestionTimeout)'
+      $(manifestVariables)
+      ${{ parameters.dryRunArg }}

--- a/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
@@ -9,7 +9,8 @@ steps:
   parameters:
     displayName: Wait for Image Ingestion
     condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))
-    serviceConnection: $(marStatus.serviceConnectionName)
+    # Upstream edit: https://github.com/microsoft/go-lab/issues/78 Remove unused service connection that would be unconditionally checked for validity even though this task never runs in go-images.
+    # serviceConnection: $(marStatus.serviceConnectionName)
     internalProjectName: 'internal'
     args: >
       waitForMcrImageIngestion

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -32,6 +32,8 @@ variables:
 - name: officialBranches
   # comma-delimited list of branch names
   value: main
+- name: overrideOfficialBranchValidation
+  value: false
 - name: mirrorRepoPrefix
   value: 'mirror/'
 - name: cgBuildGrepArgs

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2437925
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2461919
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner2.0-docker-testrunner

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -44,8 +44,3 @@ variables:
   value: $(dotnetDockerBot.userName)
 - name: gitHubVersionsRepoInfo.email
   value: $(dotnetDockerBot.email)
-
-- name: kusto.servicePrincipalPassword
-  value: $(app-DotnetDockerTelemetryIngestion-client-secret)
-- name: mcrStatus.servicePrincipalPassword
-  value: $(app-DotnetDockerMcrStatusApi-client-secret)

--- a/eng/common/templates/variables/dotnet/common.yml
+++ b/eng/common/templates/variables/dotnet/common.yml
@@ -6,11 +6,7 @@ variables:
   value: internal
 - name: dockerHubRegistryCreds
   value: --registry-creds 'docker.io=$(dotnetDockerHubBot.userName);$(BotAccount-dotnet-dockerhub-bot-PAT)'
-- name: acr.servicePrincipalPassword
-  value: $(app-dotnetdockerbuild-client-secret)
-- name: acr.password
-  value: $(BotAccount-dotnet-docker-acr-bot-password)
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-Docker-Common
-  - group: DotNet-Docker-Secrets
+  - group: DotNet-Docker-Secrets-WIF


### PR DESCRIPTION
* Update eng/common to dotnet/docker-tools@947b0c8db5
  * Simple checkout, no need to review.
* Remove unused serviceConnections in eng/common
  * Review this. This means future updates to eng/common need to be careful not to wipe out this change. Included a code comment to make it easier to spot too-early removal in diffs.
  * Unifying our eng/common dirs is tracked by https://github.com/microsoft/go-lab/issues/78.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2463672&view=results