### PR TITLE
remove subversion from prod image (not build image

### DIFF
--- a/patches/0007-Remove-packages-marked-vulnerable.patch
+++ b/patches/0007-Remove-packages-marked-vulnerable.patch
@@ -8,23 +8,23 @@ Subject: [PATCH] Remove packages marked vulnerable
  1 file changed, 10 insertions(+)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index bfa9b58f6558b3..dbbf8dad9be147 100644
+index bfa9b58f6558b3..f4a1f33dadb9e7 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
-@@ -40,6 +40,16 @@ RUN set -eux; \
- 	tdnf clean all
+@@ -311,6 +311,16 @@ RUN set -eux; \
  {{ ) else ( -}}
- FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:{{ env.variant }}-scm AS build
-+
-+# Remove optional packages that are marked as vulnerable and that don't have fixes available.
-+# Then try to install up-to-date versions, so that if the distro makes them available in the future,
-+# our next build will automatically include them.
-+RUN set -eux; \
-+	apt-get autoremove -y \
+ FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:{{ env.variant }}-scm
+
++ # Remove optional packages that are marked as vulnerable and that don't have fixes available.
++ # Then try to install up-to-date versions, so that if the distro makes them available in the future,
++ # our next build will automatically include them.
++ RUN set -eux; \
++ 	apt-get autoremove -y \
 +		subversion \
-+	; \
-+	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
-+	rm -rf /var/lib/apt/lists/*
- {{ ) end -}}
- 
- ENV PATH /usr/local/go/bin:$PATH
++ 	; \
++ 	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
++ 	rm -rf /var/lib/apt/lists/*
++
+ # install cgo-related dependencies
+ RUN set -eux; \
+ 	apt-get update; \

--- a/patches/0007-Remove-packages-marked-vulnerable.patch
+++ b/patches/0007-Remove-packages-marked-vulnerable.patch
@@ -8,22 +8,22 @@ Subject: [PATCH] Remove packages marked vulnerable
  1 file changed, 10 insertions(+)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index bfa9b58f6558b3..f4a1f33dadb9e7 100644
+index bfa9b58f6558b3..4e4af49fd94854 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
 @@ -311,6 +311,16 @@ RUN set -eux; \
  {{ ) else ( -}}
  FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:{{ env.variant }}-scm
-
-+ # Remove optional packages that are marked as vulnerable and that don't have fixes available.
-+ # Then try to install up-to-date versions, so that if the distro makes them available in the future,
-+ # our next build will automatically include them.
-+ RUN set -eux; \
-+ 	apt-get autoremove -y \
-+		subversion \
-+ 	; \
-+ 	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
-+ 	rm -rf /var/lib/apt/lists/*
+ 
++# Remove optional packages that are marked as vulnerable and that don't have fixes available.
++# Then try to install up-to-date versions, so that if the distro makes them available in the future,
++# our next build will automatically include them.
++RUN set -eux; \
++	apt-get autoremove -y \
++	subversion \
++	; \
++	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
++	rm -rf /var/lib/apt/lists/*
 +
  # install cgo-related dependencies
  RUN set -eux; \

--- a/patches/0007-Remove-packages-marked-vulnerable.patch
+++ b/patches/0007-Remove-packages-marked-vulnerable.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Remove packages marked vulnerable
  1 file changed, 10 insertions(+)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index bfa9b58f6558b3..4e4af49fd94854 100644
+index bfa9b58f6558b3..b380f4f4041422 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
 @@ -311,6 +311,16 @@ RUN set -eux; \
@@ -20,7 +20,7 @@ index bfa9b58f6558b3..4e4af49fd94854 100644
 +# our next build will automatically include them.
 +RUN set -eux; \
 +	apt-get autoremove -y \
-+	subversion \
++		subversion \
 +	; \
 +	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
 +	rm -rf /var/lib/apt/lists/*

--- a/src/microsoft/1.24/bookworm/Dockerfile
+++ b/src/microsoft/1.24/bookworm/Dockerfile
@@ -89,15 +89,15 @@ RUN set -eux; \
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm
 
- # Remove optional packages that are marked as vulnerable and that don't have fixes available.
- # Then try to install up-to-date versions, so that if the distro makes them available in the future,
- # our next build will automatically include them.
- RUN set -eux; \
- 	apt-get autoremove -y \
-		subversion \
- 	; \
- 	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
- 	rm -rf /var/lib/apt/lists/*
+# Remove optional packages that are marked as vulnerable and that don't have fixes available.
+# Then try to install up-to-date versions, so that if the distro makes them available in the future,
+# our next build will automatically include them.
+RUN set -eux; \
+	apt-get autoremove -y \
+	subversion \
+	; \
+	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+	rm -rf /var/lib/apt/lists/*
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.24/bookworm/Dockerfile
+++ b/src/microsoft/1.24/bookworm/Dockerfile
@@ -6,16 +6,6 @@
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm AS build
 
-# Remove optional packages that are marked as vulnerable and that don't have fixes available.
-# Then try to install up-to-date versions, so that if the distro makes them available in the future,
-# our next build will automatically include them.
-RUN set -eux; \
-	apt-get autoremove -y \
-		subversion \
-	; \
-	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
-	rm -rf /var/lib/apt/lists/*
-
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.24.6
@@ -98,6 +88,16 @@ RUN set -eux; \
 	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm
+
+# Remove optional packages that are marked as vulnerable and that don't have fixes available.
+# Then try to install up-to-date versions, so that if the distro makes them available in the future,
+# our next build will automatically include them.
+RUN set -eux; \
+	apt-get autoremove -y \
+		subversion \
+	; \
+	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+	rm -rf /var/lib/apt/lists/*
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.24/bookworm/Dockerfile
+++ b/src/microsoft/1.24/bookworm/Dockerfile
@@ -89,15 +89,15 @@ RUN set -eux; \
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm
 
-# Remove optional packages that are marked as vulnerable and that don't have fixes available.
-# Then try to install up-to-date versions, so that if the distro makes them available in the future,
-# our next build will automatically include them.
-RUN set -eux; \
-	apt-get autoremove -y \
+ # Remove optional packages that are marked as vulnerable and that don't have fixes available.
+ # Then try to install up-to-date versions, so that if the distro makes them available in the future,
+ # our next build will automatically include them.
+ RUN set -eux; \
+ 	apt-get autoremove -y \
 		subversion \
-	; \
-	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
-	rm -rf /var/lib/apt/lists/*
+ 	; \
+ 	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+ 	rm -rf /var/lib/apt/lists/*
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.24/bookworm/Dockerfile
+++ b/src/microsoft/1.24/bookworm/Dockerfile
@@ -94,7 +94,7 @@ FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm
 # our next build will automatically include them.
 RUN set -eux; \
 	apt-get autoremove -y \
-	subversion \
+		subversion \
 	; \
 	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
 	rm -rf /var/lib/apt/lists/*

--- a/src/microsoft/1.24/bullseye/Dockerfile
+++ b/src/microsoft/1.24/bullseye/Dockerfile
@@ -89,15 +89,15 @@ RUN set -eux; \
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm
 
- # Remove optional packages that are marked as vulnerable and that don't have fixes available.
- # Then try to install up-to-date versions, so that if the distro makes them available in the future,
- # our next build will automatically include them.
- RUN set -eux; \
- 	apt-get autoremove -y \
-		subversion \
- 	; \
- 	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
- 	rm -rf /var/lib/apt/lists/*
+# Remove optional packages that are marked as vulnerable and that don't have fixes available.
+# Then try to install up-to-date versions, so that if the distro makes them available in the future,
+# our next build will automatically include them.
+RUN set -eux; \
+	apt-get autoremove -y \
+	subversion \
+	; \
+	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+	rm -rf /var/lib/apt/lists/*
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.24/bullseye/Dockerfile
+++ b/src/microsoft/1.24/bullseye/Dockerfile
@@ -89,15 +89,15 @@ RUN set -eux; \
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm
 
-# Remove optional packages that are marked as vulnerable and that don't have fixes available.
-# Then try to install up-to-date versions, so that if the distro makes them available in the future,
-# our next build will automatically include them.
-RUN set -eux; \
-	apt-get autoremove -y \
+ # Remove optional packages that are marked as vulnerable and that don't have fixes available.
+ # Then try to install up-to-date versions, so that if the distro makes them available in the future,
+ # our next build will automatically include them.
+ RUN set -eux; \
+ 	apt-get autoremove -y \
 		subversion \
-	; \
-	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
-	rm -rf /var/lib/apt/lists/*
+ 	; \
+ 	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+ 	rm -rf /var/lib/apt/lists/*
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.24/bullseye/Dockerfile
+++ b/src/microsoft/1.24/bullseye/Dockerfile
@@ -6,16 +6,6 @@
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm AS build
 
-# Remove optional packages that are marked as vulnerable and that don't have fixes available.
-# Then try to install up-to-date versions, so that if the distro makes them available in the future,
-# our next build will automatically include them.
-RUN set -eux; \
-	apt-get autoremove -y \
-		subversion \
-	; \
-	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
-	rm -rf /var/lib/apt/lists/*
-
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.24.6
@@ -98,6 +88,16 @@ RUN set -eux; \
 	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm
+
+# Remove optional packages that are marked as vulnerable and that don't have fixes available.
+# Then try to install up-to-date versions, so that if the distro makes them available in the future,
+# our next build will automatically include them.
+RUN set -eux; \
+	apt-get autoremove -y \
+		subversion \
+	; \
+	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+	rm -rf /var/lib/apt/lists/*
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.24/bullseye/Dockerfile
+++ b/src/microsoft/1.24/bullseye/Dockerfile
@@ -94,7 +94,7 @@ FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm
 # our next build will automatically include them.
 RUN set -eux; \
 	apt-get autoremove -y \
-	subversion \
+		subversion \
 	; \
 	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
 	rm -rf /var/lib/apt/lists/*

--- a/src/microsoft/1.25/bookworm/Dockerfile
+++ b/src/microsoft/1.25/bookworm/Dockerfile
@@ -6,16 +6,6 @@
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm AS build
 
-# Remove optional packages that are marked as vulnerable and that don't have fixes available.
-# Then try to install up-to-date versions, so that if the distro makes them available in the future,
-# our next build will automatically include them.
-RUN set -eux; \
-	apt-get autoremove -y \
-		subversion \
-	; \
-	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
-	rm -rf /var/lib/apt/lists/*
-
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.25.0
@@ -98,6 +88,16 @@ RUN set -eux; \
 	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm
+
+# Remove optional packages that are marked as vulnerable and that don't have fixes available.
+# Then try to install up-to-date versions, so that if the distro makes them available in the future,
+# our next build will automatically include them.
+RUN set -eux; \
+	apt-get autoremove -y \
+		subversion \
+	; \
+	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+	rm -rf /var/lib/apt/lists/*
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.25/bookworm/Dockerfile
+++ b/src/microsoft/1.25/bookworm/Dockerfile
@@ -89,15 +89,15 @@ RUN set -eux; \
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm
 
- # Remove optional packages that are marked as vulnerable and that don't have fixes available.
- # Then try to install up-to-date versions, so that if the distro makes them available in the future,
- # our next build will automatically include them.
- RUN set -eux; \
- 	apt-get autoremove -y \
-		subversion \
- 	; \
- 	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
- 	rm -rf /var/lib/apt/lists/*
+# Remove optional packages that are marked as vulnerable and that don't have fixes available.
+# Then try to install up-to-date versions, so that if the distro makes them available in the future,
+# our next build will automatically include them.
+RUN set -eux; \
+	apt-get autoremove -y \
+	subversion \
+	; \
+	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+	rm -rf /var/lib/apt/lists/*
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.25/bookworm/Dockerfile
+++ b/src/microsoft/1.25/bookworm/Dockerfile
@@ -89,15 +89,15 @@ RUN set -eux; \
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm
 
-# Remove optional packages that are marked as vulnerable and that don't have fixes available.
-# Then try to install up-to-date versions, so that if the distro makes them available in the future,
-# our next build will automatically include them.
-RUN set -eux; \
-	apt-get autoremove -y \
+ # Remove optional packages that are marked as vulnerable and that don't have fixes available.
+ # Then try to install up-to-date versions, so that if the distro makes them available in the future,
+ # our next build will automatically include them.
+ RUN set -eux; \
+ 	apt-get autoremove -y \
 		subversion \
-	; \
-	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
-	rm -rf /var/lib/apt/lists/*
+ 	; \
+ 	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+ 	rm -rf /var/lib/apt/lists/*
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.25/bookworm/Dockerfile
+++ b/src/microsoft/1.25/bookworm/Dockerfile
@@ -94,7 +94,7 @@ FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm
 # our next build will automatically include them.
 RUN set -eux; \
 	apt-get autoremove -y \
-	subversion \
+		subversion \
 	; \
 	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
 	rm -rf /var/lib/apt/lists/*

--- a/src/microsoft/1.25/bullseye/Dockerfile
+++ b/src/microsoft/1.25/bullseye/Dockerfile
@@ -89,15 +89,15 @@ RUN set -eux; \
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm
 
- # Remove optional packages that are marked as vulnerable and that don't have fixes available.
- # Then try to install up-to-date versions, so that if the distro makes them available in the future,
- # our next build will automatically include them.
- RUN set -eux; \
- 	apt-get autoremove -y \
-		subversion \
- 	; \
- 	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
- 	rm -rf /var/lib/apt/lists/*
+# Remove optional packages that are marked as vulnerable and that don't have fixes available.
+# Then try to install up-to-date versions, so that if the distro makes them available in the future,
+# our next build will automatically include them.
+RUN set -eux; \
+	apt-get autoremove -y \
+	subversion \
+	; \
+	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+	rm -rf /var/lib/apt/lists/*
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.25/bullseye/Dockerfile
+++ b/src/microsoft/1.25/bullseye/Dockerfile
@@ -6,16 +6,6 @@
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm AS build
 
-# Remove optional packages that are marked as vulnerable and that don't have fixes available.
-# Then try to install up-to-date versions, so that if the distro makes them available in the future,
-# our next build will automatically include them.
-RUN set -eux; \
-	apt-get autoremove -y \
-		subversion \
-	; \
-	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
-	rm -rf /var/lib/apt/lists/*
-
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.25.0
@@ -98,6 +88,16 @@ RUN set -eux; \
 	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm
+
+# Remove optional packages that are marked as vulnerable and that don't have fixes available.
+# Then try to install up-to-date versions, so that if the distro makes them available in the future,
+# our next build will automatically include them.
+RUN set -eux; \
+	apt-get autoremove -y \
+		subversion \
+	; \
+	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+	rm -rf /var/lib/apt/lists/*
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.25/bullseye/Dockerfile
+++ b/src/microsoft/1.25/bullseye/Dockerfile
@@ -89,15 +89,15 @@ RUN set -eux; \
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm
 
-# Remove optional packages that are marked as vulnerable and that don't have fixes available.
-# Then try to install up-to-date versions, so that if the distro makes them available in the future,
-# our next build will automatically include them.
-RUN set -eux; \
-	apt-get autoremove -y \
+ # Remove optional packages that are marked as vulnerable and that don't have fixes available.
+ # Then try to install up-to-date versions, so that if the distro makes them available in the future,
+ # our next build will automatically include them.
+ RUN set -eux; \
+ 	apt-get autoremove -y \
 		subversion \
-	; \
-	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
-	rm -rf /var/lib/apt/lists/*
+ 	; \
+ 	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
+ 	rm -rf /var/lib/apt/lists/*
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/src/microsoft/1.25/bullseye/Dockerfile
+++ b/src/microsoft/1.25/bullseye/Dockerfile
@@ -94,7 +94,7 @@ FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm
 # our next build will automatically include them.
 RUN set -eux; \
 	apt-get autoremove -y \
-	subversion \
+		subversion \
 	; \
 	apt-get satisfy -y 'subversion (>= 1.14.5)' || echo 'patched subversion not available' ; \
 	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Right not we're removing `subversion` from the build image rather than the final image. This PR moves the `apt-get autoremove` command to the correct location.