### PR TITLE
Update to 1.21.12-2, 1.22.5-2; update ".sig" patch to use pgpSignatureUrl

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,8 +18,8 @@
             "1.21": {},
             "1.21-bookworm": {},
             "1.21.12": {},
-            "1.21.12-1": {},
-            "1.21.12-1-bookworm": {},
+            "1.21.12-2": {},
+            "1.21.12-2-bookworm": {},
             "1.21.12-bookworm": {},
             "bookworm": {},
             "latest": {}
@@ -31,7 +31,7 @@
               "os": "linux",
               "osVersion": "bookworm",
               "tags": {
-                "1.21.12-1-bookworm-amd64": {}
+                "1.21.12-2-bookworm-amd64": {}
               }
             },
             {
@@ -41,7 +41,7 @@
               "os": "linux",
               "osVersion": "bookworm",
               "tags": {
-                "1.21.12-1-bookworm-arm64v8": {}
+                "1.21.12-2-bookworm-arm64v8": {}
               }
             },
             {
@@ -51,7 +51,7 @@
               "os": "linux",
               "osVersion": "bookworm",
               "tags": {
-                "1.21.12-1-bookworm-arm32v7": {}
+                "1.21.12-2-bookworm-arm32v7": {}
               }
             }
           ]
@@ -61,7 +61,7 @@
           "sharedTags": {
             "1-bullseye": {},
             "1.21-bullseye": {},
-            "1.21.12-1-bullseye": {},
+            "1.21.12-2-bullseye": {},
             "1.21.12-bullseye": {},
             "bullseye": {}
           },
@@ -72,7 +72,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.21.12-1-bullseye-amd64": {}
+                "1.21.12-2-bullseye-amd64": {}
               }
             },
             {
@@ -82,7 +82,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.21.12-1-bullseye-arm64v8": {}
+                "1.21.12-2-bullseye-arm64v8": {}
               }
             },
             {
@@ -92,7 +92,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.21.12-1-bullseye-arm32v7": {}
+                "1.21.12-2-bullseye-arm32v7": {}
               }
             }
           ]
@@ -102,7 +102,7 @@
           "sharedTags": {
             "1-cbl-mariner2.0": {},
             "1.21-cbl-mariner2.0": {},
-            "1.21.12-1-cbl-mariner2.0": {},
+            "1.21.12-2-cbl-mariner2.0": {},
             "1.21.12-cbl-mariner2.0": {},
             "cbl-mariner2.0": {}
           },
@@ -113,7 +113,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "1.21.12-1-cbl-mariner2.0-amd64": {}
+                "1.21.12-2-cbl-mariner2.0-amd64": {}
               }
             },
             {
@@ -123,7 +123,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "1.21.12-1-cbl-mariner2.0-arm64v8": {}
+                "1.21.12-2-cbl-mariner2.0-arm64v8": {}
               }
             }
           ]
@@ -133,14 +133,14 @@
           "sharedTags": {
             "1-fips-bookworm": {},
             "1.21-fips-bookworm": {},
-            "1.21.12-1-fips-bookworm": {},
+            "1.21.12-2-fips-bookworm": {},
             "1.21.12-fips-bookworm": {},
             "fips-bookworm": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "FROM_TAG": "1.21.12-1-bookworm-amd64",
+                "FROM_TAG": "1.21.12-2-bookworm-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -148,12 +148,12 @@
               "os": "linux",
               "osVersion": "bookworm",
               "tags": {
-                "1.21.12-1-fips-bookworm-amd64": {}
+                "1.21.12-2-fips-bookworm-amd64": {}
               }
             },
             {
               "buildArgs": {
-                "FROM_TAG": "1.21.12-1-bookworm-arm64v8",
+                "FROM_TAG": "1.21.12-2-bookworm-arm64v8",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "arm64",
@@ -162,12 +162,12 @@
               "os": "linux",
               "osVersion": "bookworm",
               "tags": {
-                "1.21.12-1-fips-bookworm-arm64v8": {}
+                "1.21.12-2-fips-bookworm-arm64v8": {}
               }
             },
             {
               "buildArgs": {
-                "FROM_TAG": "1.21.12-1-bookworm-arm32v7",
+                "FROM_TAG": "1.21.12-2-bookworm-arm32v7",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "arm",
@@ -176,7 +176,7 @@
               "os": "linux",
               "osVersion": "bookworm",
               "tags": {
-                "1.21.12-1-fips-bookworm-arm32v7": {}
+                "1.21.12-2-fips-bookworm-arm32v7": {}
               }
             }
           ]
@@ -186,14 +186,14 @@
           "sharedTags": {
             "1-fips-bullseye": {},
             "1.21-fips-bullseye": {},
-            "1.21.12-1-fips-bullseye": {},
+            "1.21.12-2-fips-bullseye": {},
             "1.21.12-fips-bullseye": {},
             "fips-bullseye": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "FROM_TAG": "1.21.12-1-bullseye-amd64",
+                "FROM_TAG": "1.21.12-2-bullseye-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -201,12 +201,12 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.21.12-1-fips-bullseye-amd64": {}
+                "1.21.12-2-fips-bullseye-amd64": {}
               }
             },
             {
               "buildArgs": {
-                "FROM_TAG": "1.21.12-1-bullseye-arm64v8",
+                "FROM_TAG": "1.21.12-2-bullseye-arm64v8",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "arm64",
@@ -215,12 +215,12 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.21.12-1-fips-bullseye-arm64v8": {}
+                "1.21.12-2-fips-bullseye-arm64v8": {}
               }
             },
             {
               "buildArgs": {
-                "FROM_TAG": "1.21.12-1-bullseye-arm32v7",
+                "FROM_TAG": "1.21.12-2-bullseye-arm32v7",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "arm",
@@ -229,7 +229,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.21.12-1-fips-bullseye-arm32v7": {}
+                "1.21.12-2-fips-bullseye-arm32v7": {}
               }
             }
           ]
@@ -239,14 +239,14 @@
           "sharedTags": {
             "1-fips-cbl-mariner2.0": {},
             "1.21-fips-cbl-mariner2.0": {},
-            "1.21.12-1-fips-cbl-mariner2.0": {},
+            "1.21.12-2-fips-cbl-mariner2.0": {},
             "1.21.12-fips-cbl-mariner2.0": {},
             "fips-cbl-mariner2.0": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "FROM_TAG": "1.21.12-1-cbl-mariner2.0-amd64",
+                "FROM_TAG": "1.21.12-2-cbl-mariner2.0-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -254,12 +254,12 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "1.21.12-1-fips-cbl-mariner2.0-amd64": {}
+                "1.21.12-2-fips-cbl-mariner2.0-amd64": {}
               }
             },
             {
               "buildArgs": {
-                "FROM_TAG": "1.21.12-1-cbl-mariner2.0-arm64v8",
+                "FROM_TAG": "1.21.12-2-cbl-mariner2.0-arm64v8",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "arm64",
@@ -268,7 +268,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "1.21.12-1-fips-cbl-mariner2.0-arm64v8": {}
+                "1.21.12-2-fips-cbl-mariner2.0-arm64v8": {}
               }
             }
           ]
@@ -278,7 +278,7 @@
           "sharedTags": {
             "1-windowsservercore-ltsc2022": {},
             "1.21-windowsservercore-ltsc2022": {},
-            "1.21.12-1-windowsservercore-ltsc2022": {},
+            "1.21.12-2-windowsservercore-ltsc2022": {},
             "1.21.12-windowsservercore-ltsc2022": {},
             "windowsservercore-ltsc2022": {}
           },
@@ -289,7 +289,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2022",
               "tags": {
-                "1.21.12-1-windowsservercore-ltsc2022-amd64": {}
+                "1.21.12-2-windowsservercore-ltsc2022-amd64": {}
               }
             }
           ]
@@ -299,7 +299,7 @@
           "sharedTags": {
             "1-windowsservercore-1809": {},
             "1.21-windowsservercore-1809": {},
-            "1.21.12-1-windowsservercore-1809": {},
+            "1.21.12-2-windowsservercore-1809": {},
             "1.21.12-windowsservercore-1809": {},
             "windowsservercore-1809": {}
           },
