### PR TITLE
Update .NET Docker tools

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -88,16 +88,21 @@ jobs:
     condition: eq(variables.imageBuilderBuildArgs, '')
     displayName: Initialize Image Builder Build Args
   - powershell: |
+      New-Item -Path $(imageInfoHostDir) -ItemType Directory -Force
+
       # Reference the existing imageBuilderBuildArgs variable as an environment variable rather than injecting it directly
       # with the $(imageBuilderBuildArgs) syntax. This is to avoid issues where the string may contain single quotes $ chars
       # which really mess up assigning to a variable. It would require assigning the string with single quotes but also needing
       # to escape the single quotes that are in the string which would need to be done outside the context of PowerShell. Since
       # all we need is for that value to be in a PowerShell variable, we can get that by the fact that AzDO automatically creates
       # the environment variable for us.
-      New-Item -Path $(imageInfoHostDir) -ItemType Directory -Force
       $imageBuilderBuildArgs = "$env:IMAGEBUILDERBUILDARGS $(imageBuilder.queueArgs) --image-info-output-path $(imageInfoContainerDir)/$(legName)-image-info.json"
       if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.internalProjectName }}" -and $env:BUILD_REASON -ne "PullRequest") {
-        $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push"
+        $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr-staging.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push"
+      }
+
+      if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.publicProjectName }}" -and ${env:PUBLIC-MIRROR_SERVER} -ne "") {
+        $imageBuilderBuildArgs = "$imageBuilderBuildArgs --base-override-regex '^(?!mcr\.microsoft\.com)' --base-override-sub '$(public-mirror.server)/'"
       }
 
       # If the pipeline isn't configured to disable the cache and a build variable hasn't been set to disable the cache
@@ -105,13 +110,14 @@ jobs:
         $imageBuilderBuildArgs = "$imageBuilderBuildArgs --image-info-source-path $(versionsBasePath)$(imageInfoVersionsPath)"
       }
 
+      echo "imageBuilderBuildArgs: $imageBuilderBuildArgs"
       echo "##vso[task.setvariable variable=imageBuilderBuildArgs]$imageBuilderBuildArgs"
     displayName: Set Image Builder Build Args
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
       name: BuildImages
       displayName: Build Images
-      serviceConnection: $(acr.serviceConnectionName)
+      serviceConnection: $(build.serviceConnectionName)
       internalProjectName: ${{ parameters.internalProjectName }}
       dockerClientOS: ${{ parameters.dockerClientOS }}
       args: >
@@ -124,8 +130,8 @@ jobs:
         --retry
         --source-repo $(publicGitRepoUri)
         --digests-out-var 'builtImages'
-        --acr-subscription '$(acr.subscription)'
-        --acr-resource-group '$(acr.resourceGroup)'
+        --acr-subscription '$(acr-staging.subscription)'
+        --acr-resource-group '$(acr-staging.resourceGroup)'
         $(manifestVariables)
         $(imageBuilderBuildArgs)
   - template: /eng/common/templates/steps/publish-artifact.yml@self
