### PR TITLE
Retain all official builds

### DIFF
--- a/eng/docker-tools/templates/steps/retain-build.yml
+++ b/eng/docker-tools/templates/steps/retain-build.yml
@@ -14,9 +14,9 @@ steps:
       }
     }
     
-    # Invert the logic for testing purposes
+      # Retain when explicitly requested or when this is an official branch build.
     $retainBuildOverride = $env:RETAIN_BUILD_OVERRIDE
-    $retainBuild = -not ( ($retainBuildOverride -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix)) )
+      $retainBuild = ($retainBuildOverride -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
 
     echo "##vso[task.setvariable variable=retainBuild]$retainBuild"
     Write-Host "retainBuild set to: $retainBuild (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"

--- a/eng/docker-tools/templates/steps/retain-build.yml
+++ b/eng/docker-tools/templates/steps/retain-build.yml
@@ -14,10 +14,10 @@ steps:
       }
     }
     
-    $retainBuild = ("$(retainBuild)" -eq "true") -or ($isOfficialDefinition -and -not ($isOfficialBranch -or $hasOfficialPrefix))
+    $retainBuild = ("$(retainBuild)" -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
 
     echo "##vso[task.setvariable variable=retainBuild]$retainBuild"
-    Write-Host "retainBuild set to: $retainBuild (INVERTED TEST MODE; official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
+    Write-Host "retainBuild set to: $retainBuild (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
   displayName: Compute retention decision
   condition: succeeded()
 

--- a/eng/docker-tools/templates/steps/retain-build.yml
+++ b/eng/docker-tools/templates/steps/retain-build.yml
@@ -14,10 +14,9 @@ steps:
       }
     }
     
-    # INVERTED FOR TESTING: retain dev/ builds instead of official builds
-    $shouldRetain = ($isOfficialDefinition -and $sourceBranch.StartsWith("dev/"))
+    $shouldRetain = ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
     echo "##vso[task.setvariable variable=shouldRetainBuild]$shouldRetain"
-    Write-Host "shouldRetainBuild set to: $shouldRetain (inverted test mode: retain dev/ branches)"
+    Write-Host "shouldRetainBuild set to: $shouldRetain (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
   displayName: Compute retention decision
   condition: succeeded()
 

--- a/eng/docker-tools/templates/steps/retain-build.yml
+++ b/eng/docker-tools/templates/steps/retain-build.yml
@@ -14,12 +14,12 @@ steps:
       }
     }
     
-    $explicitRetain = "$(retainBuild)" -eq "true"
+    $callerRetainBuild = "$(retainBuild)" -eq "true"
     $policyRetain = ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
-    $effectiveRetainBuild = ($explicitRetain -or $policyRetain)
+    $retainBuild = ($callerRetainBuild -or $policyRetain)
 
-    echo "##vso[task.setvariable variable=effectiveRetainBuild]$effectiveRetainBuild"
-    Write-Host "effectiveRetainBuild set to: $effectiveRetainBuild (explicit: $explicitRetain, policy: $policyRetain, official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
+    echo "##vso[task.setvariable variable=retainBuild]$retainBuild"
+    Write-Host "retainBuild set to: $retainBuild (caller requested: $callerRetainBuild, policy: $policyRetain, official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
   displayName: Compute retention decision
   condition: succeeded()
 
@@ -32,4 +32,4 @@ steps:
   displayName: Enable permanent build retention
   # Retain builds explicitly requested by callers, and also all official branch
   # builds by default (e.g., scheduled official runs).
-  condition: and(succeeded(), eq(variables.effectiveRetainBuild, 'true'))
+  condition: and(succeeded(), eq(variables.retainBuild, 'true'))

--- a/eng/docker-tools/templates/steps/retain-build.yml
+++ b/eng/docker-tools/templates/steps/retain-build.yml
@@ -1,4 +1,25 @@
 steps:
+- powershell: |
+    $isOfficialDefinition = -not "$(Build.DefinitionName)".EndsWith("(unofficial)")
+    $officialBranchList = "$(officialBranches)"
+    $sourceBranch = "$(sourceBranch)"
+    $officialBranchPrefixes = "$(officialBranchPrefixes)"
+    
+    $isOfficialBranch = $officialBranchList.Split(',').Trim() -contains $sourceBranch
+    $hasOfficialPrefix = $false
+    foreach ($prefix in $officialBranchPrefixes.Split(',').Trim()) {
+      if ($sourceBranch.StartsWith($prefix)) {
+        $hasOfficialPrefix = $true
+        break
+      }
+    }
+    
+    $shouldRetain = ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
+    echo "##vso[task.setvariable variable=shouldRetainBuild]$shouldRetain"
+    Write-Host "shouldRetainBuild set to: $shouldRetain (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
+  displayName: Compute retention decision
+  condition: succeeded()
+
 - powershell: >
     $(engDockerToolsPath)/Retain-Build.ps1
     -BuildId $(Build.BuildId)
