### PR TITLE
Disable image-info publish to fix auth failure

### DIFF
--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -29,7 +29,7 @@ variables:
   value: false
 # Publish image info to https://github.com/dotnet/versions/tree/main/build-info
 - name: publishImageInfo
-  value: true
+  value: false # true # Authentication stopped working ~2025-03-05. See https://github.com/microsoft/go-lab/issues/180
 # https://github.com/microsoft/go/issues/192 tracks enabling ingestKustoImageInfo.
 - name: ingestKustoImageInfo
   value: false


### PR DESCRIPTION
* Follow up: https://github.com/microsoft/go-lab/issues/180

Auth stopped working, and image-info publish is blocking the build. Disable it for now, we don't use it for anything critical (yet) and can run a build again to refresh it once we figure it out.

Example failure: https://dev.azure.com/dnceng/internal/_build/results?buildId=2655888&view=logs&j=739bb7ec-7296-5b40-7dff-ee3297bfdaa4&t=bf6a5b93-88b0-5310-04fe-dec22ee32d0e&l=1964