@@ -310,7 +310,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1809",
               "tags": {
-                "1.21.12-1-windowsservercore-1809-amd64": {}
+                "1.21.12-2-windowsservercore-1809-amd64": {}
               }
             }
           ]
@@ -320,14 +320,14 @@
           "sharedTags": {
             "1-nanoserver-ltsc2022": {},
             "1.21-nanoserver-ltsc2022": {},
-            "1.21.12-1-nanoserver-ltsc2022": {},
+            "1.21.12-2-nanoserver-ltsc2022": {},
             "1.21.12-nanoserver-ltsc2022": {},
             "nanoserver-ltsc2022": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "DOWNLOADER_TAG": "1.21.12-1-windowsservercore-ltsc2022-amd64",
+                "DOWNLOADER_TAG": "1.21.12-2-windowsservercore-ltsc2022-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -335,7 +335,7 @@
               "os": "windows",
               "osVersion": "nanoserver-ltsc2022",
               "tags": {
-                "1.21.12-1-nanoserver-ltsc2022-amd64": {}
+                "1.21.12-2-nanoserver-ltsc2022-amd64": {}
               }
             }
           ]
@@ -345,14 +345,14 @@
           "sharedTags": {
             "1-nanoserver-1809": {},
             "1.21-nanoserver-1809": {},
-            "1.21.12-1-nanoserver-1809": {},
+            "1.21.12-2-nanoserver-1809": {},
             "1.21.12-nanoserver-1809": {},
             "nanoserver-1809": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "DOWNLOADER_TAG": "1.21.12-1-windowsservercore-1809-amd64",
+                "DOWNLOADER_TAG": "1.21.12-2-windowsservercore-1809-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -360,7 +360,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "1.21.12-1-nanoserver-1809-amd64": {}
+                "1.21.12-2-nanoserver-1809-amd64": {}
               }
             }
           ]
@@ -370,14 +370,14 @@
           "sharedTags": {
             "1-fips-windowsservercore-ltsc2022": {},
             "1.21-fips-windowsservercore-ltsc2022": {},
-            "1.21.12-1-fips-windowsservercore-ltsc2022": {},
+            "1.21.12-2-fips-windowsservercore-ltsc2022": {},
             "1.21.12-fips-windowsservercore-ltsc2022": {},
             "fips-windowsservercore-ltsc2022": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "FROM_TAG": "1.21.12-1-windowsservercore-ltsc2022-amd64",
+                "FROM_TAG": "1.21.12-2-windowsservercore-ltsc2022-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -385,7 +385,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2022",
               "tags": {
-                "1.21.12-1-fips-windowsservercore-ltsc2022-amd64": {}
+                "1.21.12-2-fips-windowsservercore-ltsc2022-amd64": {}
               }
             }
           ]
@@ -395,14 +395,14 @@
           "sharedTags": {
             "1-fips-windowsservercore-1809": {},
             "1.21-fips-windowsservercore-1809": {},
-            "1.21.12-1-fips-windowsservercore-1809": {},
+            "1.21.12-2-fips-windowsservercore-1809": {},
             "1.21.12-fips-windowsservercore-1809": {},
             "fips-windowsservercore-1809": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "FROM_TAG": "1.21.12-1-windowsservercore-1809-amd64",
+                "FROM_TAG": "1.21.12-2-windowsservercore-1809-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -410,7 +410,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1809",
               "tags": {
-                "1.21.12-1-fips-windowsservercore-1809-amd64": {}
+                "1.21.12-2-fips-windowsservercore-1809-amd64": {}
               }
             }
           ]
@@ -420,14 +420,14 @@
           "sharedTags": {
             "1-fips-nanoserver-ltsc2022": {},
             "1.21-fips-nanoserver-ltsc2022": {},
-            "1.21.12-1-fips-nanoserver-ltsc2022": {},
+            "1.21.12-2-fips-nanoserver-ltsc2022": {},
             "1.21.12-fips-nanoserver-ltsc2022": {},
             "fips-nanoserver-ltsc2022": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "FROM_TAG": "1.21.12-1-nanoserver-ltsc2022-amd64",
+                "FROM_TAG": "1.21.12-2-nanoserver-ltsc2022-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -435,7 +435,7 @@
               "os": "windows",
               "osVersion": "nanoserver-ltsc2022",
               "tags": {
-                "1.21.12-1-fips-nanoserver-ltsc2022-amd64": {}
+                "1.21.12-2-fips-nanoserver-ltsc2022-amd64": {}
               }
             }
           ]
@@ -445,14 +445,14 @@
           "sharedTags": {
             "1-fips-nanoserver-1809": {},
             "1.21-fips-nanoserver-1809": {},
-            "1.21.12-1-fips-nanoserver-1809": {},
+            "1.21.12-2-fips-nanoserver-1809": {},
             "1.21.12-fips-nanoserver-1809": {},
             "fips-nanoserver-1809": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "FROM_TAG": "1.21.12-1-nanoserver-1809-amd64",
+                "FROM_TAG": "1.21.12-2-nanoserver-1809-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -460,7 +460,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "1.21.12-1-fips-nanoserver-1809-amd64": {}
+                "1.21.12-2-fips-nanoserver-1809-amd64": {}
               }
             }
           ]

--- a/manifest.json
+++ b/manifest.json
@@ -471,8 +471,8 @@
             "1.22": {},
             "1.22-bookworm": {},
             "1.22.5": {},
-            "1.22.5-1": {},
-            "1.22.5-1-bookworm": {},
+            "1.22.5-2": {},
+            "1.22.5-2-bookworm": {},
             "1.22.5-bookworm": {}
           },
           "platforms": [
@@ -482,7 +482,7 @@
               "os": "linux",
               "osVersion": "bookworm",
               "tags": {
-                "1.22.5-1-bookworm-amd64": {}
+                "1.22.5-2-bookworm-amd64": {}
               }
             },
             {
@@ -492,7 +492,7 @@
               "os": "linux",
               "osVersion": "bookworm",
               "tags": {
-                "1.22.5-1-bookworm-arm64v8": {}
+                "1.22.5-2-bookworm-arm64v8": {}
               }
             },
             {
@@ -502,7 +502,7 @@
               "os": "linux",
               "osVersion": "bookworm",
               "tags": {
-                "1.22.5-1-bookworm-arm32v7": {}
+                "1.22.5-2-bookworm-arm32v7": {}
               }
             }
           ]
@@ -511,7 +511,7 @@
           "productVersion": "1.22",
           "sharedTags": {
             "1.22-bullseye": {},
-            "1.22.5-1-bullseye": {},
+            "1.22.5-2-bullseye": {},
             "1.22.5-bullseye": {}
           },
           "platforms": [
@@ -521,7 +521,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.22.5-1-bullseye-amd64": {}
+                "1.22.5-2-bullseye-amd64": {}
               }
             },
             {
@@ -531,7 +531,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.22.5-1-bullseye-arm64v8": {}
+                "1.22.5-2-bullseye-arm64v8": {}
               }
             },
             {
@@ -541,7 +541,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.22.5-1-bullseye-arm32v7": {}
+                "1.22.5-2-bullseye-arm32v7": {}
               }
             }
           ]
@@ -550,7 +550,7 @@
           "productVersion": "1.22",
           "sharedTags": {
             "1.22-cbl-mariner2.0": {},
-            "1.22.5-1-cbl-mariner2.0": {},
+            "1.22.5-2-cbl-mariner2.0": {},
             "1.22.5-cbl-mariner2.0": {}
           },
           "platforms": [
@@ -560,7 +560,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "1.22.5-1-cbl-mariner2.0-amd64": {}
+                "1.22.5-2-cbl-mariner2.0-amd64": {}
               }
             },
             {
@@ -570,7 +570,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "1.22.5-1-cbl-mariner2.0-arm64v8": {}
+                "1.22.5-2-cbl-mariner2.0-arm64v8": {}
               }
             }
           ]
