### PR TITLE
Work around Component Governance false positives

### DIFF
--- a/eng/ci-tools/cg_tools.go
+++ b/eng/ci-tools/cg_tools.go
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build tools
+
+package ci_tools
+
+// Work around Go detector false positives: import dependencies just so that we can upgrade
+// them. See https://github.com/microsoft/component-detection/issues/1333
+
+import (
+	_ "github.com/golang-jwt/jwt/v5"
+)

--- a/eng/ci-tools/go.mod
+++ b/eng/ci-tools/go.mod
@@ -2,7 +2,10 @@ module ci-tools
 
 go 1.22.0
 
-require github.com/microsoft/go-infra v0.0.6
+require (
+	github.com/golang-jwt/jwt/v5 v5.2.2
+	github.com/microsoft/go-infra v0.0.6
+)
 
 require (
 	github.com/google/uuid v1.6.0 // indirect

--- a/eng/ci-tools/go.sum
+++ b/eng/ci-tools/go.sum
@@ -1,5 +1,7 @@
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
Apply usual workaround (no side effects) for:

* https://github.com/microsoft/component-detection/issues/1333

This will get our CG detections down to zero in s360 with minimal work by hand now and generating minimal ongoing work in the future.

* Similar: https://github.com/microsoft/go/pull/1623