### PR TITLE
Add missing acr-staging var redirections

### DIFF
--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -76,8 +76,12 @@ variables:
   value: $(GolangDockerBuild)
 
 # We don't use a different ACR for staging vs. non-staging images.
+- name: acr-staging.resourceGroup
+  value: $(acr.resourceGroup)
 - name: acr-staging.server
   value: $(acr.server)
+- name: acr-staging.subscription
+  value: $(acr.subscription)
 # We don't host a public mirror. Note: an empty string is necessary so the
 # variable is defined and .NET Docker logic works.
 - name: public-mirror.server


### PR DESCRIPTION
Found that this was missing while working on go-infra-images, where it caused an error during `copyBaseImages`. I think it just happened not to cause an error yet in this repo because all this repo's base images are already on MAR. This is not a good state to be in, and could be confusing later if another use for these staging ACR variables comes up in an update, so let's fix it.