### PR TITLE
Upgrade test runner to Azure Linux 3.0

### DIFF
--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -2,5 +2,5 @@ variables:
   imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2499947
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
-  imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner2.0-docker-testrunner
+  imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux3.0-docker-testrunner
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)


### PR DESCRIPTION
When doing an audit of which images were being used in mcr.microsoft.com/dotnet-buildtools/prereqs, I saw that this repo has the only remaining usage of the Mariner 2.0 test runner image. That will be EOL this summer anyway. Upgrading it to 3.0.