@@ -172,7 +178,7 @@ jobs:
         # Manifest tool docs: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/custom-sbom-generation-workflows
         $images -Split ',' | ForEach-Object {
           echo "Generating SBOM for $_";
-          $formattedImageName = $_.Replace('$(acr.server)/$(stagingRepoPrefix)', "").Replace('/', '_').Replace(':', '_');
+          $formattedImageName = $_.Replace('$(acr-staging.server)/$(stagingRepoPrefix)', "").Replace('/', '_').Replace(':', '_');
           $sbomChildDir = "$(sbomDirectory)/$formattedImageName";
           New-Item -Type Directory -Path $sbomChildDir > $null;
           & $dotnetPath "$manifestToolDllPath" `

--- a/eng/common/templates/jobs/copy-base-images-staging.yml
+++ b/eng/common/templates/jobs/copy-base-images-staging.yml
@@ -1,0 +1,30 @@
+parameters:
+- name: name
+  type: string
+  default: null
+- name: pool
+  type: object
+  default: {}
+- name: customInitSteps
+  type: stepList
+  default: []
+- name: additionalOptions
+  type: string
+  default: ''
+- name: continueOnError
+  type: string
+  default: false
+
+jobs:
+- template: /eng/common/templates/jobs/copy-base-images.yml@self
+  parameters:
+    name: ${{ parameters.name }}
+    pool: ${{ parameters.pool }}
+    customInitSteps: ${{ parameters.customInitSteps }}
+    additionalOptions: ${{ parameters.additionalOptions }}
+    acr:
+      server: $(acr-staging.server)
+      serviceConnection: $(internal-mirror.serviceConnectionName)
+      subscription: $(acr-staging.subscription)
+      resourceGroup: $(acr-staging.resourceGroup)
+    repoPrefix: $(mirrorRepoPrefix)

--- a/eng/common/templates/jobs/copy-base-images.yml
+++ b/eng/common/templates/jobs/copy-base-images.yml
@@ -1,10 +1,28 @@
 parameters:
-  name: null
-  pool: {}
-  additionalOptions: null
-  publicProjectName: null
-  internalProjectName: null
-  customInitSteps: []
+- name: name
+  type: string
+  default: null
+- name: pool
+  type: object
+  default: {}
+- name: acr
+  type: object
+  default: null
+- name: repoPrefix
+  type: string
+  default: null
+- name: customInitSteps
+  type: stepList
+  default: []
+- name: additionalOptions
+  type: string
+  default: ''
+- name: continueOnError
+  type: string
+  default: false
+- name: forceDryRun
+  type: boolean
+  default: false
 
 jobs:
 - job: ${{ parameters.name }}
@@ -14,7 +32,8 @@ jobs:
   - ${{ parameters.customInitSteps }}
   - template: /eng/common/templates/steps/copy-base-images.yml@self
     parameters:
+      acr: ${{ parameters.acr }} 
+      repoPrefix: ${{ parameters.repoPrefix }}
       additionalOptions: ${{ parameters.additionalOptions }}
-      publicProjectName: ${{ parameters.publicProjectName }}
-      internalProjectName: ${{ parameters.internalProjectName }}
-      continueOnError: true
+      continueOnError: ${{ parameters.continueOnError }}
+      forceDryRun: ${{ parameters.forceDryRun }}

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -47,17 +47,6 @@ jobs:
     parameters:
       publicSourceBranch: $(publicSourceBranch)
   - template: /eng/common/templates/steps/set-dry-run.yml@self
-  - powershell: |
-      New-Item -ItemType Directory -Path $(sourceBuildIdOutputDir)
-      Set-Content -Path $(sourceBuildIdOutputDir)/source-build-id.txt -Value $(sourceBuildId)
-    displayName: Write Source Build ID to File
-  - template: /eng/common/templates/steps/publish-artifact.yml@self
-    parameters:
-      path: $(sourceBuildIdOutputDir)
-      artifactName: source-build-id
-      displayName: Publish Source Build ID Artifact
-      internalProjectName: ${{ parameters.internalProjectName }}
-      publicProjectName: ${{ parameters.publicProjectName }}
   - script: echo "##vso[task.setvariable variable=imageQueueTime]$(date --rfc-2822)"
     displayName: Set Publish Variables
   - script: >
@@ -67,13 +56,14 @@ jobs:
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
       displayName: Copy Images
-      serviceConnection: $(acr.serviceConnectionName)
+      serviceConnection: $(publish.serviceConnectionName)
       internalProjectName: ${{ parameters.internalProjectName }}
       args: >
         copyAcrImages
         '$(acr.subscription)'
         '$(acr.resourceGroup)'
         '$(stagingRepoPrefix)'
+        '$(acr-staging.server)'
         --os-type '*'
         --architecture '*'
         --repo-prefix '$(publishRepoPrefix)'
@@ -84,7 +74,7 @@ jobs:
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
       displayName: Publish Manifest
-      serviceConnection: $(acr.serviceConnectionName)
+      serviceConnection: $(publish.serviceConnectionName)
       internalProjectName: ${{ parameters.internalProjectName }}
       dockerClientOS: ${{ parameters.dockerClientOS }}
       args: >
@@ -130,8 +120,7 @@ jobs:
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
       displayName: Ingest Kusto Image Info
-      # Upstream edit: https://github.com/microsoft/go-lab/issues/78 Remove unused service connection that would be unconditionally checked for validity even though this task never runs in go-images.
-      # serviceConnection: $(kusto.serviceConnectionName)
+      serviceConnection: $(kusto.serviceConnectionName)
       internalProjectName: ${{ parameters.internalProjectName }}
       condition: and(succeeded(), eq(variables['ingestKustoImageInfo'], 'true'))
       args: >
@@ -169,3 +158,15 @@ jobs:
       $(imageBuilder.commonCmdArgs)
     displayName: Post Publish Notification
     condition: and(always(), eq(variables['publishNotificationsEnabled'], 'true'))
+  - powershell: |
+      New-Item -ItemType Directory -Path $(sourceBuildIdOutputDir)
+      Set-Content -Path $(sourceBuildIdOutputDir)/source-build-id.txt -Value $(sourceBuildId)
+    condition: succeeded()
+    displayName: Write Source Build ID to File
+  - template: /eng/common/templates/steps/publish-artifact.yml@self
+    parameters:
+      path: $(sourceBuildIdOutputDir)
+      artifactName: source-build-id
+      displayName: Publish Source Build ID Artifact
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -64,13 +64,11 @@ stages:
             echo "##vso[task.setvariable variable=osVersions]"
             echo "##vso[task.setvariable variable=architecture]"
           displayName: Initialize Test Variables
-  - template: /eng/common/templates/jobs/copy-base-images.yml@self
+  - template: /eng/common/templates/jobs/copy-base-images-staging.yml@self
     parameters:
       name: CopyBaseImages
       pool: ${{ parameters.linuxAmd64Pool }}
       additionalOptions: "--manifest '$(manifest)' $(imageBuilder.pathArgs) $(manifestVariables)"
-      publicProjectName: ${{ parameters.publicProjectName }}
-      internalProjectName: ${{ parameters.internalProjectName }}
       customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps }}
   - template: /eng/common/templates/jobs/generate-matrix.yml@self
     parameters:

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -14,6 +14,7 @@ parameters:
   windowsAmdBuildJobTimeout: 60
   windowsAmdTestJobTimeout: 60
   linuxAmdBuildJobTimeout: 60
+  linuxArmBuildJobTimeout: 60
   linuxAmd64Pool: ""
   buildMatrixType: platformDependencyGraph
   testMatrixType: platformVersionedOs
@@ -51,6 +52,7 @@ stages:
     windowsAmdBuildJobTimeout: ${{ parameters.windowsAmdBuildJobTimeout }}
     windowsAmdTestJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
     linuxAmdBuildJobTimeout: ${{ parameters.linuxAmdBuildJobTimeout }}
+    linuxArmBuildJobTimeout: ${{ parameters.linuxArmBuildJobTimeout }}
     buildMatrixType: ${{ parameters.buildMatrixType }}
     testMatrixType: ${{ parameters.testMatrixType }}
 

--- a/eng/common/templates/steps/annotate-eol-digests.yml
+++ b/eng/common/templates/steps/annotate-eol-digests.yml
@@ -1,0 +1,23 @@
+parameters:
+  internalProjectName: null
+  force: false
+  dataFile: null
+steps:
+  - script: |
+      optionalArgs=""
+      if [ "${{ lower(parameters.force) }}" == "true" ]; then
+        optionalArgs="$optionalArgs --force"
+      fi
+      echo "##vso[task.setvariable variable=optionalArgs]$optionalArgs"
+    displayName: Set Optional Args
+  - template: /eng/common/templates/steps/run-imagebuilder.yml@self
+    parameters:
+      name: AnnotateEOLImages
+      displayName: Annotate EOL Images
+      serviceConnection: $(publish.serviceConnectionName)
+      internalProjectName: ${{ parameters.internalProjectName }}
+      args: >
+        annotateEolDigests
+        /repo/${{ parameters.dataFile }}
+        $(acr.server)
+        $(optionalArgs)

--- a/eng/common/templates/steps/clean-acr-images.yml
+++ b/eng/common/templates/steps/clean-acr-images.yml
@@ -1,5 +1,8 @@
 parameters:
   repo: null
+  subscription: null
+  resourceGroup: null
+  acr: null
   action: null
   age: null
   customArgs: ""
@@ -8,14 +11,14 @@ steps:
   - template: /eng/common/templates/steps/run-imagebuilder.yml@self
     parameters:
       displayName: Clean ACR Images - ${{ parameters.repo }}
-      serviceConnection: $(acr.serviceConnectionName)
+      serviceConnection: $(clean.serviceConnectionName)
       internalProjectName: ${{ parameters.internalProjectName }}
       args: >
         cleanAcrImages
         ${{ parameters.repo }}
-        $(acr.subscription)
-        $(acr.resourceGroup)
-        $(acr.server)
+        ${{ parameters.subscription }}
+        ${{ parameters.resourceGroup }}
+        ${{ parameters.acr }}
         --action ${{ parameters.action }}
         --age ${{ parameters.age }}
         ${{ parameters.customArgs }}

--- a/eng/common/templates/steps/copy-base-images.yml
+++ b/eng/common/templates/steps/copy-base-images.yml
@@ -1,29 +1,44 @@
 parameters:
-  additionalOptions: null
-  publicProjectName: null
-  internalProjectName: null
-  continueOnError: false
+- name: acr
+  type: object
+  default:
+    server: ""
+    serviceConnection: ""
+    subscription: ""
+    resourceGroup: ""
+- name: repoPrefix
+  type: string
+  default: null
+- name: additionalOptions
+  type: string
+  default: ""
+- name: continueOnError
+  type: string
+  default: false
+- name: forceDryRun
+  type: boolean
+  default: false
 
 steps:
-- ${{ if or(eq(variables['System.TeamProject'], parameters.publicProjectName), eq(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: /eng/common/templates/steps/set-dry-run.yml@self
+- ${{ if or(eq(parameters.forceDryRun, true), eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+  - script: echo "##vso[task.setvariable variable=dryRunArg]--dry-run"
 - template: /eng/common/templates/steps/run-imagebuilder.yml@self
   parameters:
     displayName: Copy Base Images
-    serviceConnection: $(acr.serviceConnectionName)
+    serviceConnection: ${{ parameters.acr.serviceConnection }}
     continueOnError: ${{ parameters.continueOnError }}
-    internalProjectName: ${{ parameters.internalProjectName }}
+    internalProjectName: 'internal'
     # Use environment variable to reference $(dryRunArg). Since $(dryRunArg) might be undefined,
     # PowerShell will treat the Azure Pipelines variable macro syntax as a command and throw an
     # error
     args: >
       copyBaseImages
-      '$(acr.subscription)'
-      '$(acr.resourceGroup)'
+      '${{ parameters.acr.subscription }}'
+      '${{ parameters.acr.resourceGroup }}'
       $(dockerHubRegistryCreds)
       $(customCopyBaseImagesArgs)
-      --repo-prefix $(mirrorRepoPrefix)
-      --registry-override '$(acr.server)'
+      --repo-prefix '${{ parameters.repoPrefix }}'
+      --registry-override '${{ parameters.acr.server }}'
       --os-type 'linux'
       --architecture '*'
       $env:DRYRUNARG

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -22,7 +22,7 @@ steps:
       optionalTestArgs="$optionalTestArgs -TestCategories pre-build"
     else
       if [ "${{ variables['System.TeamProject'] }}" == "${{ parameters.internalProjectName }}" ] && [ "${{ variables['Build.Reason'] }}" != "PullRequest" ]; then
-        optionalTestArgs="$optionalTestArgs -PullImages -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info.json"
+        optionalTestArgs="$optionalTestArgs -PullImages -Registry $(acr-staging.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info.json"
       fi
       if [ "$REPOTESTARGS" != "" ]; then
         optionalTestArgs="$optionalTestArgs $REPOTESTARGS"
@@ -45,13 +45,13 @@ steps:
   - template: /eng/common/templates/steps/run-pwsh-with-auth.yml@self
     parameters:
       displayName: Docker login
-      serviceConnection: $(acr.serviceConnectionName)
+      serviceConnection: $(test.serviceConnectionName)
       condition: and(succeeded(), ${{ parameters.condition }})
       command: >
         $azLoginArgs = '--service-principal --tenant $env:AZURE_TENANT_ID -u $env:AZURE_CLIENT_ID --federated-token $env:AZURE_FEDERATED_TOKEN';
         docker exec -e AZURE_TENANT_ID=$env:tenantId -e AZURE_CLIENT_ID=$env:servicePrincipalId -e AZURE_FEDERATED_TOKEN=$env:idToken $(testRunner.container) pwsh
         -File $(engCommonRelativePath)/Invoke-WithRetry.ps1
-        "az login $azLoginArgs; az acr login -n $(acr.server)"
+        "az login $azLoginArgs; az acr login -n $(acr-staging.server)"
   - ${{ if eq(parameters.preBuildValidation, 'false') }}:
     - template: /eng/common/templates/steps/download-build-artifact.yml@self
       parameters:
@@ -73,7 +73,7 @@ steps:
   displayName: Test Images
   condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - script: docker exec $(testRunner.container) docker logout $(acr.server)
+  - script: docker exec $(testRunner.container) docker logout $(acr-staging.server)
     displayName: Docker logout
     condition: and(always(), ${{ parameters.condition }})
     continueOnError: true

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -13,17 +13,17 @@ steps:
   - template: /eng/common/templates/steps/run-pwsh-with-auth.yml@self
     parameters:
       displayName: Docker login
-      serviceConnection: $(acr.serviceConnectionName)
+      serviceConnection: $(test.serviceConnectionName)
       dockerClientOS: windows
       condition: and(succeeded(), ${{ parameters.condition }})
       command: >
         az login --service-principal --tenant $env:tenantId -u $env:servicePrincipalId --federated-token $env:idToken;
-        $accessToken = $(az acr login -n $(acr.server) --expose-token --query accessToken --output tsv);
-        docker login $(acr.server) -u 00000000-0000-0000-0000-000000000000 -p $accessToken
+        $accessToken = $(az acr login -n $(acr-staging.server) --expose-token --query accessToken --output tsv);
+        docker login $(acr-staging.server) -u 00000000-0000-0000-0000-000000000000 -p $accessToken
 - ${{ parameters.customInitSteps }}
 - powershell: |
     if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}" -and "${{ variables['Build.Reason'] }}" -ne "PullRequest") {
-      $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
+      $optionalTestArgs="$optionalTestArgs -PullImages -Registry ${env:ACR-STAGING_SERVER} -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
     }
     if ($env:REPOTESTARGS) {
       $optionalTestArgs += " $env:REPOTESTARGS"
@@ -50,7 +50,7 @@ steps:
   displayName: Test Images
   condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - script: docker logout $(acr.server)
+  - script: docker logout $(acr-staging.server)
     displayName: Docker logout
     condition: and(always(), ${{ parameters.condition }})
     continueOnError: true

--- a/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml
@@ -8,8 +8,7 @@ steps:
   parameters:
     displayName: Wait for MCR Doc Ingestion
     condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))
-    # Upstream edit: https://github.com/microsoft/go-lab/issues/78 Remove unused service connection that would be unconditionally checked for validity even though this task never runs in go-images.
-    # serviceConnection: $(marStatus.serviceConnectionName)
+    serviceConnection: $(marStatus.serviceConnectionName)
     internalProjectName: 'internal'
     args: >
       waitForMcrDocIngestion

--- a/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
+++ b/eng/common/templates/steps/wait-for-mcr-image-ingestion.yml
@@ -9,8 +9,7 @@ steps:
   parameters:
     displayName: Wait for Image Ingestion
     condition: and(${{ parameters.condition }}, eq(variables['waitForIngestionEnabled'], 'true'))
-    # Upstream edit: https://github.com/microsoft/go-lab/issues/78 Remove unused service connection that would be unconditionally checked for validity even though this task never runs in go-images.
-    # serviceConnection: $(marStatus.serviceConnectionName)
+    serviceConnection: $(marStatus.serviceConnectionName)
     internalProjectName: 'internal'
     args: >
       waitForMcrImageIngestion

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -32,8 +32,6 @@ variables:
 - name: officialBranches
   # comma-delimited list of branch names
   value: main
-- name: overrideOfficialBranchValidation
-  value: false
 - name: mirrorRepoPrefix
   value: 'mirror/'
 - name: cgBuildGrepArgs
@@ -61,7 +59,7 @@ variables:
 # Define these as placeholder values to allow string validation to succeed since we don't have the
 # variable group with the actual values in public builds. For internal builds, the variable group
 # will cause these values to be overridden with the real values.
-- name: acr.servicePrincipalTenant
-  value: 00000000-0000-0000-0000-000000000000
 - name: acr.subscription
+  value: 00000000-0000-0000-0000-000000000000
+- name: acr-staging.subscription
   value: 00000000-0000-0000-0000-000000000000

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2461919
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2499947
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner2.0-docker-testrunner

--- a/eng/common/templates/variables/dotnet/common.yml
+++ b/eng/common/templates/variables/dotnet/common.yml
@@ -7,6 +7,6 @@ variables:
 - name: dockerHubRegistryCreds
   value: --registry-creds 'docker.io=$(dotnetDockerHubBot.userName);$(BotAccount-dotnet-dockerhub-bot-PAT)'
 
+- group: DotNet-Docker-Common
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - group: DotNet-Docker-Common
   - group: DotNet-Docker-Secrets-WIF

--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -59,6 +59,14 @@ variables:
 - name: acr.servicePrincipalPassword
   value: $(GolangDockerBuild)
 
+# We don't use a different ACR for staging vs. non-staging images.
+- name: acr-staging.server
+  value: $(acr.server)
+# We don't host a public mirror. Note: an empty string is necessary so the
+# variable is defined and .NET Docker logic works.
+- name: public-mirror.server
+  value: ''
+
 - name: test.serviceConnectionName
   value: $(acr.serviceConnectionName)
 - name: internal-mirror.serviceConnectionName
@@ -71,8 +79,6 @@ variables:
   value: ''
 - name: kusto.serviceConnectionName
   value: ''
-- name: acr-staging.server
-  value: $(acr.server)
 
 # Configuration for publishing the image-info JSON file.
 - name: commonVersionsImageInfoPath

--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -59,6 +59,21 @@ variables:
 - name: acr.servicePrincipalPassword
   value: $(GolangDockerBuild)
 
+- name: test.serviceConnectionName
+  value: $(acr.serviceConnectionName)
+- name: internal-mirror.serviceConnectionName
+  value: $(acr.serviceConnectionName)
+- name: build.serviceConnectionName
+  value: $(acr.serviceConnectionName)
+- name: publish.serviceConnectionName
+  value: $(acr.serviceConnectionName)
+- name: marStatus.serviceConnectionName
+  value: ''
+- name: kusto.serviceConnectionName
+  value: ''
+- name: acr-staging.server
+  value: $(acr.server)
+
 # Configuration for publishing the image-info JSON file.
 - name: commonVersionsImageInfoPath
   value: build-info/microsoft/go-images


### PR DESCRIPTION
I ran an update to the .NET Docker tools last month, but when the test build was complete, I was busy with something else and didn't end up submitting this PR. Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2501083&view=results

There is no immediate need for this update in particular, but it gets us past a small break, so it's worth getting it in.

* The first commit is a simple checkout, no need to review.
* The second commit fills in new configuration variables that upstream uses to set up unique service connections for various parts of the infrastructure. For now, we (still) use one service connection. I've filed https://github.com/microsoft/go-lab/issues/97 to split it up.