### PR TITLE
Switch to use microsoft-golang-bot for imageInfo publish

### DIFF
--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -49,7 +49,7 @@ variables:
     - group: go-docker-common
   - ${{ if eq(parameters.nightly, true) }}:
     - group: go-docker-common-nightly
-  - group: Dotnet-Docker-Secrets-WIF
+  - group: Microsoft-GoLang-bot
 
 - name: acr.password
   ${{ if eq(parameters.nightly, false) }}:
@@ -99,7 +99,7 @@ variables:
 - name: gitHubVersionsRepoInfo.path
   value: ${{ variables.commonVersionsImageInfoPath }}
 - name: gitHubVersionsRepoInfo.accessToken
-  value: $(BotAccount-dotnet-docker-bot-PAT)
+  value: $(BotAccount-microsoft-golang-bot-PAT)
 - name: gitHubVersionsRepoInfo.userName
   value: $(dotnetDockerBot.userName)
 - name: gitHubVersionsRepoInfo.email


### PR DESCRIPTION
* Fixes https://github.com/microsoft/go-lab/issues/180

~Trying this change out internally to test.~

~[Worked](https://dev.azure.com/dnceng/internal/_build/results?buildId=2656212&view=logs&j=739bb7ec-7296-5b40-7dff-ee3297bfdaa4&t=bf6a5b93-88b0-5310-04fe-dec22ee32d0e&l=1965) in that it created a commit in the target repo, *however* it didn't update the `main` branch pointer. (I would guess due to branch protection.) I think this is a good incremental step, and it seems like it might need on the GitHub side without any further change to our code.~

After the branch rule update, it [fully worked](https://dev.azure.com/dnceng/internal/_build/results?buildId=2656223&view=logs&j=739bb7ec-7296-5b40-7dff-ee3297bfdaa4&t=bf6a5b93-88b0-5310-04fe-dec22ee32d0e&l=1965).