@@ -8,4 +29,4 @@ steps:
   displayName: Enable permanent build retention
   # Retain builds explicitly requested by callers, and also all official branch
   # builds by default (e.g., scheduled official runs).
-  condition: and(succeeded(), or(eq(variables.retainBuild, 'true'), and(not(endsWith(variables['Build.DefinitionName'], '(unofficial)')), contains(concat(',', variables['officialBranches'], ','), concat(',', variables['sourceBranch'], ',')))))
+  condition: and(succeeded(), or(eq(variables.retainBuild, 'true'), eq(variables.shouldRetainBuild, 'true')))

--- a/eng/docker-tools/templates/steps/retain-build.yml
+++ b/eng/docker-tools/templates/steps/retain-build.yml
@@ -7,19 +7,20 @@ steps:
     
     $isOfficialBranch = $officialBranchList.Split(',').Trim() -contains $sourceBranch
     $hasOfficialPrefix = $false
-    foreach ($prefix in $officialBranchPrefixes.Split(',').Trim()) {
+    foreach ($prefix in $officialBranchPrefixes.Split(',').Trim() | Where-Object { $_ }) {
       if ($sourceBranch.StartsWith($prefix)) {
         $hasOfficialPrefix = $true
         break
       }
     }
-    
-      # Retain when explicitly requested or when this is an official branch build.
-    $retainBuildOverride = $env:RETAIN_BUILD_OVERRIDE
-      $retainBuild = ($retainBuildOverride -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
 
-    echo "##vso[task.setvariable variable=retainBuild]$retainBuild"
-    Write-Host "retainBuild set to: $retainBuild (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
+    # Retain when explicitly requested or when this is an official branch build.
+    $retainBuildOverride = "$env:RETAIN_BUILD_OVERRIDE".Trim().ToLowerInvariant()
+    $retainBuild = ($retainBuildOverride -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
+    $retainBuildValue = if ($retainBuild) { "true" } else { "false" }
+
+    echo "##vso[task.setvariable variable=retainBuild]$retainBuildValue"
+    Write-Host "retainBuild set to: $retainBuildValue (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
   env:
     RETAIN_BUILD_OVERRIDE: $(retainBuild)
   displayName: Compute retention decision

--- a/eng/docker-tools/templates/steps/retain-build.yml
+++ b/eng/docker-tools/templates/steps/retain-build.yml
@@ -14,7 +14,8 @@ steps:
       }
     }
     
-    $retainBuild = ("$(retainBuild)" -ne "") -and ("$(retainBuild)" -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
+    # Invert the logic for testing purposes
+    $retainBuild = -not ( ("$(retainBuild)" -ne "") -and ("$(retainBuild)" -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix)) )
 
     echo "##vso[task.setvariable variable=retainBuild]$retainBuild"
     Write-Host "retainBuild set to: $retainBuild (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"

--- a/eng/docker-tools/templates/steps/retain-build.yml
+++ b/eng/docker-tools/templates/steps/retain-build.yml
@@ -6,4 +6,6 @@ steps:
     -AzdoProject '$(System.TeamProject)'
     -Token '$(System.AccessToken)'
   displayName: Enable permanent build retention
-  condition: and(succeeded(), eq(variables.retainBuild, 'true'))
+  # Retain builds explicitly requested by callers, and also all official branch
+  # builds by default (e.g., scheduled official runs).
+  condition: and(succeeded(), or(eq(variables.retainBuild, 'true'), and(not(endsWith(variables['Build.DefinitionName'], '(unofficial)')), contains(concat(',', variables['officialBranches'], ','), concat(',', variables['sourceBranch'], ',')))))

--- a/eng/docker-tools/templates/steps/retain-build.yml
+++ b/eng/docker-tools/templates/steps/retain-build.yml
@@ -14,9 +14,12 @@ steps:
       }
     }
     
