### PR TITLE
increase timeout for Publish job and change patches author to bot

### DIFF
--- a/.git-go-patch
+++ b/.git-go-patch
@@ -1,0 +1,7 @@
+{
+  "MinimumToolVersion": "v1.0.1",
+  "SubmoduleDir": "go",
+  "PatchesDir": "patches",
+  "StatusFileDir": "eng/artifacts/go-patch",
+  "ExtractAsAuthor": "bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>"
+}

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -9,7 +9,7 @@ parameters:
 jobs:
 - job: Publish
   pool: ${{ parameters.pool }}
-  timeoutInMinutes: 90
+  timeoutInMinutes: 180
 
   variables:
   - name: imageBuilder.commonCmdArgs

--- a/patches/0001-Check-signature-of-microsoft-go-builds.patch
+++ b/patches/0001-Check-signature-of-microsoft-go-builds.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: microsoft-golang-bot <microsoft-golang-bot@users.noreply.github.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Fri, 11 Feb 2022 18:03:46 -0600
 Subject: [PATCH] Check signature of microsoft/go builds
 

--- a/patches/0002-Add-Azure-Linux-FIPS-package-upgrade.patch
+++ b/patches/0002-Add-Azure-Linux-FIPS-package-upgrade.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: microsoft-golang-bot <microsoft-golang-bot@users.noreply.github.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Fri, 11 Feb 2022 18:07:18 -0600
 Subject: [PATCH] Add Azure Linux, FIPS, package upgrade
 

--- a/patches/0003-Add-downloader-stage-to-Windows-Dockerfile.patch
+++ b/patches/0003-Add-downloader-stage-to-Windows-Dockerfile.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: microsoft-golang-bot <microsoft-golang-bot@users.noreply.github.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Fri, 11 Feb 2022 18:35:40 -0600
 Subject: [PATCH] Add "downloader" stage to Windows Dockerfile
 
@@ -17,7 +17,7 @@ reference later.
  1 file changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/Dockerfile-windows-nanoserver.template b/Dockerfile-windows-nanoserver.template
-index 6fd53f6..8e3ecb3 100644
+index 6fd53f64f59cbe..8e3ecb31d16ed8 100644
 --- a/Dockerfile-windows-nanoserver.template
 +++ b/Dockerfile-windows-nanoserver.template
 @@ -1,3 +1,9 @@

--- a/patches/0004-Add-support-for-fips-linux-and-fips-variants-in-micr.patch
+++ b/patches/0004-Add-support-for-fips-linux-and-fips-variants-in-micr.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: microsoft-golang-bot <microsoft-golang-bot@users.noreply.github.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Wed, 1 Jun 2022 12:03:45 -0500
 Subject: [PATCH] Add support for "fips-linux/*" and "fips/*" variants in
  microsoft/go-images

--- a/patches/0005-Use-MCR-mirror-for-buildpack-deps.patch
+++ b/patches/0005-Use-MCR-mirror-for-buildpack-deps.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: microsoft-golang-bot <microsoft-golang-bot@users.noreply.github.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Fri, 3 Jun 2022 12:26:05 -0500
 Subject: [PATCH] Use MCR mirror for buildpack-deps
 
@@ -8,10 +8,10 @@ Subject: [PATCH] Use MCR mirror for buildpack-deps
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index b8849cc2142d76..d71d53dde7565e 100644
+index e14bb6a6bf3344..0e18cc03ae5a63 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
-@@ -30,7 +30,7 @@ RUN set -eux; \
+@@ -39,7 +39,7 @@ RUN set -eux; \
  	; \
  	tdnf clean all
  {{ ) else ( -}}
@@ -20,7 +20,7 @@ index b8849cc2142d76..d71d53dde7565e 100644
  {{ ) end -}}
  
  ENV PATH /usr/local/go/bin:$PATH
-@@ -209,7 +209,7 @@ RUN set -eux; \
+@@ -310,7 +310,7 @@ RUN set -eux; \
  	tdnf clean all
  
  {{ ) else ( -}}

--- a/patches/0006-Remove-link-not-known-by-builder.patch
+++ b/patches/0006-Remove-link-not-known-by-builder.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Davis Goodin <dagood@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Thu, 4 Apr 2024 10:57:18 -0500
 Subject: [PATCH] Remove "--link" not known by builder
 
@@ -24,10 +24,10 @@ about the 1.21 tar.gz bug.
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index 9f0b6ae099a74e..9b8b5ec9eadf63 100644
+index 0e18cc03ae5a63..bfa9b58f6558b3 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
-@@ -182,8 +182,7 @@ RUN set -eux; \
+@@ -259,8 +259,7 @@ RUN set -eux; \
  	go version; \
  # make sure our reproducibile timestamp is probably still correct (best-effort inline reproducibility test)
  	epoch="$(stat -c '%Y' /target/usr/local/go)"; \
@@ -37,7 +37,7 @@ index 9f0b6ae099a74e..9b8b5ec9eadf63 100644
  
  {{ if is_alpine then ( -}}
  FROM alpine:{{ alpine_version }}
-@@ -265,6 +264,6 @@ ENV GOTOOLCHAIN=local
+@@ -346,6 +345,6 @@ ENV GOTOOLCHAIN=local
  ENV GOPATH /go
  ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
  # (see notes above about "COPY --link")

--- a/patches/0007-Remove-packages-marked-vulnerable.patch
+++ b/patches/0007-Remove-packages-marked-vulnerable.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Davis Goodin <dagood@microsoft.com>
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Mon, 21 Jul 2025 08:39:31 -0700
 Subject: [PATCH] Remove packages marked vulnerable
 


### PR DESCRIPTION
Resolves `##[error]The job running on agent NetCore1ESPool-Internal 28 ran longer than the maximum time of 90 minutes.`