### PR TITLE
cleanup: add custom age parameter and enable pruneEol

### DIFF
--- a/eng/pipeline/cleanup-acr-images-pipeline-unofficial.yml
+++ b/eng/pipeline/cleanup-acr-images-pipeline-unofficial.yml
@@ -24,7 +24,7 @@ parameters:
     type: boolean
     default: true
   - name: age
-    displayName: Age (in days) of images to clean up
+    displayName: Minimum age (in days) of images to clean up; reduce if necessary to clear s360
     type: number
     default: 15
 schedules: []

--- a/eng/pipeline/cleanup-acr-images-pipeline-unofficial.yml
+++ b/eng/pipeline/cleanup-acr-images-pipeline-unofficial.yml
@@ -23,6 +23,10 @@ parameters:
     displayName: "[Debug input] Disable TSA reporting. Use to try modifications in dev branches."
     type: boolean
     default: true
+  - name: age
+    displayName: Age (in days) of images to clean up
+    type: number
+    default: 15
 schedules: []
 variables:
   - template: /eng/pipeline/variables/go-common.yml@self
@@ -51,3 +55,4 @@ extends:
           stagesTemplate: /eng/pipeline/stages/go-cleanup-acr-images.yml@self
           stagesTemplateParameters:
             enableDryRun: ${{ parameters.enableDryRun }}
+            age: ${{ parameters.age }}

--- a/eng/pipeline/cleanup-acr-images-pipeline.yml
+++ b/eng/pipeline/cleanup-acr-images-pipeline.yml
@@ -23,6 +23,10 @@ parameters:
     displayName: "[Debug input] Disable TSA reporting. Use to try modifications in dev branches."
     type: boolean
     default: false
+  - name: age
+    displayName: Age (in days) of images to clean up
+    type: number
+    default: 15
 schedules:
   - cron: "0 5 * * *"
     displayName: Nightly build
@@ -57,3 +61,4 @@ extends:
           stagesTemplate: /eng/pipeline/stages/go-cleanup-acr-images.yml@self
           stagesTemplateParameters:
             enableDryRun: ${{ parameters.enableDryRun }}
+            age: ${{ parameters.age }}

--- a/eng/pipeline/cleanup-acr-images-pipeline.yml
+++ b/eng/pipeline/cleanup-acr-images-pipeline.yml
@@ -24,7 +24,7 @@ parameters:
     type: boolean
     default: false
   - name: age
-    displayName: Age (in days) of images to clean up
+    displayName: Minimum age (in days) of images to clean up; reduce if necessary to clear s360
     type: number
     default: 15
 schedules:

--- a/eng/pipeline/cleanup-acr-images.gen.yml
+++ b/eng/pipeline/cleanup-acr-images.gen.yml
@@ -34,7 +34,7 @@ parameters:
     default: ${ yml (not .official) }
 
   - name: age
-    displayName: Age (in days) of images to clean up
+    displayName: Minimum age (in days) of images to clean up; reduce if necessary to clear s360
     type: number
     default: 15
 

--- a/eng/pipeline/cleanup-acr-images.gen.yml
+++ b/eng/pipeline/cleanup-acr-images.gen.yml
@@ -33,6 +33,11 @@ parameters:
     type: boolean
     default: ${ yml (not .official) }
 
+  - name: age
+    displayName: Age (in days) of images to clean up
+    type: number
+    default: 15
+
 schedules:
   - ${ inlineif .official }:
     - cron: "0 5 * * *"
@@ -74,3 +79,4 @@ extends:
           stagesTemplate: /eng/pipeline/stages/go-cleanup-acr-images.yml@self
           stagesTemplateParameters:
             enableDryRun: ${{ parameters.enableDryRun }}
+            age: ${{ parameters.age }}

--- a/eng/pipeline/stages/go-cleanup-acr-images.yml
+++ b/eng/pipeline/stages/go-cleanup-acr-images.yml
@@ -20,6 +20,7 @@ stages:
     dependsOn: []
     jobs:
       - job: Clean
+        timeoutInMinutes: 180
         pool:
           name: $(default1ESInternalPoolName)
           image: $(default1ESInternalPoolImage)
@@ -47,7 +48,7 @@ stages:
             parameters:
               internalProjectName: ${{ parameters.internalProjectName }}
               repo: "public/oss/go/*"
-              acr: ${{ parameters.publishConfig.BuildRegistry }}
+              acr: ${{ parameters.publishConfig.PublishRegistry }}
               action: pruneEol
               age: ${{ parameters.age }}
           # Disabled due to https://github.com/dotnet/docker-tools/issues/797

--- a/eng/pipeline/stages/go-cleanup-acr-images.yml
+++ b/eng/pipeline/stages/go-cleanup-acr-images.yml
@@ -11,6 +11,9 @@ parameters:
 - name: publicProjectName
   type: string
   default: null
+- name: age
+  type: number
+  default: 15
 
 stages:
   - stage: Execute
@@ -39,16 +42,14 @@ stages:
               repo: "build-staging/*"
               acr: ${{ parameters.publishConfig.BuildRegistry }}
               action: delete
-              age: 15
-          # Disabled until we've worked out https://github.com/microsoft/go-lab/issues/245
-          # - template: /eng/docker-tools/templates/steps/clean-acr-images.yml@self
-          #   parameters:
-          #     internalProjectName: ${{ parameters.internalProjectName }}
-          #     repo: "public/oss/go/*"
-          #     acr: ${{ parameters.publishConfig.PublishRegistry }}
-          #     action: pruneEol
-          #     age: 15
-          #     customArgs: $(excludedBuildToolsPrereqsImagesArgs)
+              age: ${{ parameters.age }}
+          - template: /eng/docker-tools/templates/steps/clean-acr-images.yml@self
+            parameters:
+              internalProjectName: ${{ parameters.internalProjectName }}
+              repo: "public/oss/go/*"
+              acr: ${{ parameters.publishConfig.BuildRegistry }}
+              action: pruneEol
+              age: ${{ parameters.age }}
           # Disabled due to https://github.com/dotnet/docker-tools/issues/797
           # - template: /eng/docker-tools/templates/steps/clean-acr-images.yml@self
           #   parameters:


### PR DESCRIPTION
This allows us to speed up the SFI resolution process when required. There's also no reason why we shouldn't be running the pruneEol stage (it will actually speed up the regular annotation job as part of our release. 