### PR TITLE
Update cleanup pipeline to work like docker-tools

### DIFF
--- a/eng/pipeline/cleanup-acr-images-pipeline-unofficial.yml
+++ b/eng/pipeline/cleanup-acr-images-pipeline-unofficial.yml
@@ -15,6 +15,10 @@ trigger: none
 pr: none
 # For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
+  - name: enableDryRun
+    displayName: Enable Dry Run
+    default: true
+    type: boolean
   - name: disableTSA
     displayName: "[Debug input] Disable TSA reporting. Use to try modifications in dev branches."
     type: boolean
@@ -22,7 +26,6 @@ parameters:
 schedules: []
 variables:
   - template: /eng/pipeline/variables/go-common.yml@self
-  - template: /eng/pipeline/variables/secrets.yml@self
 resources:
   repositories:
     - repository: 1ESPipelineTemplates
@@ -43,48 +46,8 @@ extends:
         enabled: ${{ not(parameters.disableTSA) }}
         configFile: $(Build.SourcesDirectory)/.config/tsa/tsaoptions.json
     stages:
-      - stage: Build
-        dependsOn: []
-        jobs:
-          - job: Build
-            pool:
-              name: $(default1ESInternalPoolName)
-              image: $(default1ESInternalPoolImage)
-              os: linux
-            steps:
-              - template: /eng/docker-tools/templates/steps/init-common.yml@self
-                parameters:
-                  dockerClientOS: linux
-              - template: /eng/docker-tools/templates/steps/reference-service-connections.yml@self
-                parameters:
-                  serviceConnections:
-                    - name: $(clean.serviceConnectionName)
-              - template: /eng/docker-tools/templates/steps/clean-acr-images.yml@self
-                parameters:
-                  internalProjectName: ${{ variables.internalProjectName }}
-                  repo: "build-staging/*"
-                  acr:
-                    server: $(acr-staging.server)
-                  action: delete
-                  age: 15
-                  customArgs: "--dry-run" # Dry run is the default, but make it explicit.
-            # Disabled until we've worked out https://github.com/microsoft/go-lab/issues/245
-            # - template: /eng/docker-tools/templates/steps/clean-acr-images.yml@self
-            #   parameters:
-            #     internalProjectName: ${{ variables.internalProjectName }}
-            #     repo: "public/oss/go/*"
-            #     acr:
-            #       server: $(acr.server)
-            #     action: pruneEol
-            #     age: 15
-            #     customArgs: "--dry-run" # Dry run is the default, but make it explicit.
-            # Disabled due to https://github.com/dotnet/docker-tools/issues/797
-            # - template: /eng/docker-tools/templates/steps/clean-acr-images.yml@self
-            #   parameters:
-            #     internalProjectName: ${{ variables.internalProjectName }}
-            #     repo: "mirror/*"
-            #     acr:
-            #       server: $(acr-staging.server)
-            #     action: pruneDangling
-            #     age: 0
-            #     customArgs: "--dry-run" # Dry run is the default, but make it explicit.
+      - template: /eng/pipeline/stages/publish-config-prod.yml@self
+        parameters:
+          stagesTemplate: /eng/pipeline/stages/go-cleanup-acr-images.yml@self
+          stagesTemplateParameters:
+            enableDryRun: ${{ parameters.enableDryRun }}

--- a/eng/pipeline/cleanup-acr-images-pipeline.yml
+++ b/eng/pipeline/cleanup-acr-images-pipeline.yml
@@ -15,6 +15,10 @@ trigger: none
 pr: none
 # For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
+  - name: enableDryRun
+    displayName: Enable Dry Run
+    default: false
+    type: boolean
   - name: disableTSA
     displayName: "[Debug input] Disable TSA reporting. Use to try modifications in dev branches."
     type: boolean
@@ -28,7 +32,6 @@ schedules:
     always: true
 variables:
   - template: /eng/pipeline/variables/go-common.yml@self
-  - template: /eng/pipeline/variables/secrets.yml@self
 resources:
   repositories:
     - repository: 1ESPipelineTemplates
