### PR TITLE
Disable scheduled builds using yml

### DIFF
--- a/eng/pipeline/go-docker-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline.yml
@@ -7,13 +7,7 @@
 
 trigger: none
 pr: none
-schedules:
-  - cron: '0 10 * * Mon,Wed'
-    displayName: Periodic build to refresh dependencies
-    branches:
-      include:
-        - microsoft/main
-    always: true
+schedules: []
 parameters:
   - name: sourceBuildPipelineRunId
     displayName: >

--- a/eng/pipeline/go-docker-rolling-internal.gen.yml
+++ b/eng/pipeline/go-docker-rolling-internal.gen.yml
@@ -7,15 +7,17 @@ pipelineymlgen:
     - file: go-docker-rolling-internal-pipeline-unofficial.yml
       data:
         official: false
+        schedule: false
     - file: go-docker-rolling-internal-pipeline.yml
       data:
         official: true
+        schedule: false
 ---
 
 trigger: none
 pr: none
 schedules:
-  - ${ inlineif .official }:
+  - ${ inlineif (and .official .schedule) }:
     - cron: '0 10 * * Mon,Wed'
       displayName: Periodic build to refresh dependencies
       branches:


### PR DESCRIPTION
Change the yml to remove the trigger. Schedules can't be disabled on the AzDO pipeline UI side in a way that still allows us (or release automation) to manually queue builds, so we must change it here.

* For https://github.com/microsoft/go/issues/2313
* Interrupted https://github.com/microsoft/go/issues/2339