@@ -579,13 +579,13 @@
           "productVersion": "1.22",
           "sharedTags": {
             "1.22-fips-bookworm": {},
-            "1.22.5-1-fips-bookworm": {},
+            "1.22.5-2-fips-bookworm": {},
             "1.22.5-fips-bookworm": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "FROM_TAG": "1.22.5-1-bookworm-amd64",
+                "FROM_TAG": "1.22.5-2-bookworm-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -593,12 +593,12 @@
               "os": "linux",
               "osVersion": "bookworm",
               "tags": {
-                "1.22.5-1-fips-bookworm-amd64": {}
+                "1.22.5-2-fips-bookworm-amd64": {}
               }
             },
             {
               "buildArgs": {
-                "FROM_TAG": "1.22.5-1-bookworm-arm64v8",
+                "FROM_TAG": "1.22.5-2-bookworm-arm64v8",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "arm64",
@@ -607,12 +607,12 @@
               "os": "linux",
               "osVersion": "bookworm",
               "tags": {
-                "1.22.5-1-fips-bookworm-arm64v8": {}
+                "1.22.5-2-fips-bookworm-arm64v8": {}
               }
             },
             {
               "buildArgs": {
-                "FROM_TAG": "1.22.5-1-bookworm-arm32v7",
+                "FROM_TAG": "1.22.5-2-bookworm-arm32v7",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "arm",
@@ -621,7 +621,7 @@
               "os": "linux",
               "osVersion": "bookworm",
               "tags": {
-                "1.22.5-1-fips-bookworm-arm32v7": {}
+                "1.22.5-2-fips-bookworm-arm32v7": {}
               }
             }
           ]
@@ -630,13 +630,13 @@
           "productVersion": "1.22",
           "sharedTags": {
             "1.22-fips-bullseye": {},
-            "1.22.5-1-fips-bullseye": {},
+            "1.22.5-2-fips-bullseye": {},
             "1.22.5-fips-bullseye": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "FROM_TAG": "1.22.5-1-bullseye-amd64",
+                "FROM_TAG": "1.22.5-2-bullseye-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -644,12 +644,12 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.22.5-1-fips-bullseye-amd64": {}
+                "1.22.5-2-fips-bullseye-amd64": {}
               }
             },
             {
               "buildArgs": {
-                "FROM_TAG": "1.22.5-1-bullseye-arm64v8",
+                "FROM_TAG": "1.22.5-2-bullseye-arm64v8",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "arm64",
@@ -658,12 +658,12 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.22.5-1-fips-bullseye-arm64v8": {}
+                "1.22.5-2-fips-bullseye-arm64v8": {}
               }
             },
             {
               "buildArgs": {
-                "FROM_TAG": "1.22.5-1-bullseye-arm32v7",
+                "FROM_TAG": "1.22.5-2-bullseye-arm32v7",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "arm",
@@ -672,7 +672,7 @@
               "os": "linux",
               "osVersion": "bullseye",
               "tags": {
-                "1.22.5-1-fips-bullseye-arm32v7": {}
+                "1.22.5-2-fips-bullseye-arm32v7": {}
               }
             }
           ]
@@ -681,13 +681,13 @@
           "productVersion": "1.22",
           "sharedTags": {
             "1.22-fips-cbl-mariner2.0": {},
-            "1.22.5-1-fips-cbl-mariner2.0": {},
+            "1.22.5-2-fips-cbl-mariner2.0": {},
             "1.22.5-fips-cbl-mariner2.0": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "FROM_TAG": "1.22.5-1-cbl-mariner2.0-amd64",
+                "FROM_TAG": "1.22.5-2-cbl-mariner2.0-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -695,12 +695,12 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "1.22.5-1-fips-cbl-mariner2.0-amd64": {}
+                "1.22.5-2-fips-cbl-mariner2.0-amd64": {}
               }
             },
             {
               "buildArgs": {
-                "FROM_TAG": "1.22.5-1-cbl-mariner2.0-arm64v8",
+                "FROM_TAG": "1.22.5-2-cbl-mariner2.0-arm64v8",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "arm64",
@@ -709,7 +709,7 @@
               "os": "linux",
               "osVersion": "cbl-mariner2.0",
               "tags": {
-                "1.22.5-1-fips-cbl-mariner2.0-arm64v8": {}
+                "1.22.5-2-fips-cbl-mariner2.0-arm64v8": {}
               }
             }
           ]
@@ -718,7 +718,7 @@
           "productVersion": "1.22",
           "sharedTags": {
             "1.22-windowsservercore-ltsc2022": {},
-            "1.22.5-1-windowsservercore-ltsc2022": {},
+            "1.22.5-2-windowsservercore-ltsc2022": {},
             "1.22.5-windowsservercore-ltsc2022": {}
           },
           "platforms": [
@@ -728,7 +728,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2022",
               "tags": {
-                "1.22.5-1-windowsservercore-ltsc2022-amd64": {}
+                "1.22.5-2-windowsservercore-ltsc2022-amd64": {}
               }
             }
           ]
@@ -737,7 +737,7 @@
           "productVersion": "1.22",
           "sharedTags": {
             "1.22-windowsservercore-1809": {},
-            "1.22.5-1-windowsservercore-1809": {},
+            "1.22.5-2-windowsservercore-1809": {},
             "1.22.5-windowsservercore-1809": {}
           },
           "platforms": [
@@ -747,7 +747,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1809",
               "tags": {
-                "1.22.5-1-windowsservercore-1809-amd64": {}
+                "1.22.5-2-windowsservercore-1809-amd64": {}
               }
             }
           ]
@@ -756,13 +756,13 @@
           "productVersion": "1.22",
           "sharedTags": {
             "1.22-nanoserver-ltsc2022": {},
-            "1.22.5-1-nanoserver-ltsc2022": {},
+            "1.22.5-2-nanoserver-ltsc2022": {},
             "1.22.5-nanoserver-ltsc2022": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "DOWNLOADER_TAG": "1.22.5-1-windowsservercore-ltsc2022-amd64",
+                "DOWNLOADER_TAG": "1.22.5-2-windowsservercore-ltsc2022-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -770,7 +770,7 @@
               "os": "windows",
               "osVersion": "nanoserver-ltsc2022",
               "tags": {
-                "1.22.5-1-nanoserver-ltsc2022-amd64": {}
+                "1.22.5-2-nanoserver-ltsc2022-amd64": {}
               }
             }
           ]
@@ -779,13 +779,13 @@
           "productVersion": "1.22",
           "sharedTags": {
             "1.22-nanoserver-1809": {},
-            "1.22.5-1-nanoserver-1809": {},
+            "1.22.5-2-nanoserver-1809": {},
             "1.22.5-nanoserver-1809": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "DOWNLOADER_TAG": "1.22.5-1-windowsservercore-1809-amd64",
+                "DOWNLOADER_TAG": "1.22.5-2-windowsservercore-1809-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -793,7 +793,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "1.22.5-1-nanoserver-1809-amd64": {}
+                "1.22.5-2-nanoserver-1809-amd64": {}
               }
             }
           ]
@@ -802,13 +802,13 @@
           "productVersion": "1.22",
           "sharedTags": {
             "1.22-fips-windowsservercore-ltsc2022": {},
-            "1.22.5-1-fips-windowsservercore-ltsc2022": {},
+            "1.22.5-2-fips-windowsservercore-ltsc2022": {},
             "1.22.5-fips-windowsservercore-ltsc2022": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "FROM_TAG": "1.22.5-1-windowsservercore-ltsc2022-amd64",
+                "FROM_TAG": "1.22.5-2-windowsservercore-ltsc2022-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -816,7 +816,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2022",
               "tags": {
-                "1.22.5-1-fips-windowsservercore-ltsc2022-amd64": {}
+                "1.22.5-2-fips-windowsservercore-ltsc2022-amd64": {}
               }
             }
           ]