@@ -49,48 +52,8 @@ extends:
         enabled: ${{ not(parameters.disableTSA) }}
         configFile: $(Build.SourcesDirectory)/.config/tsa/tsaoptions.json
     stages:
-      - stage: Build
-        dependsOn: []
-        jobs:
-          - job: Build
-            pool:
-              name: $(default1ESInternalPoolName)
-              image: $(default1ESInternalPoolImage)
-              os: linux
-            steps:
-              - template: /eng/docker-tools/templates/steps/init-common.yml@self
-                parameters:
-                  dockerClientOS: linux
-              - template: /eng/docker-tools/templates/steps/reference-service-connections.yml@self
-                parameters:
-                  serviceConnections:
-                    - name: $(clean.serviceConnectionName)
-              - template: /eng/docker-tools/templates/steps/clean-acr-images.yml@self
-                parameters:
-                  internalProjectName: ${{ variables.internalProjectName }}
-                  repo: "build-staging/*"
-                  acr:
-                    server: $(acr-staging.server)
-                  action: delete
-                  age: 15
-                  customArgs: "--dry-run" # Dry run is the default, but make it explicit.
-            # Disabled until we've worked out https://github.com/microsoft/go-lab/issues/245
-            # - template: /eng/docker-tools/templates/steps/clean-acr-images.yml@self
-            #   parameters:
-            #     internalProjectName: ${{ variables.internalProjectName }}
-            #     repo: "public/oss/go/*"
-            #     acr:
-            #       server: $(acr.server)
-            #     action: pruneEol
-            #     age: 15
-            #     customArgs: "--dry-run" # Dry run is the default, but make it explicit.
-            # Disabled due to https://github.com/dotnet/docker-tools/issues/797
-            # - template: /eng/docker-tools/templates/steps/clean-acr-images.yml@self
-            #   parameters:
-            #     internalProjectName: ${{ variables.internalProjectName }}
-            #     repo: "mirror/*"
-            #     acr:
-            #       server: $(acr-staging.server)
-            #     action: pruneDangling
-            #     age: 0
-            #     customArgs: "--dry-run" # Dry run is the default, but make it explicit.
+      - template: /eng/pipeline/stages/publish-config-prod.yml@self
+        parameters:
+          stagesTemplate: /eng/pipeline/stages/go-cleanup-acr-images.yml@self
+          stagesTemplateParameters:
+            enableDryRun: ${{ parameters.enableDryRun }}

--- a/eng/pipeline/cleanup-acr-images.gen.yml
+++ b/eng/pipeline/cleanup-acr-images.gen.yml
@@ -23,6 +23,11 @@ pr: none
 
 # For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
+  - name: enableDryRun
+    displayName: Enable Dry Run
+    default: ${ yml (not .official) }
+    type: boolean
+
   - name: disableTSA
     displayName: "[Debug input] Disable TSA reporting. Use to try modifications in dev branches."
     type: boolean
@@ -39,7 +44,6 @@ schedules:
 
 variables:
   - template: /eng/pipeline/variables/go-common.yml@self
-  - template: /eng/pipeline/variables/secrets.yml@self
 
 resources:
   repositories:
@@ -65,48 +69,8 @@ extends:
         enabled: ${{ not(parameters.disableTSA) }}
         configFile: $(Build.SourcesDirectory)/.config/tsa/tsaoptions.json
     stages:
