### PR TITLE
Add "which" package to Azure Linux images

### DIFF
--- a/patches/0002-Add-Azure-Linux-FIPS-package-upgrade.patch
+++ b/patches/0002-Add-Azure-Linux-FIPS-package-upgrade.patch
@@ -4,11 +4,11 @@ Date: Fri, 11 Feb 2022 18:07:18 -0600
 Subject: [PATCH] Add Azure Linux, FIPS, package upgrade
 
 ---
- Dockerfile-linux.template | 104 +++++++++++++++++++++++++++++++++++++-
- 1 file changed, 103 insertions(+), 1 deletion(-)
+ Dockerfile-linux.template | 105 +++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 104 insertions(+), 1 deletion(-)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index 19d45e2048b326..7bb576fc025c47 100644
+index 19d45e2048b326..e14bb6a6bf3344 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
 @@ -4,9 +4,40 @@
@@ -104,7 +104,7 @@ index 19d45e2048b326..7bb576fc025c47 100644
  	gpg --batch --verify go.tgz.asc go.tgz; \
  	gpgconf --kill all; \
  	rm -rf "$GNUPGHOME" go.tgz.asc; \
-@@ -216,18 +266,70 @@ RUN set -eux; \
+@@ -216,18 +266,71 @@ RUN set -eux; \
  FROM alpine:{{ alpine_version }}
  
  RUN apk add --no-cache ca-certificates
@@ -139,6 +139,7 @@ index 19d45e2048b326..7bb576fc025c47 100644
 +		make \
 +		shadow-utils \
 +		util-linux \
++		which \
 +{{
 +	if is_fips then (
 +-}}

--- a/src/microsoft/1.23/azurelinux3.0/Dockerfile
+++ b/src/microsoft/1.23/azurelinux3.0/Dockerfile
@@ -131,6 +131,7 @@ RUN set -eux; \
 		make \
 		shadow-utils \
 		util-linux \
+		which \
 	; \
 	tdnf clean all
 

--- a/src/microsoft/1.23/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.23/cbl-mariner2.0/Dockerfile
@@ -131,6 +131,7 @@ RUN set -eux; \
 		make \
 		shadow-utils \
 		util-linux \
+		which \
 	; \
 	tdnf clean all
 

--- a/src/microsoft/1.24/azurelinux3.0/Dockerfile
+++ b/src/microsoft/1.24/azurelinux3.0/Dockerfile
@@ -131,6 +131,7 @@ RUN set -eux; \
 		make \
 		shadow-utils \
 		util-linux \
+		which \
 	; \
 	tdnf clean all
 

--- a/src/microsoft/1.24/cbl-mariner2.0/Dockerfile
+++ b/src/microsoft/1.24/cbl-mariner2.0/Dockerfile
@@ -131,6 +131,7 @@ RUN set -eux; \
 		make \
 		shadow-utils \
 		util-linux \
+		which \
 	; \
 	tdnf clean all
 


### PR DESCRIPTION
* Also mentioned in https://github.com/microsoft/go/issues/1638

`which` is another tool that is present in ordinary Go images, but not our Azure Linux based images. (Both 2.0 and 3.0 this time.)