@@ -825,13 +825,13 @@
           "productVersion": "1.22",
           "sharedTags": {
             "1.22-fips-windowsservercore-1809": {},
-            "1.22.5-1-fips-windowsservercore-1809": {},
+            "1.22.5-2-fips-windowsservercore-1809": {},
             "1.22.5-fips-windowsservercore-1809": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "FROM_TAG": "1.22.5-1-windowsservercore-1809-amd64",
+                "FROM_TAG": "1.22.5-2-windowsservercore-1809-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -839,7 +839,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1809",
               "tags": {
-                "1.22.5-1-fips-windowsservercore-1809-amd64": {}
+                "1.22.5-2-fips-windowsservercore-1809-amd64": {}
               }
             }
           ]
@@ -848,13 +848,13 @@
           "productVersion": "1.22",
           "sharedTags": {
             "1.22-fips-nanoserver-ltsc2022": {},
-            "1.22.5-1-fips-nanoserver-ltsc2022": {},
+            "1.22.5-2-fips-nanoserver-ltsc2022": {},
             "1.22.5-fips-nanoserver-ltsc2022": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "FROM_TAG": "1.22.5-1-nanoserver-ltsc2022-amd64",
+                "FROM_TAG": "1.22.5-2-nanoserver-ltsc2022-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -862,7 +862,7 @@
               "os": "windows",
               "osVersion": "nanoserver-ltsc2022",
               "tags": {
-                "1.22.5-1-fips-nanoserver-ltsc2022-amd64": {}
+                "1.22.5-2-fips-nanoserver-ltsc2022-amd64": {}
               }
             }
           ]
@@ -871,13 +871,13 @@
           "productVersion": "1.22",
           "sharedTags": {
             "1.22-fips-nanoserver-1809": {},
-            "1.22.5-1-fips-nanoserver-1809": {},
+            "1.22.5-2-fips-nanoserver-1809": {},
             "1.22.5-fips-nanoserver-1809": {}
           },
           "platforms": [
             {
               "buildArgs": {
-                "FROM_TAG": "1.22.5-1-nanoserver-1809-amd64",
+                "FROM_TAG": "1.22.5-2-nanoserver-1809-amd64",
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "amd64",
@@ -885,7 +885,7 @@
               "os": "windows",
               "osVersion": "nanoserver-1809",
               "tags": {
-                "1.22.5-1-fips-nanoserver-1809-amd64": {}
+                "1.22.5-2-fips-nanoserver-1809-amd64": {}
               }
             }
           ]

--- a/patches/0001-Check-signature-of-microsoft-go-builds.patch
+++ b/patches/0001-Check-signature-of-microsoft-go-builds.patch
@@ -3,22 +3,39 @@ From: microsoft-golang-bot <microsoft-golang-bot@users.noreply.github.com>
 Date: Fri, 11 Feb 2022 18:03:46 -0600
 Subject: [PATCH] Check signature of microsoft/go builds
 
-Change ".asc" to ".sig" to match the filename we publish. Download our
-public key from an https Microsoft URL to check the signature against.
+Microsoft Go artifacts on download.visualstudio.microsoft.com don't
+support ".sig" suffix: the base URL also changes. Use the
+pgpSignatureUrl entry present in the Microsoft Go versions.json instead.
 ---
- Dockerfile-linux.template | 4 +++-
- 1 file changed, 3 insertions(+), 1 deletion(-)
+ Dockerfile-linux.template | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index 1bfd5d4910a837..1c8c549b281edc 100644
+index 9c2fb247d2311b..80154991b9f163 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
-@@ -87,12 +87,14 @@ RUN set -eux; \
+@@ -64,6 +64,7 @@ RUN set -eux; \
+ 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+ {{ ) end -}}
+ 	url=; \
++	urlSig=; \
+ 	case "$arch" in \
+ {{
+ 	[
+@@ -79,6 +80,7 @@ RUN set -eux; \
+ -}}
+ 		{{ $osArch | @sh }}) \
+ 			url={{ .url | @sh }}; \
++			urlSig={{ .pgpSignatureUrl | @sh }}; \
+ 			sha256={{ .sha256 | @sh }}; \
+ 			;; \
+ {{
+@@ -88,12 +90,14 @@ RUN set -eux; \
  		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
  	esac; \
  	\
 -	wget -O go.tgz.asc "$url.asc"; \
-+	wget -O go.tgz.asc "$url.sig"; \
++	wget -O go.tgz.asc "$urlSig"; \
  	wget -O go.tgz "$url"{{ if is_alpine then "" else " --progress=dot:giga" end }}; \
  	echo "$sha256 *go.tgz" | sha256sum -c -; \
  	\

--- a/patches/0002-Add-Mariner-FIPS-package-upgrade.patch
+++ b/patches/0002-Add-Mariner-FIPS-package-upgrade.patch
@@ -4,14 +4,14 @@ Date: Fri, 11 Feb 2022 18:07:18 -0600
 Subject: [PATCH] Add Mariner, FIPS, package upgrade
 
 ---
- Dockerfile-linux.template | 88 +++++++++++++++++++++++++++++++++++++++
- 1 file changed, 88 insertions(+)
+ Dockerfile-linux.template | 91 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 91 insertions(+)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index 1c8c549b281edc..b73c219e3b3946 100644
+index 80154991b9f163..14dc75fe6f8d72 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
-@@ -4,9 +4,31 @@
+@@ -4,9 +4,34 @@
  	;
  	def alpine_version:
  		env.variant | ltrimstr("alpine")
@@ -38,12 +38,15 @@ index 1c8c549b281edc..b73c219e3b3946 100644
 +	tdnf install -y \
 +		tar \
 +		wget \
++		# To reduce image size, the Azure Linux (aka CBL-Mariner) image doesn't include full ca-certificates: https://github.com/microsoft/azurelinux/issues/3563
++		# We need ca-certificates here to verify https://download.visualstudio.microsoft.com.
++		ca-certificates \
 +	; \
 +	tdnf clean all
  {{ ) else ( -}}
  FROM buildpack-deps:{{ env.variant }}-scm AS build
  {{ ) end -}}
-@@ -30,6 +52,13 @@ ENV GOLANG_VERSION {{ .version }}
+@@ -30,6 +55,13 @@ ENV GOLANG_VERSION {{ .version }}
  				riscv64: "riscv64",
  				s390x: "s390x",
  			}
@@ -57,7 +60,7 @@ index 1c8c549b281edc..b73c219e3b3946 100644
  		else
  			{
  				# https://salsa.debian.org/dpkg-team/dpkg/-/blob/main/data/cputable
-@@ -59,6 +88,8 @@ RUN set -eux; \
+@@ -60,6 +92,8 @@ RUN set -eux; \
  		tar \
  	; \
  	arch="$(apk --print-arch)"; \
@@ -66,7 +69,7 @@ index 1c8c549b281edc..b73c219e3b3946 100644
  {{ ) else ( -}}
  	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
  {{ ) end -}}
-@@ -95,10 +126,16 @@ RUN set -eux; \
+@@ -98,10 +132,16 @@ RUN set -eux; \
  	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
  	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
  	gpg --batch --import microsoft-managed-lang-compiler.asc; \
@@ -83,7 +86,7 @@ index 1c8c549b281edc..b73c219e3b3946 100644
  	gpg --batch --verify go.tgz.asc go.tgz; \
  	gpgconf --kill all; \
  	rm -rf "$GNUPGHOME" go.tgz.asc; \
-@@ -142,18 +179,69 @@ RUN set -eux; \
+@@ -154,18 +194,69 @@ RUN set -eux; \
  FROM alpine:{{ alpine_version }}
  
  RUN apk add --no-cache ca-certificates