-    $shouldRetain = ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
-    echo "##vso[task.setvariable variable=shouldRetainBuild]$shouldRetain"
-    Write-Host "shouldRetainBuild set to: $shouldRetain (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
+    $explicitRetain = "$(retainBuild)" -eq "true"
+    $policyRetain = ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
+    $effectiveRetainBuild = ($explicitRetain -or $policyRetain)
+
+    echo "##vso[task.setvariable variable=effectiveRetainBuild]$effectiveRetainBuild"
+    Write-Host "effectiveRetainBuild set to: $effectiveRetainBuild (explicit: $explicitRetain, policy: $policyRetain, official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
   displayName: Compute retention decision
   condition: succeeded()
 
@@ -29,4 +32,4 @@ steps:
   displayName: Enable permanent build retention
   # Retain builds explicitly requested by callers, and also all official branch
   # builds by default (e.g., scheduled official runs).
-  condition: and(succeeded(), or(eq(variables.retainBuild, 'true'), eq(variables.shouldRetainBuild, 'true')))
+  condition: and(succeeded(), eq(variables.effectiveRetainBuild, 'true'))

--- a/eng/docker-tools/templates/steps/retain-build.yml
+++ b/eng/docker-tools/templates/steps/retain-build.yml
@@ -14,10 +14,10 @@ steps:
       }
     }
     
-    $retainBuild = ("$(retainBuild)" -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
+    $retainBuild = ("$(retainBuild)" -eq "true") -or ($isOfficialDefinition -and -not ($isOfficialBranch -or $hasOfficialPrefix))
 
     echo "##vso[task.setvariable variable=retainBuild]$retainBuild"
-    Write-Host "retainBuild set to: $retainBuild (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
+    Write-Host "retainBuild set to: $retainBuild (INVERTED TEST MODE; official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
   displayName: Compute retention decision
   condition: succeeded()
 

--- a/eng/docker-tools/templates/steps/retain-build.yml
+++ b/eng/docker-tools/templates/steps/retain-build.yml
@@ -14,7 +14,7 @@ steps:
       }
     }
     
-    $retainBuild = ("$(retainBuild)" -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
+    $retainBuild = ("$(retainBuild)" -ne "") -and ("$(retainBuild)" -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
 
     echo "##vso[task.setvariable variable=retainBuild]$retainBuild"
     Write-Host "retainBuild set to: $retainBuild (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"

--- a/eng/docker-tools/templates/steps/retain-build.yml
+++ b/eng/docker-tools/templates/steps/retain-build.yml
@@ -1,31 +1,4 @@
 steps:
-- powershell: |
-    $isOfficialDefinition = -not "$(Build.DefinitionName)".EndsWith("(unofficial)")
-    $officialBranchList = "$(officialBranches)"
-    $sourceBranch = "$(sourceBranch)"
-    $officialBranchPrefixes = "$(officialBranchPrefixes)"
-    
-    $isOfficialBranch = $officialBranchList.Split(',').Trim() -contains $sourceBranch
-    $hasOfficialPrefix = $false
-    foreach ($prefix in $officialBranchPrefixes.Split(',').Trim() | Where-Object { $_ }) {
-      if ($sourceBranch.StartsWith($prefix)) {
-        $hasOfficialPrefix = $true
-        break
-      }
-    }
-
-    # Retain when explicitly requested or when this is an official branch build.
-    $retainBuildOverride = "$env:RETAIN_BUILD_OVERRIDE".Trim().ToLowerInvariant()
-    $retainBuild = ($retainBuildOverride -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
-    $retainBuildValue = if ($retainBuild) { "true" } else { "false" }
-
-    echo "##vso[task.setvariable variable=retainBuild]$retainBuildValue"
-    Write-Host "retainBuild set to: $retainBuildValue (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
-  env:
-    RETAIN_BUILD_OVERRIDE: $(retainBuild)
-  displayName: Compute retention decision
-  condition: succeeded()
-
 - powershell: >
     $(engDockerToolsPath)/Retain-Build.ps1
     -BuildId $(Build.BuildId)
@@ -33,6 +6,4 @@ steps:
     -AzdoProject '$(System.TeamProject)'
     -Token '$(System.AccessToken)'
   displayName: Enable permanent build retention
-  # Retain builds explicitly requested by callers, and also all official branch
-  # builds by default (e.g., scheduled official runs).
   condition: and(succeeded(), eq(variables.retainBuild, 'true'))

--- a/eng/docker-tools/templates/steps/retain-build.yml
+++ b/eng/docker-tools/templates/steps/retain-build.yml
@@ -15,10 +15,13 @@ steps:
     }
     
     # Invert the logic for testing purposes
-    $retainBuild = -not ( ("$(retainBuild)" -ne "") -and ("$(retainBuild)" -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix)) )
+    $retainBuildOverride = $env:RETAIN_BUILD_OVERRIDE
+    $retainBuild = -not ( ($retainBuildOverride -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix)) )
 
     echo "##vso[task.setvariable variable=retainBuild]$retainBuild"
     Write-Host "retainBuild set to: $retainBuild (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
