### PR TITLE
Use app for image info update with custom eng/common

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -174,7 +174,7 @@ jobs:
       '$(imageInfoContainerDir)/full-image-info-new.json'
       '$(gitHubVersionsRepoInfo.userName)'
       '$(gitHubVersionsRepoInfo.email)'
-      '$(gitHubVersionsRepoInfo.accessToken)'
+      $(gitHubVersionsRepoInfo.authArgs)
       --git-owner '$(gitHubVersionsRepoInfo.org)'
       --git-repo '$(gitHubVersionsRepoInfo.repo)'
       --git-branch '$(gitHubVersionsRepoInfo.branch)'

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2660728
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2688810
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux3.0-docker-testrunner

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -38,8 +38,8 @@ variables:
   value: main
 - name: gitHubVersionsRepoInfo.path
   value: ${{ variables.commonVersionsImageInfoPath }}
-- name: gitHubVersionsRepoInfo.accessToken
-  value: $(BotAccount-dotnet-docker-bot-PAT)
+- name: gitHubVersionsRepoInfo.authArgs
+  value: --gh-token '$(BotAccount-dotnet-docker-bot-PAT)'
 - name: gitHubVersionsRepoInfo.userName
   value: $(dotnetDockerBot.userName)
 - name: gitHubVersionsRepoInfo.email

--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -98,12 +98,16 @@ variables:
   value: main
 - name: gitHubVersionsRepoInfo.path
   value: ${{ variables.commonVersionsImageInfoPath }}
-- name: gitHubVersionsRepoInfo.accessToken
-  value: $(BotAccount-microsoft-golang-bot-PAT)
+- name: gitHubVersionsRepoInfo.authArgs
+  value: >-
+    --gh-private-key '$(BotAccount-bot-for-go-private-key)'
+    --gh-app-client-id '$(BotAccount-bot-for-go-client-id)'
+    --gh-app-installation-id '$(BotAccount-bot-for-go-installation)'
 - name: gitHubVersionsRepoInfo.userName
-  value: $(dotnetDockerBot.userName)
+  value: bot-for-go[bot]
 - name: gitHubVersionsRepoInfo.email
-  value: $(dotnetDockerBot.email)
+  # App's user id: https://api.github.com/users/bot-for-go%5Bbot%5D
+  value: 199222863+$(gitHubVersionsRepoInfo.userName)@users.noreply.github.com
 
 # Pool/image configuration.
 # Copied from /eng/common/templates/variables/dotnet/common.yml


### PR DESCRIPTION
Update eng/common to get new app auth feature and modify args to pass it in.

After image-builder is updated to include the feature (C#-side) and https://github.com/dotnet/docker-tools/pull/1675 is merged for the YML, we can update back to a clean eng/common.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2689023&view=logs&j=739bb7ec-7296-5b40-7dff-ee3297bfdaa4&t=729bd3d3-63cd-5b66-6efd-ae98d0926964&l=177

* For https://github.com/microsoft/go-lab/issues/152