### PR TITLE
Remove unnecessary go-docker-secrets variable group reference

### DIFF
--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -57,7 +57,6 @@ variables:
     - group: go-docker-common
   - ${{ if eq(parameters.nightly, true) }}:
     - group: go-docker-common-nightly
-  - group: go-docker-secrets
   - group: Dotnet-Docker-Secrets-WIF
 
 - name: acr.password


### PR DESCRIPTION
Earlier, I tried disabling some secrets in our key vault that aren't being used anymore to shake out any remaining secret-related work. It turns out this `go-docker-secrets` variable group was still trying to download them, which caused the build to fail. I restored the secrets to make the build work for the last release.

It turns out that none of the secrets in the group are needed anymore, so we can simply remove the reference from the yml. The service connection to use is defined in `go-docker-common`, and it removes the need for any Go-specific secrets. (Remaining secrets are for Docker Hub, shared with .NET Docker.)

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2469059&view=results