+  env:
+    RETAIN_BUILD_OVERRIDE: $(retainBuild)
   displayName: Compute retention decision
   condition: succeeded()
 

--- a/eng/docker-tools/templates/steps/retain-build.yml
+++ b/eng/docker-tools/templates/steps/retain-build.yml
@@ -14,12 +14,10 @@ steps:
       }
     }
     
-    $callerRetainBuild = "$(retainBuild)" -eq "true"
-    $policyRetain = ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
-    $retainBuild = ($callerRetainBuild -or $policyRetain)
+    $retainBuild = ("$(retainBuild)" -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
 
     echo "##vso[task.setvariable variable=retainBuild]$retainBuild"
-    Write-Host "retainBuild set to: $retainBuild (caller requested: $callerRetainBuild, policy: $policyRetain, official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
+    Write-Host "retainBuild set to: $retainBuild (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
   displayName: Compute retention decision
   condition: succeeded()
 

--- a/eng/docker-tools/templates/steps/retain-build.yml
+++ b/eng/docker-tools/templates/steps/retain-build.yml
@@ -14,9 +14,10 @@ steps:
       }
     }
     
-    $shouldRetain = ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
+    # INVERTED FOR TESTING: retain dev/ builds instead of official builds
+    $shouldRetain = ($isOfficialDefinition -and $sourceBranch.StartsWith("dev/"))
     echo "##vso[task.setvariable variable=shouldRetainBuild]$shouldRetain"
-    Write-Host "shouldRetainBuild set to: $shouldRetain (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
+    Write-Host "shouldRetainBuild set to: $shouldRetain (inverted test mode: retain dev/ branches)"
   displayName: Compute retention decision
   condition: succeeded()
 

--- a/eng/pipeline/go-docker-rolling-internal-pipeline-unofficial.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline-unofficial.yml
@@ -63,6 +63,7 @@ extends:
             versionsRepoRef: VersionsRepo
             noCache: true
             customGenerateMatrixInitSteps:
+              - template: /eng/pipeline/steps/set-retain-build-var.yml@self
               - template: /eng/pipeline/steps/set-public-source-branch-var.yml@self
             customBuildInitSteps:
               - template: /eng/pipeline/steps/set-imagebuilder-build-args-var.yml@self

--- a/eng/pipeline/go-docker-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline.yml
@@ -69,6 +69,7 @@ extends:
             versionsRepoRef: VersionsRepo
             noCache: true
             customGenerateMatrixInitSteps:
+              - template: /eng/pipeline/steps/set-retain-build-var.yml@self
               - template: /eng/pipeline/steps/set-public-source-branch-var.yml@self
             customBuildInitSteps:
               - template: /eng/pipeline/steps/set-imagebuilder-build-args-var.yml@self

--- a/eng/pipeline/go-docker-rolling-internal.gen.yml
+++ b/eng/pipeline/go-docker-rolling-internal.gen.yml
@@ -90,6 +90,7 @@ extends:
             versionsRepoRef: VersionsRepo
             noCache: true
             customGenerateMatrixInitSteps:
+              - template: /eng/pipeline/steps/set-retain-build-var.yml@self
               - template: /eng/pipeline/steps/set-public-source-branch-var.yml@self
             customBuildInitSteps:
               - template: /eng/pipeline/steps/set-imagebuilder-build-args-var.yml@self

