### PR TITLE
pool: upgrade Arm 1ES runner from Mariner 2 to AL 3

### DIFF
--- a/eng/common/templates/variables/dotnet/common.yml
+++ b/eng/common/templates/variables/dotnet/common.yml
@@ -24,14 +24,14 @@ variables:
   value: NetCore1ESPool-Internal
 
 - name: linuxArm64PoolImage
-  value: Mariner-2-Docker-ARM64
+  value: azure-linux-3-arm64
 - name: linuxArm64PublicPoolName
   value: Docker-Linux-Arm-Public
 - name: linuxArm64InternalPoolName
   value: Docker-Linux-Arm-Internal
 
 - name: linuxArm32PoolImage
-  value: Mariner-2-Docker-ARM64
+  value: azure-linux-3-arm64
 - name: linuxArm32PublicPoolName
   value: Docker-Linux-Arm-Public
 - name: linuxArm32InternalPoolName

--- a/eng/common/templates/variables/dotnet/common.yml
+++ b/eng/common/templates/variables/dotnet/common.yml
@@ -24,14 +24,14 @@ variables:
   value: NetCore1ESPool-Internal
 
 - name: linuxArm64PoolImage
-  value: azure-linux-3-arm64
+  value: Mariner-2-Docker-ARM64
 - name: linuxArm64PublicPoolName
   value: Docker-Linux-Arm-Public
 - name: linuxArm64InternalPoolName
   value: Docker-Linux-Arm-Internal
 
 - name: linuxArm32PoolImage
-  value: azure-linux-3-arm64
+  value: Mariner-2-Docker-ARM64
 - name: linuxArm32PublicPoolName
   value: Docker-Linux-Arm-Public
 - name: linuxArm32InternalPoolName

--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -124,14 +124,14 @@ variables:
   value: NetCore1ESPool-Internal
 
 - name: linuxArm64PoolImage
-  value: Mariner-2-Docker-ARM64
+  value: azure-linux-3-arm64
 - name: linuxArm64PublicPoolName
   value: Docker-Linux-Arm-Public
 - name: linuxArm64InternalPoolName
   value: Docker-Linux-Arm-Internal
 
 - name: linuxArm32PoolImage
-  value: Mariner-2-Docker-ARM64
+  value: azure-linux-3-arm64
 - name: linuxArm32PublicPoolName
   value: Docker-Linux-Arm-Public
 - name: linuxArm32InternalPoolName

--- a/eng/pipeline/variables/common.yml
+++ b/eng/pipeline/variables/common.yml
@@ -124,14 +124,14 @@ variables:
   value: NetCore1ESPool-Internal
 
 - name: linuxArm64PoolImage
-  value: azure-linux-3-arm64
+  value: build.azurelinux.3.arm64
 - name: linuxArm64PublicPoolName
   value: Docker-Linux-Arm-Public
 - name: linuxArm64InternalPoolName
   value: Docker-Linux-Arm-Internal
 
 - name: linuxArm32PoolImage
-  value: azure-linux-3-arm64
+  value: build.azurelinux.3.arm64
 - name: linuxArm32PublicPoolName
   value: Docker-Linux-Arm-Public
 - name: linuxArm32InternalPoolName


### PR DESCRIPTION
We have an SFI alert telling us to get off this deprecated 1ES image.

Triggered an internal pipeline to confirm the pool name is valid: https://dev.azure.com/dnceng/internal/_build/results?buildId=2923095