--- a/src/microsoft/1.21/bookworm/Dockerfile
+++ b/src/microsoft/1.21/bookworm/Dockerfile
@@ -16,16 +16,16 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.21/20240702.5/go.20240702.5.linux-amd64.tar.gz'; \
-			sha256='862046055d51670fc98fbb628da78d7ed7b18b48d8309fe972489607d9de3097'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/1a10f1be2fafa3bb318623c216537366/go.20240722.4.linux-amd64.tar.gz'; \
+			sha256='27a475b059bf9e2ea1219870ae66eb573fdc5cb4e01dd04cf5140697814be17c'; \
 			;; \
 		'armhf') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.21/20240702.5/go.20240702.5.linux-armv6l.tar.gz'; \
-			sha256='eefc663af731b747510d56b33839042662c2bb24931321b0a560f69416dbb7a3'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/c6b56416f39cd09981545ead8ccfe750/go.20240722.4.linux-armv6l.tar.gz'; \
+			sha256='4b6a53719c5dbb0f2eb455d020d4c3b79a96d412a9daeb3deadcc7fdcbd7654f'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.21/20240702.5/go.20240702.5.linux-arm64.tar.gz'; \
-			sha256='98e601f53085a6f61d2d7a1537a948ae4664b860cb9f33f48926e586b87fc98a'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/5dd42460468455ff40378d326789a67b/go.20240722.4.linux-arm64.tar.gz'; \
+			sha256='fc8a1aee9c8d01b5d4da85c9b4e47ef65e2bcfedb50a562c86d2c2b0a0d5cd06'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.21/bookworm/Dockerfile
+++ b/src/microsoft/1.21/bookworm/Dockerfile
@@ -14,23 +14,27 @@ RUN set -eux; \
 	now="$(date '+%s')"; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
+	urlSig=; \
 	case "$arch" in \
 		'amd64') \
 			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/1a10f1be2fafa3bb318623c216537366/go.20240722.4.linux-amd64.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/efd9985d571f6ddf080a8695a7bdb986/go.20240722.4.linux-amd64.tar.gz.sig'; \
 			sha256='27a475b059bf9e2ea1219870ae66eb573fdc5cb4e01dd04cf5140697814be17c'; \
 			;; \
 		'armhf') \
 			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/c6b56416f39cd09981545ead8ccfe750/go.20240722.4.linux-armv6l.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/9d215a7b9da33c7d5f23b0994743f2c7/go.20240722.4.linux-armv6l.tar.gz.sig'; \
 			sha256='4b6a53719c5dbb0f2eb455d020d4c3b79a96d412a9daeb3deadcc7fdcbd7654f'; \
 			;; \
 		'arm64') \
 			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/5dd42460468455ff40378d326789a67b/go.20240722.4.linux-arm64.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/41c3b010c79117429cc3a0ed5d39ba09/go.20240722.4.linux-arm64.tar.gz.sig'; \
 			sha256='fc8a1aee9c8d01b5d4da85c9b4e47ef65e2bcfedb50a562c86d2c2b0a0d5cd06'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
 	\
-	wget -O go.tgz.asc "$url.sig"; \
+	wget -O go.tgz.asc "$urlSig"; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
 	echo "$sha256 *go.tgz" | sha256sum -c -; \
 	\

--- a/src/microsoft/1.21/bullseye/Dockerfile
+++ b/src/microsoft/1.21/bullseye/Dockerfile
@@ -16,16 +16,16 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.21/20240702.5/go.20240702.5.linux-amd64.tar.gz'; \
-			sha256='862046055d51670fc98fbb628da78d7ed7b18b48d8309fe972489607d9de3097'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/1a10f1be2fafa3bb318623c216537366/go.20240722.4.linux-amd64.tar.gz'; \
+			sha256='27a475b059bf9e2ea1219870ae66eb573fdc5cb4e01dd04cf5140697814be17c'; \
 			;; \
 		'armhf') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.21/20240702.5/go.20240702.5.linux-armv6l.tar.gz'; \
-			sha256='eefc663af731b747510d56b33839042662c2bb24931321b0a560f69416dbb7a3'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/c6b56416f39cd09981545ead8ccfe750/go.20240722.4.linux-armv6l.tar.gz'; \
+			sha256='4b6a53719c5dbb0f2eb455d020d4c3b79a96d412a9daeb3deadcc7fdcbd7654f'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.21/20240702.5/go.20240702.5.linux-arm64.tar.gz'; \
-			sha256='98e601f53085a6f61d2d7a1537a948ae4664b860cb9f33f48926e586b87fc98a'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/5dd42460468455ff40378d326789a67b/go.20240722.4.linux-arm64.tar.gz'; \
+			sha256='fc8a1aee9c8d01b5d4da85c9b4e47ef65e2bcfedb50a562c86d2c2b0a0d5cd06'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.21/bullseye/Dockerfile
+++ b/src/microsoft/1.21/bullseye/Dockerfile
@@ -14,23 +14,27 @@ RUN set -eux; \
 	now="$(date '+%s')"; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
+	urlSig=; \
 	case "$arch" in \
 		'amd64') \
 			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/1a10f1be2fafa3bb318623c216537366/go.20240722.4.linux-amd64.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/efd9985d571f6ddf080a8695a7bdb986/go.20240722.4.linux-amd64.tar.gz.sig'; \
 			sha256='27a475b059bf9e2ea1219870ae66eb573fdc5cb4e01dd04cf5140697814be17c'; \
 			;; \
 		'armhf') \
 			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/c6b56416f39cd09981545ead8ccfe750/go.20240722.4.linux-armv6l.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/9d215a7b9da33c7d5f23b0994743f2c7/go.20240722.4.linux-armv6l.tar.gz.sig'; \
 			sha256='4b6a53719c5dbb0f2eb455d020d4c3b79a96d412a9daeb3deadcc7fdcbd7654f'; \
 			;; \
 		'arm64') \
 			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/5dd42460468455ff40378d326789a67b/go.20240722.4.linux-arm64.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/41c3b010c79117429cc3a0ed5d39ba09/go.20240722.4.linux-arm64.tar.gz.sig'; \
 			sha256='fc8a1aee9c8d01b5d4da85c9b4e47ef65e2bcfedb50a562c86d2c2b0a0d5cd06'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
 	\
-	wget -O go.tgz.asc "$url.sig"; \
+	wget -O go.tgz.asc "$urlSig"; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
 	echo "$sha256 *go.tgz" | sha256sum -c -; \
 	\

--- a/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
@@ -26,16 +26,16 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.21/20240702.5/go.20240702.5.linux-amd64.tar.gz'; \
-			sha256='862046055d51670fc98fbb628da78d7ed7b18b48d8309fe972489607d9de3097'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/1a10f1be2fafa3bb318623c216537366/go.20240722.4.linux-amd64.tar.gz'; \
+			sha256='27a475b059bf9e2ea1219870ae66eb573fdc5cb4e01dd04cf5140697814be17c'; \
 			;; \
 		'armv7') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.21/20240702.5/go.20240702.5.linux-armv6l.tar.gz'; \
-			sha256='eefc663af731b747510d56b33839042662c2bb24931321b0a560f69416dbb7a3'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/c6b56416f39cd09981545ead8ccfe750/go.20240722.4.linux-armv6l.tar.gz'; \
+			sha256='4b6a53719c5dbb0f2eb455d020d4c3b79a96d412a9daeb3deadcc7fdcbd7654f'; \
 			;; \
 		'aarch64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.21/20240702.5/go.20240702.5.linux-arm64.tar.gz'; \
-			sha256='98e601f53085a6f61d2d7a1537a948ae4664b860cb9f33f48926e586b87fc98a'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/5dd42460468455ff40378d326789a67b/go.20240722.4.linux-arm64.tar.gz'; \
+			sha256='fc8a1aee9c8d01b5d4da85c9b4e47ef65e2bcfedb50a562c86d2c2b0a0d5cd06'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \

--- a/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
@@ -24,23 +24,27 @@ RUN set -eux; \
 	now="$(date '+%s')"; \
 	arch="$(uname -m)"; \
 	url=; \
