### PR TITLE
Use ONEESPT_BUILDTYPE for official vs unofficial detection

### DIFF
--- a/eng/pipeline/steps/set-retain-build-var.yml
+++ b/eng/pipeline/steps/set-retain-build-var.yml
@@ -12,7 +12,12 @@
 #     of the configured official branches/prefixes.
 steps:
 - powershell: |
-    $isOfficialDefinition = -not "$(Build.DefinitionName)".EndsWith("(unofficial)")
+    # Use the 1ESPT-provided ONEESPT_BUILDTYPE env var as the source of truth
+    # for official vs unofficial, matching how docker-tools' validate-branch.yml
+    # and set-dry-run.yml decide. The Build.DefinitionName suffix convention is
+    # human-set and case-sensitive, so relying on it can permanently retain
+    # builds from an unofficial pipeline with a non-conforming name.
+    $isOfficialDefinition = "$env:ONEESPT_BUILDTYPE" -ne "Unofficial"
     $officialBranchList = "$(officialBranches)"
     $sourceBranch = "$(sourceBranch)"
     $officialBranchPrefixes = "$(officialBranchPrefixes)"


### PR DESCRIPTION
This pull request updates the logic for determining official vs. unofficial builds in the `set-retain-build-var.yml` pipeline step. The change switches the source of truth from a naming convention on `Build.DefinitionName` to the `ONEESPT_BUILDTYPE` environment variable, which is more reliable and consistent with other pipeline steps.

Pipeline reliability improvement:

* [`eng/pipeline/steps/set-retain-build-var.yml`](diffhunk://#diff-574c1e7299056b204329f0a8babe385beb366ef7476c9bf187fa97f0ccc548ecL15-R20): Updated the method for identifying official builds to use the `ONEESPT_BUILDTYPE` environment variable instead of relying on the case-sensitive and human-set `Build.DefinitionName` suffix. This prevents unofficial pipelines with non-conforming names from being incorrectly retained.