### PR TITLE
Fix officialBranches: remove quotes to match tooling expectations

### DIFF
--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -38,9 +38,9 @@ variables:
 - name: officialBranches
   # list multiple branches as "'branch1', 'branch2', etc."
   ${{ if eq(parameters.nightly, false) }}:
-    value: "'microsoft/main'"
+    value: microsoft/main
   ${{ if eq(parameters.nightly, true) }}:
-    value: "'microsoft/nightly'"
+    value: microsoft/nightly
 
 - name: manifest
   value: manifest.json


### PR DESCRIPTION
* Followup for https://github.com/dotnet/docker-tools/pull/1011.
* The official branch validation was broken, so this has never actually caused our builds to fail until we upgraded past https://github.com/dotnet/docker-tools/pull/1263 just yesterday.

Fixes https://dev.azure.com/dnceng/internal/_build/results?buildId=2463893&view=results (unable to test without merging).