+	urlSig=; \
 	case "$arch" in \
 		'x86_64') \
 			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/1a10f1be2fafa3bb318623c216537366/go.20240722.4.linux-amd64.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/efd9985d571f6ddf080a8695a7bdb986/go.20240722.4.linux-amd64.tar.gz.sig'; \
 			sha256='27a475b059bf9e2ea1219870ae66eb573fdc5cb4e01dd04cf5140697814be17c'; \
 			;; \
 		'armv7') \
 			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/c6b56416f39cd09981545ead8ccfe750/go.20240722.4.linux-armv6l.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/9d215a7b9da33c7d5f23b0994743f2c7/go.20240722.4.linux-armv6l.tar.gz.sig'; \
 			sha256='4b6a53719c5dbb0f2eb455d020d4c3b79a96d412a9daeb3deadcc7fdcbd7654f'; \
 			;; \
 		'aarch64') \
 			url='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/5dd42460468455ff40378d326789a67b/go.20240722.4.linux-arm64.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/41c3b010c79117429cc3a0ed5d39ba09/go.20240722.4.linux-arm64.tar.gz.sig'; \
 			sha256='fc8a1aee9c8d01b5d4da85c9b4e47ef65e2bcfedb50a562c86d2c2b0a0d5cd06'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
 	\
-	wget -O go.tgz.asc "$url.sig"; \
+	wget -O go.tgz.asc "$urlSig"; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
 	echo "$sha256 *go.tgz" | sha256sum -c -; \
 	\

--- a/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.21/cbl-mariner2.0/Dockerfile
@@ -13,6 +13,9 @@ RUN set -eux; \
 	tdnf install -y \
 		tar \
 		wget \
+		# To reduce image size, the Azure Linux (aka CBL-Mariner) image doesn't include full ca-certificates: https://github.com/microsoft/azurelinux/issues/3563
+		# We need ca-certificates here to verify https://download.visualstudio.microsoft.com.
+		ca-certificates \
 	; \
 	tdnf clean all
 

--- a/src/microsoft/1.21/fips/bookworm/Dockerfile
+++ b/src/microsoft/1.21/fips/bookworm/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.21.12-1-bookworm
+ARG FROM_TAG=1.21.12-2-bookworm
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/1.21/fips/bullseye/Dockerfile
+++ b/src/microsoft/1.21/fips/bullseye/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.21.12-1-bullseye
+ARG FROM_TAG=1.21.12-2-bullseye
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/1.21/fips/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.21/fips/cbl-mariner2.0/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.21.12-1-cbl-mariner2.0
+ARG FROM_TAG=1.21.12-2-cbl-mariner2.0
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/1.21/windows/fips/nanoserver-1809/Dockerfile
+++ b/src/microsoft/1.21/windows/fips/nanoserver-1809/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.21.12-1-nanoserver-1809
+ARG FROM_TAG=1.21.12-2-nanoserver-1809
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/1.21/windows/fips/nanoserver-ltsc2022/Dockerfile
+++ b/src/microsoft/1.21/windows/fips/nanoserver-ltsc2022/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.21.12-1-nanoserver-ltsc2022
+ARG FROM_TAG=1.21.12-2-nanoserver-ltsc2022
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/1.21/windows/fips/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.21/windows/fips/windowsservercore-1809/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.21.12-1-windowsservercore-1809
+ARG FROM_TAG=1.21.12-2-windowsservercore-1809
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/1.21/windows/fips/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.21/windows/fips/windowsservercore-ltsc2022/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.21.12-1-windowsservercore-ltsc2022
+ARG FROM_TAG=1.21.12-2-windowsservercore-ltsc2022
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/1.21/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.21/windows/windowsservercore-1809/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.21.12
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.21/20240702.5/go.20240702.5.windows-amd64.zip'; \
+RUN $url = 'https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/e0bc30786c4b74b786c97a06f3805edd/go.20240722.4.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'f1f875ec7f483133b488c5e6b6a7a980496b7d5b7de1fedea4aec8e247d2a1ea'; \
+	$sha256 = '419696dbcbfd6ebf6b0b1aa0806e92dc1a959577715e210477486d7c1e89a622'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.21/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.21/windows/windowsservercore-ltsc2022/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.21.12
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.21/20240702.5/go.20240702.5.windows-amd64.zip'; \
+RUN $url = 'https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/e0bc30786c4b74b786c97a06f3805edd/go.20240722.4.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'f1f875ec7f483133b488c5e6b6a7a980496b7d5b7de1fedea4aec8e247d2a1ea'; \
+	$sha256 = '419696dbcbfd6ebf6b0b1aa0806e92dc1a959577715e210477486d7c1e89a622'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.22/bookworm/Dockerfile
+++ b/src/microsoft/1.22/bookworm/Dockerfile
@@ -14,23 +14,27 @@ RUN set -eux; \
 	now="$(date '+%s')"; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
+	urlSig=; \
 	case "$arch" in \
 		'amd64') \
 			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/06dceb5a69d1318939c8c466d496dbe0/go1.22.5-20240722.5.linux-amd64.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/b9bcf92dc4f4b09cb6a3a0ed6a7c4518/go1.22.5-20240722.5.linux-amd64.tar.gz.sig'; \
 			sha256='59963327dc86e8a5f48d9485ed800c26f80b9975c9331736c33005947a02686f'; \
 			;; \
 		'armhf') \
 			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/254bc806f38765e6d02981f1481c4aa9/go1.22.5-20240722.5.linux-armv6l.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/f04f32de31cc766d213daf0862587a85/go1.22.5-20240722.5.linux-armv6l.tar.gz.sig'; \
 			sha256='c641ce883b1967fb5df679ee652ebd2482dcbc14e528b36fea942ab69b4ca2f2'; \
 			;; \
 		'arm64') \
 			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/eeb1608811d4a63e40bdf4cbb0a5d76f/go1.22.5-20240722.5.linux-arm64.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/c3a5cebb631b73f51eb97dd320afb9a5/go1.22.5-20240722.5.linux-arm64.tar.gz.sig'; \
 			sha256='92078bdb0a2cbe1a5c175b3046427eca30f137b57106157d0696099254bbe03d'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
 	\
-	wget -O go.tgz.asc "$url.sig"; \
+	wget -O go.tgz.asc "$urlSig"; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
 	echo "$sha256 *go.tgz" | sha256sum -c -; \
 	\

--- a/src/microsoft/1.22/bookworm/Dockerfile
+++ b/src/microsoft/1.22/bookworm/Dockerfile
@@ -16,15 +16,15 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.22.5-20240702.3.linux-amd64.tar.gz'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/06dceb5a69d1318939c8c466d496dbe0/go1.22.5-20240722.5.linux-amd64.tar.gz'; \
 			sha256='59963327dc86e8a5f48d9485ed800c26f80b9975c9331736c33005947a02686f'; \
 			;; \
 		'armhf') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.22.5-20240702.3.linux-armv6l.tar.gz'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/254bc806f38765e6d02981f1481c4aa9/go1.22.5-20240722.5.linux-armv6l.tar.gz'; \
 			sha256='c641ce883b1967fb5df679ee652ebd2482dcbc14e528b36fea942ab69b4ca2f2'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.22.5-20240702.3.linux-arm64.tar.gz'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/eeb1608811d4a63e40bdf4cbb0a5d76f/go1.22.5-20240722.5.linux-arm64.tar.gz'; \
 			sha256='92078bdb0a2cbe1a5c175b3046427eca30f137b57106157d0696099254bbe03d'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \

--- a/src/microsoft/1.22/bullseye/Dockerfile
+++ b/src/microsoft/1.22/bullseye/Dockerfile
@@ -14,23 +14,27 @@ RUN set -eux; \
 	now="$(date '+%s')"; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
+	urlSig=; \
 	case "$arch" in \
 		'amd64') \
 			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/06dceb5a69d1318939c8c466d496dbe0/go1.22.5-20240722.5.linux-amd64.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/b9bcf92dc4f4b09cb6a3a0ed6a7c4518/go1.22.5-20240722.5.linux-amd64.tar.gz.sig'; \
 			sha256='59963327dc86e8a5f48d9485ed800c26f80b9975c9331736c33005947a02686f'; \
 			;; \
 		'armhf') \
 			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/254bc806f38765e6d02981f1481c4aa9/go1.22.5-20240722.5.linux-armv6l.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/f04f32de31cc766d213daf0862587a85/go1.22.5-20240722.5.linux-armv6l.tar.gz.sig'; \
 			sha256='c641ce883b1967fb5df679ee652ebd2482dcbc14e528b36fea942ab69b4ca2f2'; \
 			;; \
 		'arm64') \
 			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/eeb1608811d4a63e40bdf4cbb0a5d76f/go1.22.5-20240722.5.linux-arm64.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/c3a5cebb631b73f51eb97dd320afb9a5/go1.22.5-20240722.5.linux-arm64.tar.gz.sig'; \
 			sha256='92078bdb0a2cbe1a5c175b3046427eca30f137b57106157d0696099254bbe03d'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
 	\
