### PR TITLE
Extend Windows build timeout

### DIFF
--- a/eng/pipeline/stages/build-test-publish-repo.yml
+++ b/eng/pipeline/stages/build-test-publish-repo.yml
@@ -14,6 +14,10 @@ stages:
       customPublishInitSteps:
         - template: /eng/pipeline/steps/set-public-source-branch-var.yml@self
 
+      # Windows builds often take almost exactly 60 minutes, which is the default timeout.
+      # This causes flakiness. Extend the timeout for leeway.
+      windowsAmdBuildJobTimeout: 90 # minutes
+
       # Linux AMD64
       linuxAmd64Pool:
         ${{ if eq(variables['System.TeamProject'], parameters.extraParameters.publicProjectName) }}:


### PR DESCRIPTION
Attempt 1 of https://dev.azure.com/dnceng/internal/_build/results?buildId=2635932&view=results took almost exactly 1 hour. Both Windows 2022 legs timed out while finishing up 1ES PT work. Retry is in progress, but I don't have any reason to expect different results, so we may need this PR to unblock the release.

Test build, to make sure this change parses: https://dev.azure.com/dnceng/internal/_build/results?buildId=2636051&view=results