### PR TITLE
Remove packages marked vulnerable

### DIFF
--- a/patches/0007-Remove-packages-marked-vulnerable.patch
+++ b/patches/0007-Remove-packages-marked-vulnerable.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Mon, 21 Jul 2025 08:39:31 -0700
+Subject: [PATCH] Remove packages marked vulnerable
+
+---
+ Dockerfile-linux.template | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
+index bfa9b58f6558b3..dbbf8dad9be147 100644
+--- a/Dockerfile-linux.template
++++ b/Dockerfile-linux.template
+@@ -40,6 +40,16 @@ RUN set -eux; \
+ 	tdnf clean all
+ {{ ) else ( -}}
+ FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:{{ env.variant }}-scm AS build
++
++# Remove optional packages that are marked as vulnerable and that don't have fixes available.
++# Then try to install up-to-date versions, so that if the distro makes them available in the future,
++# our next build will automatically include them.
++RUN set -eux; \
++	apt-get autoremove -y \
++		subversion \
++	; \
++	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
++	rm -rf /var/lib/apt/lists/*
+ {{ ) end -}}
+ 
+ ENV PATH /usr/local/go/bin:$PATH

--- a/src/microsoft/1.23/bookworm/Dockerfile
+++ b/src/microsoft/1.23/bookworm/Dockerfile
@@ -6,6 +6,16 @@
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm AS build
 
+# Remove optional packages that are marked as vulnerable and that don't have fixes available.
+# Then try to install up-to-date versions, so that if the distro makes them available in the future,
+# our next build will automatically include them.
+RUN set -eux; \
+	apt-get autoremove -y \
+		subversion \
+	; \
+	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+	rm -rf /var/lib/apt/lists/*
+
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.23.11

--- a/src/microsoft/1.23/bullseye/Dockerfile
+++ b/src/microsoft/1.23/bullseye/Dockerfile
@@ -6,6 +6,16 @@
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm AS build
 
+# Remove optional packages that are marked as vulnerable and that don't have fixes available.
+# Then try to install up-to-date versions, so that if the distro makes them available in the future,
+# our next build will automatically include them.
+RUN set -eux; \
+	apt-get autoremove -y \
+		subversion \
+	; \
+	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+	rm -rf /var/lib/apt/lists/*
+
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.23.11

--- a/src/microsoft/1.24/bookworm/Dockerfile
+++ b/src/microsoft/1.24/bookworm/Dockerfile
@@ -6,6 +6,16 @@
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm AS build
 
+# Remove optional packages that are marked as vulnerable and that don't have fixes available.
+# Then try to install up-to-date versions, so that if the distro makes them available in the future,
+# our next build will automatically include them.
+RUN set -eux; \
+	apt-get autoremove -y \
+		subversion \
+	; \
+	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+	rm -rf /var/lib/apt/lists/*
+
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.24.5

--- a/src/microsoft/1.24/bullseye/Dockerfile
+++ b/src/microsoft/1.24/bullseye/Dockerfile
@@ -6,6 +6,16 @@
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm AS build
 
+# Remove optional packages that are marked as vulnerable and that don't have fixes available.
+# Then try to install up-to-date versions, so that if the distro makes them available in the future,
+# our next build will automatically include them.
+RUN set -eux; \
+	apt-get autoremove -y \
+		subversion \
+	; \
+	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+	rm -rf /var/lib/apt/lists/*
+
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.24.5


### PR DESCRIPTION
Remove subversion and install `subversion (>= 1.14.5)`, effectively removing marked-as-vulnerable versions of the package.

* For https://github.com/microsoft/go-lab/issues/222

Example from CI:

```
#6 0.712 + apt-get satisfy -y subversion (>= 1.14.5)
#6 0.728 Reading package lists...
#6 0.741 Building dependency tree...
#6 0.744 Reading state information...
#6 0.750 Some packages could not be installed. This may mean that you have
#6 0.750 requested an impossible situation or if you are using the unstable
#6 0.750 distribution that some required packages have not yet been created
#6 0.750 or been moved out of Incoming.
#6 0.750 The following information may help to resolve the situation:
#6 0.750 
#6 0.751 The following packages have unmet dependencies:
#6 0.752  command line argument : Depends: subversion (>= 1.14.5) but it is not installable
#6 0.752 E: Unable to correct problems, you have held broken packages.
#6 0.754 + echo patched subversion not available
#6 0.756 patched subversion not available
```