-	wget -O go.tgz.asc "$url.sig"; \
+	wget -O go.tgz.asc "$urlSig"; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
 	echo "$sha256 *go.tgz" | sha256sum -c -; \
 	\

--- a/src/microsoft/1.22/bullseye/Dockerfile
+++ b/src/microsoft/1.22/bullseye/Dockerfile
@@ -16,15 +16,15 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.22.5-20240702.3.linux-amd64.tar.gz'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/06dceb5a69d1318939c8c466d496dbe0/go1.22.5-20240722.5.linux-amd64.tar.gz'; \
 			sha256='59963327dc86e8a5f48d9485ed800c26f80b9975c9331736c33005947a02686f'; \
 			;; \
 		'armhf') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.22.5-20240702.3.linux-armv6l.tar.gz'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/254bc806f38765e6d02981f1481c4aa9/go1.22.5-20240722.5.linux-armv6l.tar.gz'; \
 			sha256='c641ce883b1967fb5df679ee652ebd2482dcbc14e528b36fea942ab69b4ca2f2'; \
 			;; \
 		'arm64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.22.5-20240702.3.linux-arm64.tar.gz'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/eeb1608811d4a63e40bdf4cbb0a5d76f/go1.22.5-20240722.5.linux-arm64.tar.gz'; \
 			sha256='92078bdb0a2cbe1a5c175b3046427eca30f137b57106157d0696099254bbe03d'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \

--- a/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
@@ -24,23 +24,27 @@ RUN set -eux; \
 	now="$(date '+%s')"; \
 	arch="$(uname -m)"; \
 	url=; \
+	urlSig=; \
 	case "$arch" in \
 		'x86_64') \
 			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/06dceb5a69d1318939c8c466d496dbe0/go1.22.5-20240722.5.linux-amd64.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/b9bcf92dc4f4b09cb6a3a0ed6a7c4518/go1.22.5-20240722.5.linux-amd64.tar.gz.sig'; \
 			sha256='59963327dc86e8a5f48d9485ed800c26f80b9975c9331736c33005947a02686f'; \
 			;; \
 		'armv7') \
 			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/254bc806f38765e6d02981f1481c4aa9/go1.22.5-20240722.5.linux-armv6l.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/f04f32de31cc766d213daf0862587a85/go1.22.5-20240722.5.linux-armv6l.tar.gz.sig'; \
 			sha256='c641ce883b1967fb5df679ee652ebd2482dcbc14e528b36fea942ab69b4ca2f2'; \
 			;; \
 		'aarch64') \
 			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/eeb1608811d4a63e40bdf4cbb0a5d76f/go1.22.5-20240722.5.linux-arm64.tar.gz'; \
+			urlSig='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/c3a5cebb631b73f51eb97dd320afb9a5/go1.22.5-20240722.5.linux-arm64.tar.gz.sig'; \
 			sha256='92078bdb0a2cbe1a5c175b3046427eca30f137b57106157d0696099254bbe03d'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
 	\
-	wget -O go.tgz.asc "$url.sig"; \
+	wget -O go.tgz.asc "$urlSig"; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
 	echo "$sha256 *go.tgz" | sha256sum -c -; \
 	\

--- a/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
@@ -26,15 +26,15 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.22.5-20240702.3.linux-amd64.tar.gz'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/06dceb5a69d1318939c8c466d496dbe0/go1.22.5-20240722.5.linux-amd64.tar.gz'; \
 			sha256='59963327dc86e8a5f48d9485ed800c26f80b9975c9331736c33005947a02686f'; \
 			;; \
 		'armv7') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.22.5-20240702.3.linux-armv6l.tar.gz'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/254bc806f38765e6d02981f1481c4aa9/go1.22.5-20240722.5.linux-armv6l.tar.gz'; \
 			sha256='c641ce883b1967fb5df679ee652ebd2482dcbc14e528b36fea942ab69b4ca2f2'; \
 			;; \
 		'aarch64') \
-			url='https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.22.5-20240702.3.linux-arm64.tar.gz'; \
+			url='https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/eeb1608811d4a63e40bdf4cbb0a5d76f/go1.22.5-20240722.5.linux-arm64.tar.gz'; \
 			sha256='92078bdb0a2cbe1a5c175b3046427eca30f137b57106157d0696099254bbe03d'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \

--- a/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.22/cbl-mariner2.0/Dockerfile
@@ -13,6 +13,9 @@ RUN set -eux; \
 	tdnf install -y \
 		tar \
 		wget \
+		# To reduce image size, the Azure Linux (aka CBL-Mariner) image doesn't include full ca-certificates: https://github.com/microsoft/azurelinux/issues/3563
+		# We need ca-certificates here to verify https://download.visualstudio.microsoft.com.
+		ca-certificates \
 	; \
 	tdnf clean all
 

--- a/src/microsoft/1.22/fips/bookworm/Dockerfile
+++ b/src/microsoft/1.22/fips/bookworm/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.22.5-1-bookworm
+ARG FROM_TAG=1.22.5-2-bookworm
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/1.22/fips/bullseye/Dockerfile
+++ b/src/microsoft/1.22/fips/bullseye/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.22.5-1-bullseye
+ARG FROM_TAG=1.22.5-2-bullseye
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/1.22/fips/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.22/fips/cbl-mariner2.0/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.22.5-1-cbl-mariner2.0
+ARG FROM_TAG=1.22.5-2-cbl-mariner2.0
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/1.22/windows/fips/nanoserver-1809/Dockerfile
+++ b/src/microsoft/1.22/windows/fips/nanoserver-1809/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.22.5-1-nanoserver-1809
+ARG FROM_TAG=1.22.5-2-nanoserver-1809
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/1.22/windows/fips/nanoserver-ltsc2022/Dockerfile
+++ b/src/microsoft/1.22/windows/fips/nanoserver-ltsc2022/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.22.5-1-nanoserver-ltsc2022
+ARG FROM_TAG=1.22.5-2-nanoserver-ltsc2022
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/1.22/windows/fips/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.22/windows/fips/windowsservercore-1809/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.22.5-1-windowsservercore-1809
+ARG FROM_TAG=1.22.5-2-windowsservercore-1809
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/1.22/windows/fips/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.22/windows/fips/windowsservercore-ltsc2022/Dockerfile
@@ -11,7 +11,7 @@
 # build tools. If they build the non-FIPS images with the obvious tags, this "from" should line up.
 # The .NET Docker build infrastructure replaces the ARGs with arch-specific values, etc.
 ARG REPO=mcr.microsoft.com/oss/go/microsoft/golang
-ARG FROM_TAG=1.22.5-1-windowsservercore-ltsc2022
+ARG FROM_TAG=1.22.5-2-windowsservercore-ltsc2022
 
 FROM $REPO:$FROM_TAG
 

--- a/src/microsoft/1.22/windows/windowsservercore-1809/Dockerfile
+++ b/src/microsoft/1.22/windows/windowsservercore-1809/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.22.5
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.22.5-20240702.3.windows-amd64.zip'; \
+RUN $url = 'https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/2d8f121a1e9df25420d7f0b4bd70c80a/go1.22.5-20240722.5.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '8310ad1878f1420c36a67145e26ac3163c8be65fd93e61b09eca5544a21120d5'; \
+	$sha256 = 'd7b897d0c594e9a0cdc115353c337f10090bcf716138b50cee99aaa84143688d'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/1.22/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/src/microsoft/1.22/windows/windowsservercore-ltsc2022/Dockerfile
@@ -55,12 +55,12 @@ RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH)
 
 ENV GOLANG_VERSION 1.22.5
 
