### PR TITLE
Add Azure Linux 3.0 FIPS notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,13 @@ For Microsoft teams building containers, more guidance is available at [Containe
 See [What is `-fips`?](docs/tags.md#what-is--fips) for more details about the meaning of `fips` in a tag name.
 
 > [!IMPORTANT]
-> Our `1.22-fips-bullseye` (Debian) tag is capable of building a FIPS compliant Go app, but it contains a copy of OpenSSL that is **not** FIPS certified.
-> It is suitable for a `build` stage, but not for FIPS-compliant deployment.
+> Our `azurelinux3.0` tags can't be used to to run (deploy) a FIPS-compliant Go app.
+> See [https://aka.ms/azurelinux3 (internal Microsoft link)](https://aka.ms/azurelinux3) for current information about Azure Linux 3.0 and the implications for FIPS compliance.
+> (Last update: 2024-08-29.)
+
+> [!IMPORTANT]
+> Our `1.22-fips-bullseye` (Debian) tag and other Debian tags are capable of building a FIPS compliant Go app, but contain a copy of OpenSSL that is **not** FIPS certified.
+> These tags are suitable for a `build` stage, but not for FIPS-compliant deployment.
 
 ## Tag organization
 


### PR DESCRIPTION
Add a notice for Azure Linux 3.0 that directs people to the internal site. I don't know much is worth adding here about it for now, but I think it makes sense to include *something* in case our customers also didn't see the Azure Linux 3.0 announcement or the disclaimer yet.

* For https://github.com/microsoft/go-images/pull/337. This could be done as part of that PR, but technically the images won't be public until after the PR is built internally (which may take a while) so the reference to tags that don't exist yet would be confusing in the meantime.

Also, clarify that the note about Debian isn't just about `1.22-fips-bullseye` specifically.