### PR TITLE
Fix CODEOWNERS entry for /src/microsoft

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 # auto-merge flow without human intervention.
 /go
 /manifest.json
-/src/microsoft/
+/src/microsoft


### PR DESCRIPTION
Removes the traling slash as this seems to be not working correctly