-RUN $url = 'https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.22.5-20240702.3.windows-amd64.zip'; \
+RUN $url = 'https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/2d8f121a1e9df25420d7f0b4bd70c80a/go1.22.5-20240722.5.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '8310ad1878f1420c36a67145e26ac3163c8be65fd93e61b09eca5544a21120d5'; \
+	$sha256 = 'd7b897d0c594e9a0cdc115353c337f10090bcf716138b50cee99aaa84143688d'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -6,9 +6,11 @@
           "GOARCH": "amd64",
           "GOOS": "linux"
         },
-        "sha256": "862046055d51670fc98fbb628da78d7ed7b18b48d8309fe972489607d9de3097",
+        "sha256": "27a475b059bf9e2ea1219870ae66eb573fdc5cb4e01dd04cf5140697814be17c",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.21/20240702.5/go.20240702.5.linux-amd64.tar.gz"
+        "url": "https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/1a10f1be2fafa3bb318623c216537366/go.20240722.4.linux-amd64.tar.gz",
+        "sha256ChecksumUrl": "https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/50e91b1dd2187e209f35a1518fef0abb/go.20240722.4.linux-amd64.tar.gz.sha256",
+        "pgpSignatureUrl": "https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/efd9985d571f6ddf080a8695a7bdb986/go.20240722.4.linux-amd64.tar.gz.sig"
       },
       "arm32v7": {
         "env": {
@@ -16,27 +18,32 @@
           "GOARM": "7",
           "GOOS": "linux"
         },
-        "sha256": "eefc663af731b747510d56b33839042662c2bb24931321b0a560f69416dbb7a3",
+        "sha256": "4b6a53719c5dbb0f2eb455d020d4c3b79a96d412a9daeb3deadcc7fdcbd7654f",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.21/20240702.5/go.20240702.5.linux-armv6l.tar.gz"
+        "url": "https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/c6b56416f39cd09981545ead8ccfe750/go.20240722.4.linux-armv6l.tar.gz",
+        "sha256ChecksumUrl": "https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/84799663d52835f66de0d5215d5a9b96/go.20240722.4.linux-armv6l.tar.gz.sha256",
+        "pgpSignatureUrl": "https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/9d215a7b9da33c7d5f23b0994743f2c7/go.20240722.4.linux-armv6l.tar.gz.sig"
       },
       "arm64v8": {
         "env": {
           "GOARCH": "arm64",
           "GOOS": "linux"
         },
-        "sha256": "98e601f53085a6f61d2d7a1537a948ae4664b860cb9f33f48926e586b87fc98a",
+        "sha256": "fc8a1aee9c8d01b5d4da85c9b4e47ef65e2bcfedb50a562c86d2c2b0a0d5cd06",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.21/20240702.5/go.20240702.5.linux-arm64.tar.gz"
+        "url": "https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/5dd42460468455ff40378d326789a67b/go.20240722.4.linux-arm64.tar.gz",
+        "sha256ChecksumUrl": "https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/7179078971757c5ada4d209dea9daaf3/go.20240722.4.linux-arm64.tar.gz.sha256",
+        "pgpSignatureUrl": "https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/41c3b010c79117429cc3a0ed5d39ba09/go.20240722.4.linux-arm64.tar.gz.sig"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "f1f875ec7f483133b488c5e6b6a7a980496b7d5b7de1fedea4aec8e247d2a1ea",
+        "sha256": "419696dbcbfd6ebf6b0b1aa0806e92dc1a959577715e210477486d7c1e89a622",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.21/20240702.5/go.20240702.5.windows-amd64.zip"
+        "url": "https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/e0bc30786c4b74b786c97a06f3805edd/go.20240722.4.windows-amd64.zip",
+        "sha256ChecksumUrl": "https://download.visualstudio.microsoft.com/download/pr/d7c607b1-7efc-4a9b-86d8-45ea8f1479e2/74fd8adc531605397760924b604285d4/go.20240722.4.windows-amd64.zip.sha256"
       }
     },
     "variants": [
@@ -56,7 +63,7 @@
       "windows/fips/nanoserver-1809"
     ],
     "version": "1.21.12",
-    "revision": "1",
+    "revision": "2",
     "preferredMajor": true,
     "preferredMinor": true,
     "preferredVariant": "bookworm"

--- a/src/microsoft/versions.json
+++ b/src/microsoft/versions.json
@@ -77,7 +77,9 @@
         },
         "sha256": "59963327dc86e8a5f48d9485ed800c26f80b9975c9331736c33005947a02686f",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.22.5-20240702.3.linux-amd64.tar.gz"
+        "url": "https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/06dceb5a69d1318939c8c466d496dbe0/go1.22.5-20240722.5.linux-amd64.tar.gz",
+        "sha256ChecksumUrl": "https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/5e780ca943b51662aa6d9d911ca060de/go1.22.5-20240722.5.linux-amd64.tar.gz.sha256",
+        "pgpSignatureUrl": "https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/b9bcf92dc4f4b09cb6a3a0ed6a7c4518/go1.22.5-20240722.5.linux-amd64.tar.gz.sig"
       },
       "arm32v7": {
         "env": {
@@ -87,7 +89,9 @@
         },
         "sha256": "c641ce883b1967fb5df679ee652ebd2482dcbc14e528b36fea942ab69b4ca2f2",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.22.5-20240702.3.linux-armv6l.tar.gz"
+        "url": "https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/254bc806f38765e6d02981f1481c4aa9/go1.22.5-20240722.5.linux-armv6l.tar.gz",
+        "sha256ChecksumUrl": "https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/56ab130d85250e9b8c7d0b837367e2a6/go1.22.5-20240722.5.linux-armv6l.tar.gz.sha256",
+        "pgpSignatureUrl": "https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/f04f32de31cc766d213daf0862587a85/go1.22.5-20240722.5.linux-armv6l.tar.gz.sig"
       },
       "arm64v8": {
         "env": {
@@ -96,16 +100,19 @@
         },
         "sha256": "92078bdb0a2cbe1a5c175b3046427eca30f137b57106157d0696099254bbe03d",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.22.5-20240702.3.linux-arm64.tar.gz"
+        "url": "https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/eeb1608811d4a63e40bdf4cbb0a5d76f/go1.22.5-20240722.5.linux-arm64.tar.gz",
+        "sha256ChecksumUrl": "https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/366ce5e12081a46eda61aa4edd6f05f7/go1.22.5-20240722.5.linux-arm64.tar.gz.sha256",
+        "pgpSignatureUrl": "https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/c3a5cebb631b73f51eb97dd320afb9a5/go1.22.5-20240722.5.linux-arm64.tar.gz.sig"
       },
       "windows-amd64": {
         "env": {
           "GOARCH": "amd64",
           "GOOS": "windows"
         },
-        "sha256": "8310ad1878f1420c36a67145e26ac3163c8be65fd93e61b09eca5544a21120d5",
+        "sha256": "d7b897d0c594e9a0cdc115353c337f10090bcf716138b50cee99aaa84143688d",
         "supported": true,
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.22.5-20240702.3.windows-amd64.zip"
+        "url": "https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/2d8f121a1e9df25420d7f0b4bd70c80a/go1.22.5-20240722.5.windows-amd64.zip",
+        "sha256ChecksumUrl": "https://download.visualstudio.microsoft.com/download/pr/724b7dab-d078-4dec-91e1-1bd0b44ef633/929a46e9d64175544c0e0f6973d9480a/go1.22.5-20240722.5.windows-amd64.zip.sha256"
       }
     },
     "variants": [
@@ -125,7 +132,7 @@
       "windows/fips/nanoserver-1809"
     ],
     "version": "1.22.5",
-    "revision": "1",
+    "revision": "2",
     "preferredVariant": "bookworm"
   }
 }


### PR DESCRIPTION
* https://github.com/microsoft/go-images/pull/325 failed because adding `.sig` to the end of a `.tar.gz` file doesn't work after the move to the CDN. This PR applies fixes on top of the update commits by using the direct URL to the `.sig` files instead.

I'm not bothering to make this backward compatible (support versions.json files without `pgpSignatureUrl`) because we will be publishing to the CDN from now on.