### PR TITLE
Fix scheduled trigger and document tag rebuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ For more information about building FIPS-compatible Go apps with the Microsoft G
 
 GitHub issues for microsoft/go-images are maintained in the [microsoft/go](https://github.com/microsoft/go) project. For help and questions about the Microsoft Go images, please [file an issue in microsoft/go](https://github.com/microsoft/go/issues/new/choose).
 
+The supported tags in this repository are rebuilt approximately twice a week to update base image and distro package dependencies.
+
 ## Recommended tags
 
 In general, the microsoft/go-images tag names match those available for the official images. To switch from the official image to one on MCR, it may be possible to simply prepend `mcr.microsoft.com/oss/go/microsoft/` to the official image you would normally use.

--- a/eng/pipeline/go-docker-pr-pipeline.yml
+++ b/eng/pipeline/go-docker-pr-pipeline.yml
@@ -3,13 +3,6 @@ pr:
   branches:
     include:
       - microsoft/main
-schedules:
-  - cron: '0 10 * * Mon,Wed'
-    displayName: Periodic build to refresh dependencies
-    branches:
-      include:
-        - microsoft/main
-    always: true
 
 variables:
   - template: variables/common.yml

--- a/eng/pipeline/go-docker-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline.yml
@@ -1,5 +1,12 @@
 trigger: none
 pr: none
+schedules:
+  - cron: '0 10 * * Mon,Wed'
+    displayName: Periodic build to refresh dependencies
+    branches:
+      include:
+        - microsoft/main
+    always: true
 
 variables:
   - template: variables/common.yml


### PR DESCRIPTION
This PR documents that our tags are rebuilt periodically and fixes the automatic trigger so it will happen reliably.