### PR TITLE
update linuxAmd64InternalPoolImage to be consistent with dotnet

### DIFF
--- a/eng/pipeline/variables/go-common.yml
+++ b/eng/pipeline/variables/go-common.yml
@@ -66,7 +66,7 @@ variables:
   value: --registry-creds 'docker.io=placeholder;placeholder'
 
 - name: linuxAmd64InternalPoolImage
-  value: 1es-ubuntu-2204
+  value: build.azurelinux.3.amd64
 - name: linuxAmd64PublicPoolImage
   value: build.azurelinux.3.amd64.open
 - name: linuxAmd64PublicPoolName


### PR DESCRIPTION
This was updated:

https://github.com/microsoft/go-images/blob/07dae13418a6956e546c1b77a25cf073140067ca/eng/docker-tools/templates/variables/dotnet/common.yml#L16-L17