### PR TITLE
remove @microsoft-golang-review-bot from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 # auto-merge flow without human intervention.
 /go
 /manifest.json
+/src/microsoft/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Require review from golang-compiler team for changes in any file. This keeps us in the loop on
 # auto-merge PRs. The review bot is also an owner so that it can still trigger auto-merge for sync
 # PRs on its own. We may remove this rule once auto-merges are routine.
-* @microsoft/golang-compiler @microsoft-golang-review-bot
+* @microsoft/golang-compiler
 
 # Automatically request review from golang-compiler team for changes in the Microsoft-specific
 # files. This takes precedence over earlier rules in the file.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-# Require review from golang-compiler team for changes in any file. This keeps us in the loop on
-# auto-merge PRs. The review bot is also an owner so that it can still trigger auto-merge for sync
-# PRs on its own. We may remove this rule once auto-merges are routine.
+# Require review from golang-compiler team for changes in all files.
+
 * @microsoft/golang-compiler
 
-# Automatically request review from golang-compiler team for changes in the Microsoft-specific
-# files. This takes precedence over earlier rules in the file.
-/eng/ @microsoft/golang-compiler
+# Don't assign a code owner to automatically updated files to allow GitHub apps to use the
+# auto-merge flow without human intervention.
+go/
+manifest.json

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 
 # Don't assign a code owner to automatically updated files to allow GitHub apps to use the
 # auto-merge flow without human intervention.
-go/
-manifest.json
+/go
+/manifest.json


### PR DESCRIPTION
We've switched to GitHub apps so this is no longer needed