--- a/eng/pipeline/steps/set-retain-build-var.yml
+++ b/eng/pipeline/steps/set-retain-build-var.yml
@@ -1,0 +1,39 @@
+# Compute the "retainBuild" pipeline variable consumed by the docker-tools
+# retain-build step (eng/docker-tools/templates/steps/retain-build.yml). When
+# this variable is set to the string "true", the docker-tools step calls
+# Retain-Build.ps1 to mark the build with keepForever=true.
+#
+# We compute it here (outside of eng/docker-tools) because that directory is
+# synced from dotnet/docker-tools and any local edits would be overwritten.
+#
+# Retention triggers when:
+#   - the caller explicitly passed retainBuild=true as a queue-time variable, or
+#   - this is an official pipeline definition AND the source branch matches one
+#     of the configured official branches/prefixes.
+steps:
+- powershell: |
+    $isOfficialDefinition = -not "$(Build.DefinitionName)".EndsWith("(unofficial)")
+    $officialBranchList = "$(officialBranches)"
+    $sourceBranch = "$(sourceBranch)"
+    $officialBranchPrefixes = "$(officialBranchPrefixes)"
+
+    $isOfficialBranch = $officialBranchList.Split(',').Trim() -contains $sourceBranch
+    $hasOfficialPrefix = $false
+    foreach ($prefix in $officialBranchPrefixes.Split(',').Trim() | Where-Object { $_ }) {
+      if ($sourceBranch.StartsWith($prefix)) {
+        $hasOfficialPrefix = $true
+        break
+      }
+    }
+
+    # Retain when explicitly requested or when this is an official branch build.
+    $retainBuildOverride = "$env:RETAIN_BUILD_OVERRIDE".Trim().ToLowerInvariant()
+    $retainBuild = ($retainBuildOverride -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
+    $retainBuildValue = if ($retainBuild) { "true" } else { "false" }
+
+    echo "##vso[task.setvariable variable=retainBuild]$retainBuildValue"
+    Write-Host "retainBuild set to: $retainBuildValue (official def: $isOfficialDefinition, official branch: $isOfficialBranch, has prefix: $hasOfficialPrefix)"
+  env:
+    RETAIN_BUILD_OVERRIDE: $(retainBuild)
+  displayName: Compute retention decision
+  condition: succeeded()

--- a/eng/pipeline/steps/set-retain-build-var.yml
+++ b/eng/pipeline/steps/set-retain-build-var.yml
@@ -27,8 +27,9 @@ steps:
     }
 
     # Retain when explicitly requested or when this is an official branch build.
+    # NOTE: temporarily inverted for pipeline validation. Revert before merge.
     $retainBuildOverride = "$env:RETAIN_BUILD_OVERRIDE".Trim().ToLowerInvariant()
-    $retainBuild = ($retainBuildOverride -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
+    $retainBuild = -not ( ($retainBuildOverride -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix)) )
     $retainBuildValue = if ($retainBuild) { "true" } else { "false" }
 
     echo "##vso[task.setvariable variable=retainBuild]$retainBuildValue"

--- a/eng/pipeline/steps/set-retain-build-var.yml
+++ b/eng/pipeline/steps/set-retain-build-var.yml
@@ -27,9 +27,8 @@ steps:
     }
 
     # Retain when explicitly requested or when this is an official branch build.
-    # NOTE: temporarily inverted for pipeline validation. Revert before merge.
     $retainBuildOverride = "$env:RETAIN_BUILD_OVERRIDE".Trim().ToLowerInvariant()
-    $retainBuild = -not ( ($retainBuildOverride -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix)) )
+    $retainBuild = ($retainBuildOverride -eq "true") -or ($isOfficialDefinition -and ($isOfficialBranch -or $hasOfficialPrefix))
     $retainBuildValue = if ($retainBuild) { "true" } else { "false" }
 
     echo "##vso[task.setvariable variable=retainBuild]$retainBuildValue"


### PR DESCRIPTION
This pull request updates the build retention logic in the `eng/docker-tools/templates/steps/retain-build.yml` file to make retention decisions more robust and configurable. The main improvement is the addition of a PowerShell step that computes whether the build should be retained based on the build definition, branch, and explicit retention requests.

**Build retention logic improvements:**

* Added a PowerShell step (`Compute retention decision`) that sets the `retainBuild` variable based on whether the build is from an official definition, is on an official branch, or has an official branch prefix, or if retention was explicitly requested.
* Updated the condition for the `Enable permanent build retention` step to only run when `retainBuild` is true, ensuring that only qualifying builds are retained.
* Improved logging and documentation to clarify the retention decision process and make debugging easier.

Tested by setting dev builds to not retain and then inverting: 
- Not retained: https://dev.azure.com/dnceng/internal/_build/results?buildId=2980623&view=results
- Retained: https://dev.azure.com/dnceng/internal/_build/results?buildId=2980486&view=results

- https://github.com/microsoft/go-lab/issues/59?reload=1?reload=1