### PR TITLE
Document N-1 version recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,16 @@ mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0
 ```
 
 > [!NOTE]
-> Why 1.25 and not the latest 1.26?
-> By the time a Go major has been out long enough to be the N-1 major version, it has had several patch releases that fix compatibility regressions found in the `.0` release, so it tends to be a less disruptive default for build pipelines than the brand-new N.
+> Why 1.25 (N-1) and not the latest, 1.26 (N)?
+> By the time a Go major version has been out long enough to be N-1, it has had several patch releases that may fix bugs found in the `.0` release and other early patch versions.
+> We recommend starting with N-1 rather than N so this timing-specific nuance doesn't come up.
 >
-> Both N and N-1 tags are currently supported, rebuilt by this repo, and published to MAR — if you want N, pin to its major tag explicitly.
-> We recommend moving from N-1 to N **before** N+1 ships, because the old N-1 reaches end of support when N+1 releases.
-> Staying on the recommended tag past that point would mean upgrading two majors at once.
+> Both N and N-1 tags are currently supported.
+> If you want or need to use the latest, N, simply increment the major version number in the tag you use.
+>
+> To continue using Go without a support continuity gap, you must move from N-1 to N **before** N+1 ships, because the old N-1 reaches end of support immediately when N+1 releases.
+> Ideally, we recommend moving from N-1 to N as soon as possible. This way, you can detect bugs that have to do with the new Go version as soon as possible and maximize the time remaining to address them.
+> This may seem to contradict our image recommendation; however, we *do* recommend starting with N-1 and upgrading to N as soon as you can feasibly do so for the most incremental and safe migration.
 
 > [!NOTE]
 > If you've used our 1.24 or earlier images, you may expect to see a `-fips` variant.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0
 ```
 
 > [!NOTE]
+> Why 1.25 and not the latest 1.26?
+> By the time a Go major has been out long enough to be the N-1 major version, it has had several patch releases that fix compatibility regressions found in the `.0` release, so it tends to be a less disruptive default for build pipelines than the brand-new N.
+>
+> Both N and N-1 are fully supported in MAR — if you want N, pin to its major tag explicitly.
+> We recommend moving from N-1 to N **before** N+1 ships, because the old N-1 reaches end of support when N+1 releases.
+> Staying on the recommended tag past that point would mean upgrading two majors at once.
+
+> [!NOTE]
 > If you've used our 1.24 or earlier images, you may expect to see a `-fips` variant.
 > As of 1.25, we no longer produce `-fips` tags, because `systemcrypto` is enabled by default in the Microsoft build of Go as of Go 1.25.
 > Basically: the change that was previously in the `-fips` images is now present in all of our ordinary images.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0
 > Why 1.25 and not the latest 1.26?
 > By the time a Go major has been out long enough to be the N-1 major version, it has had several patch releases that fix compatibility regressions found in the `.0` release, so it tends to be a less disruptive default for build pipelines than the brand-new N.
 >
-> Both N and N-1 are fully supported in MAR — if you want N, pin to its major tag explicitly.
+> Both N and N-1 tags are currently supported, rebuilt by this repo, and published to MAR — if you want N, pin to its major tag explicitly.
 > We recommend moving from N-1 to N **before** N+1 ships, because the old N-1 reaches end of support when N+1 releases.
 > Staying on the recommended tag past that point would mean upgrading two majors at once.
 


### PR DESCRIPTION
This pull request updates the guidance in the `README.md` to clarify why the Go 1.25 tag is recommended over the latest 1.26 tag, and provides advice on version support and upgrade timing.

Documentation improvements:

* Added a detailed note explaining the rationale for recommending the Go 1.25 tag instead of the latest 1.26, including guidance on version support, upgrade timing, and the importance of staying current to avoid disruptive major version upgrades.

- https://github.com/microsoft/go-lab/issues/101