-      - stage: Build
-        dependsOn: []
-        jobs:
-          - job: Build
-            pool:
-              name: $(default1ESInternalPoolName)
-              image: $(default1ESInternalPoolImage)
-              os: linux
-            steps:
-              - template: /eng/docker-tools/templates/steps/init-common.yml@self
-                parameters:
-                  dockerClientOS: linux
-              - template: /eng/docker-tools/templates/steps/reference-service-connections.yml@self
-                parameters:
-                  serviceConnections:
-                    - name: $(clean.serviceConnectionName)
-              - template: /eng/docker-tools/templates/steps/clean-acr-images.yml@self
-                parameters:
-                  internalProjectName: ${{ variables.internalProjectName }}
-                  repo: "build-staging/*"
-                  acr:
-                    server: $(acr-staging.server)
-                  action: delete
-                  age: 15
-                  customArgs: "--dry-run" # Dry run is the default, but make it explicit.
-              # Disabled until we've worked out https://github.com/microsoft/go-lab/issues/245
-              # - template: /eng/docker-tools/templates/steps/clean-acr-images.yml@self
-              #   parameters:
-              #     internalProjectName: ${{ variables.internalProjectName }}
-              #     repo: "public/oss/go/*"
-              #     acr:
-              #       server: $(acr.server)
-              #     action: pruneEol
-              #     age: 15
-              #     customArgs: "--dry-run" # Dry run is the default, but make it explicit.
-              # Disabled due to https://github.com/dotnet/docker-tools/issues/797
-              # - template: /eng/docker-tools/templates/steps/clean-acr-images.yml@self
-              #   parameters:
-              #     internalProjectName: ${{ variables.internalProjectName }}
-              #     repo: "mirror/*"
-              #     acr:
-              #       server: $(acr-staging.server)
-              #     action: pruneDangling
-              #     age: 0
-              #     customArgs: "--dry-run" # Dry run is the default, but make it explicit.
+      - template: /eng/pipeline/stages/publish-config-prod.yml@self
+        parameters:
+          stagesTemplate: /eng/pipeline/stages/go-cleanup-acr-images.yml@self
+          stagesTemplateParameters:
+            enableDryRun: ${{ parameters.enableDryRun }}

--- a/eng/pipeline/stages/go-cleanup-acr-images.yml
+++ b/eng/pipeline/stages/go-cleanup-acr-images.yml
@@ -1,0 +1,58 @@
+parameters:
+- name: publishConfig
+  type: object
+  default: null
+- name: enableDryRun
+  type: boolean
+  default: false
+- name: internalProjectName
+  type: string
+  default: null
+- name: publicProjectName
+  type: string
+  default: null
+
+stages:
+  - stage: Execute
+    dependsOn: []
+    jobs:
+      - job: Clean
+        pool:
+          name: $(default1ESInternalPoolName)
+          image: $(default1ESInternalPoolImage)
+          os: linux
+        variables:
+          dryRunArg: ${{ iif(parameters.enableDryRun, '--dry-run', '') }}
+        steps:
+          - template: /eng/docker-tools/templates/steps/init-common.yml@self
+            parameters:
+              dockerClientOS: linux
+              publishConfig: ${{ parameters.publishConfig }}
+          - template: /eng/docker-tools/templates/steps/reference-service-connections.yml@self
+            parameters:
+              publishConfig: ${{ parameters.publishConfig }}
+              serviceConnections:
+                - ${{ parameters.publishConfig.cleanServiceConnection }}
+          - template: /eng/docker-tools/templates/steps/clean-acr-images.yml@self
+            parameters:
+              internalProjectName: ${{ parameters.internalProjectName }}
+              repo: "build-staging/*"
+              acr: ${{ parameters.publishConfig.BuildRegistry }}
+              action: delete
+              age: 15
+          # Disabled until we've worked out https://github.com/microsoft/go-lab/issues/245
+          # - template: /eng/docker-tools/templates/steps/clean-acr-images.yml@self
+          #   parameters:
+          #     internalProjectName: ${{ parameters.internalProjectName }}
+          #     repo: "public/oss/go/*"
+          #     acr: ${{ parameters.publishConfig.PublishRegistry }}
+          #     action: pruneEol
+          #     age: 15
+          #     customArgs: $(excludedBuildToolsPrereqsImagesArgs)
+          # Disabled due to https://github.com/dotnet/docker-tools/issues/797
+          # - template: /eng/docker-tools/templates/steps/clean-acr-images.yml@self
+          #   parameters:
+          #     repo: "mirror/*"
+          #     acr: ${{ parameters.publishConfig.BuildRegistry }}
+          #     action: pruneDangling
+          #     age: 0


### PR DESCRIPTION
Rework cleanup pipelines based on https://github.com/dotnet/docker-tools/blob/06c0b37e87ee9dfb0c8313bf60fb174bc909227f/eng/pipelines/cleanup-acr-images-official.yml

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2929931&view=results