### PR TITLE
Add missing dockerHubRegistryCreds variable

### DIFF
--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -9,6 +9,10 @@ variables:
 - name: internalProjectName
   value: internal
 
+# Credentials for pulling base images from Docker Hub.
+- name: dockerHubRegistryCreds
+  value: --registry-creds 'docker.io=$(dotnetDockerHubBot.userName);$(BotAccount-dotnet-dockerhub-bot-PAT)'
+
 - name: commonVersionsImageInfoPath
   value: build-info/docker
 - name: publicGitRepoUri


### PR DESCRIPTION
* Fixes https://github.com/microsoft/go-lab/issues/68
* https://github.com/microsoft/go-images/pull/308 makes the error related to this missing variable louder. It's now visible as a pipeline error, but before, it was deep in the logs. See https://dev.azure.com/dnceng/internal/_build/results?buildId=2463672&view=results

Validated as part of prototyping the WIF change in this build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2462818&view=results