### PR TITLE
Add scheduled builds for microsoft/main

### DIFF
--- a/eng/pipeline/go-docker-pr-pipeline.yml
+++ b/eng/pipeline/go-docker-pr-pipeline.yml
@@ -3,6 +3,13 @@ pr:
   branches:
     include:
       - microsoft/main
+schedules:
+  - cron: '0 10 * * Mon,Wed'
+    displayName: Periodic build to refresh dependencies
+    branches:
+      include:
+        - microsoft/main
+    always: true
 
 variables:
   - template: variables/common.yml


### PR DESCRIPTION
Rebuild periodically to get fresh dependencies.

This rebuilds and publishes to MAR even if no dependencies have changed. Related:

* https://github.com/microsoft/go/issues/167
* https://github.com/microsoft/go/issues/156
* https://github.com/microsoft/go/issues/179
* https://github.com/microsoft/go/issues/234