### PR TITLE
Refresh CA roots to fix debian arm flakiness

### DIFF
--- a/patches/0008-Refresh-CA-roots.patch
+++ b/patches/0008-Refresh-CA-roots.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
+Date: Mon, 15 Jun 2026 15:12:21 -0700
+Subject: [PATCH] Refresh CA roots
+
+Out of date CA roots in the build stage may cause download.microsoft.com to not
+be trusted, making Microsoft build of Go related downloads fail.
+
+This problem surfaced as flakiness in arm builds: https://github.com/microsoft/go-lab/issues/423
+---
+ Dockerfile-linux.template | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
+index dac1b87022f002..f47c01ea1c23ac 100644
+--- a/Dockerfile-linux.template
++++ b/Dockerfile-linux.template
+@@ -40,6 +40,12 @@ RUN set -eux; \
+ 	tdnf clean all
+ {{ ) else ( -}}
+ FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:{{ env.variant }}-scm AS build
++
++# Refresh CA roots before fetching Microsoft-hosted Go artifacts.
++RUN set -eux; \
++	apt-get update; \
++	apt-get install -y --no-install-recommends ca-certificates; \
++	rm -rf /var/lib/apt/lists/*
+ {{ ) end -}}
+ 
+ ENV PATH /usr/local/go/bin:$PATH

--- a/src/microsoft/1.25/bookworm/Dockerfile
+++ b/src/microsoft/1.25/bookworm/Dockerfile
@@ -6,6 +6,12 @@
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm AS build
 
+# Refresh CA roots before fetching Microsoft-hosted Go artifacts.
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends ca-certificates; \
+	rm -rf /var/lib/apt/lists/*
+
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.25.11

--- a/src/microsoft/1.25/bullseye/Dockerfile
+++ b/src/microsoft/1.25/bullseye/Dockerfile
@@ -6,6 +6,12 @@
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm AS build
 
+# Refresh CA roots before fetching Microsoft-hosted Go artifacts.
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends ca-certificates; \
+	rm -rf /var/lib/apt/lists/*
+
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.25.11

--- a/src/microsoft/1.26/bookworm/Dockerfile
+++ b/src/microsoft/1.26/bookworm/Dockerfile
@@ -6,6 +6,12 @@
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm-scm AS build
 
+# Refresh CA roots before fetching Microsoft-hosted Go artifacts.
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends ca-certificates; \
+	rm -rf /var/lib/apt/lists/*
+
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.26.4

--- a/src/microsoft/1.26/bullseye/Dockerfile
+++ b/src/microsoft/1.26/bullseye/Dockerfile
@@ -6,6 +6,12 @@
 
 FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye-scm AS build
 
+# Refresh CA roots before fetching Microsoft-hosted Go artifacts.
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends ca-certificates; \
+	rm -rf /var/lib/apt/lists/*
+
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.26.4


### PR DESCRIPTION
Add patch:

> Refresh CA roots
> 
> Out of date CA roots in the build stage may cause download.microsoft.com to not
> be trusted, making Microsoft build of Go related downloads fail.
> 
> This problem surfaced as flakiness in arm builds: https://github.com/microsoft/go-lab/issues/423

However, I'm not sure yet if this actually fixes it. My detailed runs with extra diagnostic steps were interrupted by an ongoing MCR outage. But: we can merge this optimistically if it even helps pass CI. The change is only in the builder stage, so it doesn't even affect the final image size. As long as that works, I don't plan to retry the detailed diagnostics, to save time.