### PR TITLE
Fix publishRepoPrefix passthrough

### DIFF
--- a/eng/pipeline/go-docker-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline.yml
@@ -76,7 +76,7 @@ extends:
       - template: /eng/common/templates/stages/dotnet/publish-config-prod.yml@self
         parameters:
           sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}
-          publishRepoPrefix: "test/"
+          publishRepoPrefix: ${{ parameters.publishRepoPrefix }}
           stagesTemplate: /eng/common/templates/stages/dotnet/build-test-publish-repo.yml@self
           stagesTemplateParameters:
             sourceBuildPipelineRunId: ${{ parameters.sourceBuildPipelineRunId }}


### PR DESCRIPTION
Noticed this hard-coded value had snuck in while transferring the recent work to microsoft/go-infra-images.