### PR TITLE
Increase publish job timeout to avoid error

### DIFF
--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -15,7 +15,7 @@ parameters:
 jobs:
 - job: Publish
   pool: ${{ parameters.pool }}
-  timeoutInMinutes: 90
+  timeoutInMinutes: 180
 
   variables:
   - name: imageBuilder.commonCmdArgs


### PR DESCRIPTION
Unknown if this is an actual timeout or a hang. The 1h30m timeout shows up since https://dev.azure.com/dnceng/internal/_build/results?buildId=2798983&view=results. There might be another cause, but this is worth trying to unblock builds while investigating elsewhere.

Direct eng/common change that will need to be resolved in some way: configurable timeout or fixing if this execution time is unexpected.

* https://github.com/microsoft/go/issues/1894