### PR TITLE
Update eng/common to dotnet/docker-tools@d7ad44f9af

### DIFF
--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -11,11 +11,16 @@ Install the .NET Core SDK at the specified path.
 .PARAMETER InstallPath
 The path where the .NET Core SDK is to be installed.
 
+.PARAMETER Channel
+The version of the .NET Core SDK to be installed.
+
 #>
 [cmdletbinding()]
 param(
     [string]
-    $InstallPath
+    $InstallPath,
+    [string]
+    $Channel = "9.0"
 )
 
 Set-StrictMode -Version Latest
@@ -40,7 +45,7 @@ if (!(Test-Path $DotnetInstallScriptPath)) {
     & "$PSScriptRoot/Invoke-WithRetry.ps1" "Invoke-WebRequest 'https://builds.dotnet.microsoft.com/dotnet/scripts/v1/$DotnetInstallScript' -OutFile $DotnetInstallScriptPath"
 }
 
-$DotnetChannel = "9.0"
+$DotnetChannel = $Channel
 
 $InstallFailed = $false
 if ($IsRunningOnUnix) {

--- a/eng/common/templates/jobs/cg-build-projects.yml
+++ b/eng/common/templates/jobs/cg-build-projects.yml
@@ -7,6 +7,11 @@ parameters:
   type: boolean
   default: false
   displayName: CG Dry Run
+# See https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options for possible Channel values
+- name: dotnetVersionChannel
+  type: string
+  default: '9.0'
+  displayName: .NET Version
 
 jobs:
 - job: BuildProjects
@@ -17,7 +22,7 @@ jobs:
     os: linux
   steps:
   - powershell: >
-      ./eng/common/Install-DotNetSdk.ps1 /usr/share/.dotnet
+      ./eng/common/Install-DotNetSdk.ps1 -Channel ${{ parameters.dotnetVersionChannel }} -InstallPath "/usr/share/.dotnet"
     displayName: Run Dotnet Install Script
   - script: >
       find . -name '*.csproj' | grep $(cgBuildGrepArgs) | xargs -n 1 /usr/share/.dotnet/dotnet build
@@ -29,7 +34,7 @@ jobs:
     - powershell: |
         Write-Host "##vso[build.updatebuildnumber]$env:BUILD_BUILDNUMBER (Dry run)"
         Write-Host "##vso[build.addbuildtag]dry-run"
-        
+
         if ("$(officialBranches)".Split(',').Contains("$(Build.SourceBranch)"))
         {
           Write-Host "##vso[task.logissue type=error]Cannot run a CG dry-run build from an official branch ($(officialBranches))."

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -192,7 +192,7 @@ jobs:
       '$(System.AccessToken)'
       '$(azdoOrgName)'
       '$(System.TeamProject)'
-      '$(gitHubNotificationsRepoInfo.accessToken)'
+      $(gitHubNotificationsRepoInfo.authArgs)
       '$(gitHubNotificationsRepoInfo.org)'
       '$(gitHubNotificationsRepoInfo.repo)'
       --repo-prefix '$(publishRepoPrefix)'

--- a/eng/common/templates/steps/publish-readmes.yml
+++ b/eng/common/templates/steps/publish-readmes.yml
@@ -9,7 +9,7 @@ steps:
     --registry-override '$(acr.server)'
     '$(mcrDocsRepoInfo.userName)'
     '$(mcrDocsRepoInfo.email)'
-    '$(mcrDocsRepoInfo.accessToken)'
+    $(mcrDocsRepoInfo.authArgs)
     '$(publicGitRepoUri)'
     ${{ parameters.dryRunArg }}
     $(manifestVariables)

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -14,8 +14,8 @@ variables:
 - name: officialRepoPrefixes
   value: public/,internal/private/,unlisted/
 
-- name: mcrDocsRepoInfo.accessToken
-  value: $(BotAccount-dotnet-docker-bot-PAT)
+- name: mcrDocsRepoInfo.authArgs
+  value: --gh-token '$(BotAccount-dotnet-docker-bot-PAT)'
 - name: mcrDocsRepoInfo.userName
   value: $(dotnetDockerBot.userName)
 - name: mcrDocsRepoInfo.email
@@ -27,8 +27,8 @@ variables:
   value: dotnet
 - name: gitHubNotificationsRepoInfo.repo
   value: dotnet-docker-internal
-- name: gitHubNotificationsRepoInfo.accessToken
-  value: $(BotAccount-dotnet-docker-bot-PAT)
+- name: gitHubNotificationsRepoInfo.authArgs
+  value: --gh-token '$(BotAccount-dotnet-docker-bot-PAT)'
 
 - name: gitHubVersionsRepoInfo.org
   value: dotnet


### PR DESCRIPTION
Reset eng/common to match latest .NET Docker tools now that it supports custom auth flags and specifies an updated version of image-builder.

* Cleans up https://github.com/microsoft/go-images/pull/393