### PR TITLE
Add helper image to run dockerupdate on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 /*/**/Dockerfile       linguist-generated
 /Dockerfile*.template  linguist-language=Dockerfile
+
+# Always check out patch files and Dockerfiles as LF.
+# This improves "git patch" behavior during "dockerupdate" when the repository
+# was checked out on Windows but is being used within WSL or a container.
+*.patch     -text
+Dockerfile* -text

--- a/eng/README.md
+++ b/eng/README.md
@@ -22,6 +22,8 @@ root of the repo, or `pwsh build.ps1` in `eng`.
 
 ## Updating the Dockerfiles
 
+### Linux
+
 Get the update tool, and view its help doc:
 
 ```sh
@@ -47,6 +49,32 @@ based on a JSON file, they are also checked in. This is done to match the
 standard approach to Docker: Dockerfiles are *always* checked in, enabling users
 to easily run `docker build .` to reproduce the result without complicated
 repo-specific tooling being involved.
+
+### Windows
+
+[/eng/ci-tools/local.Dockerfile](/eng/ci-tools/local.Dockerfile) sets up a Linux container with the `dockerupdate` dependencies that can be used to easily run the tool on Windows.
+
+Run this command to set it up from the root of the go-images repository:
+
+```sh
+docker build -f eng/ci-tools/local.Dockerfile -t dockerupdate-local eng/ci-tools
+```
+
+Then see the options using the help option:
+
+```sh
+docker run -it --rm -v .:/go-images dockerupdate-local -h
+```
+
+To quickly regenerate the Dockerfiles, discarding changes to the submodule, run:
+
+```sh
+docker run -it --rm -v .:/go-images dockerupdate-local -f
+```
+
+Any relative paths passed to the command are considered local to the repository root.
+Only files that are volume mapped can be referred to.
+In the command above, the entire repository is volume mapped.
 
 ### Updating to a new build of Go
 

--- a/eng/ci-tools/README.md
+++ b/eng/ci-tools/README.md
@@ -1,3 +1,6 @@
 # ci-tools
 
 This module exists to store CI dependencies. Using a module dependency lets CI download/install the tool while verifying against the checked-in go.sum file.
+
+This directory contains `local.Dockerfile`, which creates an image with `dockerupdate` installed.
+See [eng/README.md#windows](../README.md#windows) for instructions on using it.

--- a/eng/ci-tools/local.Dockerfile
+++ b/eng/ci-tools/local.Dockerfile
@@ -1,0 +1,22 @@
+# This Dockerfile produces an image that can be used locally (e.g. on Windows)
+# to run the dockerupdate tool. It is not published to a registry and is
+# intended for local use only. See README.md.
+
+FROM mcr.microsoft.com/oss/go/microsoft/golang:cbl-mariner2.0
+
+RUN set -eux; \
+	tdnf update -y; \
+	tdnf install -y \
+		awk \
+		git \
+		jq \
+	; \
+	tdnf clean all
+
+ADD . /go-images/eng/ci-tools
+
+WORKDIR /go-images
+
+RUN cd eng/ci-tools && go install github.com/microsoft/go-infra/cmd/dockerupdate
+
+ENTRYPOINT ["/go/bin/dockerupdate"]


### PR DESCRIPTION
Not being able to properly work on the Dockerfiles on Windows has always been an issue. I realized this is fairly easy to fix with Docker, so wrote a simple Dockerfile and instructions. I also changed the repo to use LF on Windows for many of the involved files so there's no noisy mismatch between what the Linux containers generate vs. what's checked out by Windows.

Something like this is probably also possible with WSL, but I haven't had good luck with it, and containers are more minimal and repeatable in some ways.