### PR TITLE
Vendor our public key, improve patch description

### DIFF
--- a/patches/0001-Check-signature-of-microsoft-go-builds.patch
+++ b/patches/0001-Check-signature-of-microsoft-go-builds.patch
@@ -3,15 +3,21 @@ From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Fri, 11 Feb 2022 18:03:46 -0600
 Subject: [PATCH] Check signature of microsoft/go builds
 
-Microsoft build of Go artifacts on download.visualstudio.microsoft.com don't
-support ".sig" suffix: the base URL also changes. Use the
-pgpSignatureUrl entry present in the Microsoft build of Go versions.json instead.
+Import the Microsoft build of Go signature (vendored) to use to verify
+the Go artifacts.
+
+Wire in the signature files for the Microsoft build of Go. Unlike
+upstream's endpoint, the artifacts on
+download.visualstudio.microsoft.com don't support adding a ".sig" suffix
+to the main tar.gz file URL. Other parts of the URL are random strings
+that are unique for each file. So, use the pgpSignatureUrl entry present
+in the Microsoft build of Go versions.json.
 ---
- Dockerfile-linux.template | 6 +++++-
- 1 file changed, 5 insertions(+), 1 deletion(-)
+ Dockerfile-linux.template | 31 ++++++++++++++++++++++++++++++-
+ 1 file changed, 30 insertions(+), 1 deletion(-)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index a2a8db8d6fa7e7..19d45e2048b326 100644
+index 6af4ce94203d7b..603f1e33d2f51a 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
 @@ -78,6 +78,7 @@ RUN set -eux; \
@@ -30,7 +36,7 @@ index a2a8db8d6fa7e7..19d45e2048b326 100644
  			sha256={{ .sha256 | @sh }}; \
  {{ ) else ( -}}
  			export {{ .env | to_entries | sort_by(.key) | map(.key + "=" + (.value | @sh)) | join(" ") }}; \
-@@ -108,12 +110,14 @@ RUN set -eux; \
+@@ -108,12 +110,39 @@ RUN set -eux; \
  	esac; \
  	\
  {{ if env.version != "tip" then ( -}}
@@ -41,7 +47,32 @@ index a2a8db8d6fa7e7..19d45e2048b326 100644
  	\
  # https://github.com/golang/go/issues/14739#issuecomment-324767697
  	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-+	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
++# Vendor the Microsoft build of Go signature. See https://github.com/microsoft/go-lab/issues/423
++	printf '%s\n' \
++		'-----BEGIN PGP PUBLIC KEY BLOCK-----' \
++		'Version: BSN Pgp v1.1.0.0' \
++		'' \
++		'mQENBGBt3ocBCAC0eCjRdhrHwMGh4pxw/JFulp+QcqymS9eYr7leZutRB9CpjW4O' \
++		'lXUzHzr8nIKoTbgNiak5Ws80LYvoPHwUjKqVypeRqG1vHoWzwy1t5U6imtcCspLK' \
++		'nbqkx2JFG6zcG5Dve4Kp1VeiJBQ+SwVaZfwEFFPDeCFqg2MptC7xIka2WqSTXZyL' \
++		'3PY/hNKXVeBJEg/et31FLZxWVr4/AJszu+aqhNqVMsqM8ldQF4QwVmoJQjCS/+Uy' \
++		'Nw8Dt/THbaFQvn5Tnio3Yjc+7wiKhcE1JQAi5Cj/lTFQHLGTCm21c1fJ5HTI+pTt' \
++		'O+HwJg4Wj3DEn7o+5VXj5JBtPmDxU0U6cR3vABEBAAG0QE1hbmFnZWQgTGFuZ3Vh' \
++		'Z2VzIENvbXBpbGVyIERldiBUZWFtIDxtbGFuZ2NvbXBkZXZAbWljcm9zb2Z0LmNv' \
++		'bT6JATgEEwEIACIFAmBt3ocCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJ' \
++		'EIEQBTR7jnMsdlQH/1XJO01wECeC1AMIQhNJueb5hBv+7AfSeKF36uQuX9rx5Lxp' \
++		'hBgb9x3iEK5CE+xDtLmXx2yJZJIUtLbqxXhAa0Ph1dyLXRKAbVgv3dPlsAzPusMu' \
++		'GjTyGeHNAVwodyTp3pggxzWtjoBGnVxpCNpqVDlepzoyBAfP51dd0oQ2JBfaBpNP' \
++		'ft04A69W8eS/6pwFvUL5g5zPvczsBJmqMmSiDrNKeSa68/2k9ey1DlbhfA3FPPUx' \
++		'13xCFv9pwieHHSyunbTbLzPnfRVdSlA16W7WT9aeF46R4/QyHc4AeU1p8HJtlDPz' \
++		'jy3zx0Vd4u+rvgekEhHI7zFyHIdwHWD3UoV9Flk=' \
++		'=EZkZ' \
++		'-----END PGP PUBLIC KEY BLOCK-----' \
++		> microsoft-managed-lang-compiler.asc; \
++	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
++		| grep -q '^fpr:::::::::B035FAC203AB9A45AAC802B4811005347B8E732C:$'; \
++	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
++		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
 +	gpg --batch --import microsoft-managed-lang-compiler.asc; \
  # https://www.google.com/linuxrepositories/
  	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \

--- a/patches/0001-Check-signature-of-microsoft-go-builds.patch
+++ b/patches/0001-Check-signature-of-microsoft-go-builds.patch
@@ -3,8 +3,8 @@ From: bot-for-go[bot] <199222863+bot-for-go[bot]@users.noreply.github.com>
 Date: Fri, 11 Feb 2022 18:03:46 -0600
 Subject: [PATCH] Check signature of microsoft/go builds
 
-Import the Microsoft build of Go signature (vendored) to use to verify
-the Go artifacts.
+Import the Microsoft build of Go public key (vendored)
+to use to verify the Go artifacts.
 
 Wire in the signature files for the Microsoft build of Go. Unlike
 upstream's endpoint, the artifacts on
@@ -13,11 +13,11 @@ to the main tar.gz file URL. Other parts of the URL are random strings
 that are unique for each file. So, use the pgpSignatureUrl entry present
 in the Microsoft build of Go versions.json.
 ---
- Dockerfile-linux.template | 31 ++++++++++++++++++++++++++++++-
- 1 file changed, 30 insertions(+), 1 deletion(-)
+ Dockerfile-linux.template | 32 +++++++++++++++++++++++++++++++-
+ 1 file changed, 31 insertions(+), 1 deletion(-)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index 6af4ce94203d7b..603f1e33d2f51a 100644
+index 6af4ce94203d7b..e6c70a00b82f3b 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
 @@ -78,6 +78,7 @@ RUN set -eux; \
@@ -36,7 +36,7 @@ index 6af4ce94203d7b..603f1e33d2f51a 100644
  			sha256={{ .sha256 | @sh }}; \
  {{ ) else ( -}}
  			export {{ .env | to_entries | sort_by(.key) | map(.key + "=" + (.value | @sh)) | join(" ") }}; \
-@@ -108,12 +110,39 @@ RUN set -eux; \
+@@ -108,12 +110,40 @@ RUN set -eux; \
  	esac; \
  	\
  {{ if env.version != "tip" then ( -}}
@@ -47,7 +47,7 @@ index 6af4ce94203d7b..603f1e33d2f51a 100644
  	\
  # https://github.com/golang/go/issues/14739#issuecomment-324767697
  	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-+# Vendor the Microsoft build of Go signature. See https://github.com/microsoft/go-lab/issues/423
++# Vendor the Microsoft build of Go public key. See https://github.com/microsoft/go-lab/issues/423
 +	printf '%s\n' \
 +		'-----BEGIN PGP PUBLIC KEY BLOCK-----' \
 +		'Version: BSN Pgp v1.1.0.0' \
@@ -69,11 +69,12 @@ index 6af4ce94203d7b..603f1e33d2f51a 100644
 +		'=EZkZ' \
 +		'-----END PGP PUBLIC KEY BLOCK-----' \
 +		> microsoft-managed-lang-compiler.asc; \
-+	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
++	gpg --batch --show-keys --with-colons --with-fingerprint microsoft-managed-lang-compiler.asc \
 +		| grep -q '^fpr:::::::::B035FAC203AB9A45AAC802B4811005347B8E732C:$'; \
-+	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
++	gpg --batch --show-keys --with-colons --with-fingerprint microsoft-managed-lang-compiler.asc \
 +		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
 +	gpg --batch --import microsoft-managed-lang-compiler.asc; \
++	rm microsoft-managed-lang-compiler.asc; \
  # https://www.google.com/linuxrepositories/
  	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
  # let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it

--- a/patches/0002-Add-Azure-Linux-FIPS-package-upgrade.patch
+++ b/patches/0002-Add-Azure-Linux-FIPS-package-upgrade.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Add Azure Linux, FIPS, package upgrade
  1 file changed, 104 insertions(+), 1 deletion(-)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index 603f1e33d2f51a..9fdc1986aa25cc 100644
+index e6c70a00b82f3b..b35f48860f584d 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
 @@ -4,9 +4,40 @@
@@ -88,10 +88,10 @@ index 603f1e33d2f51a..9fdc1986aa25cc 100644
  	echo "$sha256 *go.tgz" | sha256sum -c -; \
  	\
  # https://github.com/golang/go/issues/14739#issuecomment-324767697
-@@ -143,10 +187,16 @@ RUN set -eux; \
- 	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+@@ -144,10 +188,16 @@ RUN set -eux; \
  		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
  	gpg --batch --import microsoft-managed-lang-compiler.asc; \
+ 	rm microsoft-managed-lang-compiler.asc; \
 +{{ if is_azurelinux then ( -}}
 +# Azure Linux doesn't include dirmngr, which is required for keyserver import. Skipping keyserver
 +# import. In microsoft/go-images, we use a manually imported key anyway.
@@ -105,7 +105,7 @@ index 603f1e33d2f51a..9fdc1986aa25cc 100644
  	gpg --batch --verify go.tgz.asc go.tgz; \
  	gpgconf --kill all; \
  	rm -rf "$GNUPGHOME" go.tgz.asc; \
-@@ -241,18 +291,71 @@ RUN set -eux; \
+@@ -242,18 +292,71 @@ RUN set -eux; \
  FROM alpine:{{ alpine_version }}
  
  RUN apk add --no-cache ca-certificates

--- a/patches/0002-Add-Azure-Linux-FIPS-package-upgrade.patch
+++ b/patches/0002-Add-Azure-Linux-FIPS-package-upgrade.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Add Azure Linux, FIPS, package upgrade
  1 file changed, 104 insertions(+), 1 deletion(-)
 
 diff --git a/Dockerfile-linux.template b/Dockerfile-linux.template
-index efec1b701b447d..46c947e7cfbe24 100644
+index 603f1e33d2f51a..9fdc1986aa25cc 100644
 --- a/Dockerfile-linux.template
 +++ b/Dockerfile-linux.template
 @@ -4,9 +4,40 @@
@@ -75,7 +75,7 @@ index efec1b701b447d..46c947e7cfbe24 100644
  {{ ) else ( -}}
  	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
  {{ ) end -}}
-@@ -111,17 +151,27 @@ RUN set -eux; \
+@@ -111,7 +151,11 @@ RUN set -eux; \
  	\
  {{ if env.version != "tip" then ( -}}
  	wget -O go.tgz.asc "$urlSig"; \
@@ -88,8 +88,9 @@ index efec1b701b447d..46c947e7cfbe24 100644
  	echo "$sha256 *go.tgz" | sha256sum -c -; \
  	\
  # https://github.com/golang/go/issues/14739#issuecomment-324767697
- 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
- 	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
+@@ -143,10 +187,16 @@ RUN set -eux; \
+ 	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+ 		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
  	gpg --batch --import microsoft-managed-lang-compiler.asc; \
 +{{ if is_azurelinux then ( -}}
 +# Azure Linux doesn't include dirmngr, which is required for keyserver import. Skipping keyserver
@@ -104,7 +105,7 @@ index efec1b701b447d..46c947e7cfbe24 100644
  	gpg --batch --verify go.tgz.asc go.tgz; \
  	gpgconf --kill all; \
  	rm -rf "$GNUPGHOME" go.tgz.asc; \
-@@ -216,18 +266,71 @@ RUN set -eux; \
+@@ -241,18 +291,71 @@ RUN set -eux; \
  FROM alpine:{{ alpine_version }}
  
  RUN apk add --no-cache ca-certificates

--- a/src/microsoft/1.25/azurelinux3.0/Dockerfile
+++ b/src/microsoft/1.25/azurelinux3.0/Dockerfile
@@ -55,7 +55,32 @@ RUN set -eux; \
 	\
 # https://github.com/golang/go/issues/14739#issuecomment-324767697
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
+# Vendor the Microsoft build of Go signature. See https://github.com/microsoft/go-lab/issues/423
+	printf '%s\n' \
+		'-----BEGIN PGP PUBLIC KEY BLOCK-----' \
+		'Version: BSN Pgp v1.1.0.0' \
+		'' \
+		'mQENBGBt3ocBCAC0eCjRdhrHwMGh4pxw/JFulp+QcqymS9eYr7leZutRB9CpjW4O' \
+		'lXUzHzr8nIKoTbgNiak5Ws80LYvoPHwUjKqVypeRqG1vHoWzwy1t5U6imtcCspLK' \
+		'nbqkx2JFG6zcG5Dve4Kp1VeiJBQ+SwVaZfwEFFPDeCFqg2MptC7xIka2WqSTXZyL' \
+		'3PY/hNKXVeBJEg/et31FLZxWVr4/AJszu+aqhNqVMsqM8ldQF4QwVmoJQjCS/+Uy' \
+		'Nw8Dt/THbaFQvn5Tnio3Yjc+7wiKhcE1JQAi5Cj/lTFQHLGTCm21c1fJ5HTI+pTt' \
+		'O+HwJg4Wj3DEn7o+5VXj5JBtPmDxU0U6cR3vABEBAAG0QE1hbmFnZWQgTGFuZ3Vh' \
+		'Z2VzIENvbXBpbGVyIERldiBUZWFtIDxtbGFuZ2NvbXBkZXZAbWljcm9zb2Z0LmNv' \
+		'bT6JATgEEwEIACIFAmBt3ocCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJ' \
+		'EIEQBTR7jnMsdlQH/1XJO01wECeC1AMIQhNJueb5hBv+7AfSeKF36uQuX9rx5Lxp' \
+		'hBgb9x3iEK5CE+xDtLmXx2yJZJIUtLbqxXhAa0Ph1dyLXRKAbVgv3dPlsAzPusMu' \
+		'GjTyGeHNAVwodyTp3pggxzWtjoBGnVxpCNpqVDlepzoyBAfP51dd0oQ2JBfaBpNP' \
+		'ft04A69W8eS/6pwFvUL5g5zPvczsBJmqMmSiDrNKeSa68/2k9ey1DlbhfA3FPPUx' \
+		'13xCFv9pwieHHSyunbTbLzPnfRVdSlA16W7WT9aeF46R4/QyHc4AeU1p8HJtlDPz' \
+		'jy3zx0Vd4u+rvgekEhHI7zFyHIdwHWD3UoV9Flk=' \
+		'=EZkZ' \
+		'-----END PGP PUBLIC KEY BLOCK-----' \
+		> microsoft-managed-lang-compiler.asc; \
+	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+		| grep -q '^fpr:::::::::B035FAC203AB9A45AAC802B4811005347B8E732C:$'; \
+	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
 # Azure Linux doesn't include dirmngr, which is required for keyserver import. Skipping keyserver
 # import. In microsoft/go-images, we use a manually imported key anyway.

--- a/src/microsoft/1.25/azurelinux3.0/Dockerfile
+++ b/src/microsoft/1.25/azurelinux3.0/Dockerfile
@@ -55,7 +55,7 @@ RUN set -eux; \
 	\
 # https://github.com/golang/go/issues/14739#issuecomment-324767697
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-# Vendor the Microsoft build of Go signature. See https://github.com/microsoft/go-lab/issues/423
+# Vendor the Microsoft build of Go public key. See https://github.com/microsoft/go-lab/issues/423
 	printf '%s\n' \
 		'-----BEGIN PGP PUBLIC KEY BLOCK-----' \
 		'Version: BSN Pgp v1.1.0.0' \
@@ -77,11 +77,12 @@ RUN set -eux; \
 		'=EZkZ' \
 		'-----END PGP PUBLIC KEY BLOCK-----' \
 		> microsoft-managed-lang-compiler.asc; \
-	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+	gpg --batch --show-keys --with-colons --with-fingerprint microsoft-managed-lang-compiler.asc \
 		| grep -q '^fpr:::::::::B035FAC203AB9A45AAC802B4811005347B8E732C:$'; \
-	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+	gpg --batch --show-keys --with-colons --with-fingerprint microsoft-managed-lang-compiler.asc \
 		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
+	rm microsoft-managed-lang-compiler.asc; \
 # Azure Linux doesn't include dirmngr, which is required for keyserver import. Skipping keyserver
 # import. In microsoft/go-images, we use a manually imported key anyway.
 # See https://microsoft.visualstudio.com/OS/_workitems/edit/62225284

--- a/src/microsoft/1.25/bookworm/Dockerfile
+++ b/src/microsoft/1.25/bookworm/Dockerfile
@@ -46,7 +46,32 @@ RUN set -eux; \
 	\
 # https://github.com/golang/go/issues/14739#issuecomment-324767697
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
+# Vendor the Microsoft build of Go signature. See https://github.com/microsoft/go-lab/issues/423
+	printf '%s\n' \
+		'-----BEGIN PGP PUBLIC KEY BLOCK-----' \
+		'Version: BSN Pgp v1.1.0.0' \
+		'' \
+		'mQENBGBt3ocBCAC0eCjRdhrHwMGh4pxw/JFulp+QcqymS9eYr7leZutRB9CpjW4O' \
+		'lXUzHzr8nIKoTbgNiak5Ws80LYvoPHwUjKqVypeRqG1vHoWzwy1t5U6imtcCspLK' \
+		'nbqkx2JFG6zcG5Dve4Kp1VeiJBQ+SwVaZfwEFFPDeCFqg2MptC7xIka2WqSTXZyL' \
+		'3PY/hNKXVeBJEg/et31FLZxWVr4/AJszu+aqhNqVMsqM8ldQF4QwVmoJQjCS/+Uy' \
+		'Nw8Dt/THbaFQvn5Tnio3Yjc+7wiKhcE1JQAi5Cj/lTFQHLGTCm21c1fJ5HTI+pTt' \
+		'O+HwJg4Wj3DEn7o+5VXj5JBtPmDxU0U6cR3vABEBAAG0QE1hbmFnZWQgTGFuZ3Vh' \
+		'Z2VzIENvbXBpbGVyIERldiBUZWFtIDxtbGFuZ2NvbXBkZXZAbWljcm9zb2Z0LmNv' \
+		'bT6JATgEEwEIACIFAmBt3ocCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJ' \
+		'EIEQBTR7jnMsdlQH/1XJO01wECeC1AMIQhNJueb5hBv+7AfSeKF36uQuX9rx5Lxp' \
+		'hBgb9x3iEK5CE+xDtLmXx2yJZJIUtLbqxXhAa0Ph1dyLXRKAbVgv3dPlsAzPusMu' \
+		'GjTyGeHNAVwodyTp3pggxzWtjoBGnVxpCNpqVDlepzoyBAfP51dd0oQ2JBfaBpNP' \
+		'ft04A69W8eS/6pwFvUL5g5zPvczsBJmqMmSiDrNKeSa68/2k9ey1DlbhfA3FPPUx' \
+		'13xCFv9pwieHHSyunbTbLzPnfRVdSlA16W7WT9aeF46R4/QyHc4AeU1p8HJtlDPz' \
+		'jy3zx0Vd4u+rvgekEhHI7zFyHIdwHWD3UoV9Flk=' \
+		'=EZkZ' \
+		'-----END PGP PUBLIC KEY BLOCK-----' \
+		> microsoft-managed-lang-compiler.asc; \
+	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+		| grep -q '^fpr:::::::::B035FAC203AB9A45AAC802B4811005347B8E732C:$'; \
+	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \

--- a/src/microsoft/1.25/bookworm/Dockerfile
+++ b/src/microsoft/1.25/bookworm/Dockerfile
@@ -46,7 +46,7 @@ RUN set -eux; \
 	\
 # https://github.com/golang/go/issues/14739#issuecomment-324767697
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-# Vendor the Microsoft build of Go signature. See https://github.com/microsoft/go-lab/issues/423
+# Vendor the Microsoft build of Go public key. See https://github.com/microsoft/go-lab/issues/423
 	printf '%s\n' \
 		'-----BEGIN PGP PUBLIC KEY BLOCK-----' \
 		'Version: BSN Pgp v1.1.0.0' \
@@ -68,11 +68,12 @@ RUN set -eux; \
 		'=EZkZ' \
 		'-----END PGP PUBLIC KEY BLOCK-----' \
 		> microsoft-managed-lang-compiler.asc; \
-	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+	gpg --batch --show-keys --with-colons --with-fingerprint microsoft-managed-lang-compiler.asc \
 		| grep -q '^fpr:::::::::B035FAC203AB9A45AAC802B4811005347B8E732C:$'; \
-	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+	gpg --batch --show-keys --with-colons --with-fingerprint microsoft-managed-lang-compiler.asc \
 		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
+	rm microsoft-managed-lang-compiler.asc; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
 # let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it

--- a/src/microsoft/1.25/bullseye/Dockerfile
+++ b/src/microsoft/1.25/bullseye/Dockerfile
@@ -46,7 +46,32 @@ RUN set -eux; \
 	\
 # https://github.com/golang/go/issues/14739#issuecomment-324767697
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
+# Vendor the Microsoft build of Go signature. See https://github.com/microsoft/go-lab/issues/423
+	printf '%s\n' \
+		'-----BEGIN PGP PUBLIC KEY BLOCK-----' \
+		'Version: BSN Pgp v1.1.0.0' \
+		'' \
+		'mQENBGBt3ocBCAC0eCjRdhrHwMGh4pxw/JFulp+QcqymS9eYr7leZutRB9CpjW4O' \
+		'lXUzHzr8nIKoTbgNiak5Ws80LYvoPHwUjKqVypeRqG1vHoWzwy1t5U6imtcCspLK' \
+		'nbqkx2JFG6zcG5Dve4Kp1VeiJBQ+SwVaZfwEFFPDeCFqg2MptC7xIka2WqSTXZyL' \
+		'3PY/hNKXVeBJEg/et31FLZxWVr4/AJszu+aqhNqVMsqM8ldQF4QwVmoJQjCS/+Uy' \
+		'Nw8Dt/THbaFQvn5Tnio3Yjc+7wiKhcE1JQAi5Cj/lTFQHLGTCm21c1fJ5HTI+pTt' \
+		'O+HwJg4Wj3DEn7o+5VXj5JBtPmDxU0U6cR3vABEBAAG0QE1hbmFnZWQgTGFuZ3Vh' \
+		'Z2VzIENvbXBpbGVyIERldiBUZWFtIDxtbGFuZ2NvbXBkZXZAbWljcm9zb2Z0LmNv' \
+		'bT6JATgEEwEIACIFAmBt3ocCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJ' \
+		'EIEQBTR7jnMsdlQH/1XJO01wECeC1AMIQhNJueb5hBv+7AfSeKF36uQuX9rx5Lxp' \
+		'hBgb9x3iEK5CE+xDtLmXx2yJZJIUtLbqxXhAa0Ph1dyLXRKAbVgv3dPlsAzPusMu' \
+		'GjTyGeHNAVwodyTp3pggxzWtjoBGnVxpCNpqVDlepzoyBAfP51dd0oQ2JBfaBpNP' \
+		'ft04A69W8eS/6pwFvUL5g5zPvczsBJmqMmSiDrNKeSa68/2k9ey1DlbhfA3FPPUx' \
+		'13xCFv9pwieHHSyunbTbLzPnfRVdSlA16W7WT9aeF46R4/QyHc4AeU1p8HJtlDPz' \
+		'jy3zx0Vd4u+rvgekEhHI7zFyHIdwHWD3UoV9Flk=' \
+		'=EZkZ' \
+		'-----END PGP PUBLIC KEY BLOCK-----' \
+		> microsoft-managed-lang-compiler.asc; \
+	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+		| grep -q '^fpr:::::::::B035FAC203AB9A45AAC802B4811005347B8E732C:$'; \
+	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \

--- a/src/microsoft/1.25/bullseye/Dockerfile
+++ b/src/microsoft/1.25/bullseye/Dockerfile
@@ -46,7 +46,7 @@ RUN set -eux; \
 	\
 # https://github.com/golang/go/issues/14739#issuecomment-324767697
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-# Vendor the Microsoft build of Go signature. See https://github.com/microsoft/go-lab/issues/423
+# Vendor the Microsoft build of Go public key. See https://github.com/microsoft/go-lab/issues/423
 	printf '%s\n' \
 		'-----BEGIN PGP PUBLIC KEY BLOCK-----' \
 		'Version: BSN Pgp v1.1.0.0' \
@@ -68,11 +68,12 @@ RUN set -eux; \
 		'=EZkZ' \
 		'-----END PGP PUBLIC KEY BLOCK-----' \
 		> microsoft-managed-lang-compiler.asc; \
-	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+	gpg --batch --show-keys --with-colons --with-fingerprint microsoft-managed-lang-compiler.asc \
 		| grep -q '^fpr:::::::::B035FAC203AB9A45AAC802B4811005347B8E732C:$'; \
-	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+	gpg --batch --show-keys --with-colons --with-fingerprint microsoft-managed-lang-compiler.asc \
 		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
+	rm microsoft-managed-lang-compiler.asc; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
 # let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it

--- a/src/microsoft/1.26/azurelinux3.0/Dockerfile
+++ b/src/microsoft/1.26/azurelinux3.0/Dockerfile
@@ -55,7 +55,32 @@ RUN set -eux; \
 	\
 # https://github.com/golang/go/issues/14739#issuecomment-324767697
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
+# Vendor the Microsoft build of Go signature. See https://github.com/microsoft/go-lab/issues/423
+	printf '%s\n' \
+		'-----BEGIN PGP PUBLIC KEY BLOCK-----' \
+		'Version: BSN Pgp v1.1.0.0' \
+		'' \
+		'mQENBGBt3ocBCAC0eCjRdhrHwMGh4pxw/JFulp+QcqymS9eYr7leZutRB9CpjW4O' \
+		'lXUzHzr8nIKoTbgNiak5Ws80LYvoPHwUjKqVypeRqG1vHoWzwy1t5U6imtcCspLK' \
+		'nbqkx2JFG6zcG5Dve4Kp1VeiJBQ+SwVaZfwEFFPDeCFqg2MptC7xIka2WqSTXZyL' \
+		'3PY/hNKXVeBJEg/et31FLZxWVr4/AJszu+aqhNqVMsqM8ldQF4QwVmoJQjCS/+Uy' \
+		'Nw8Dt/THbaFQvn5Tnio3Yjc+7wiKhcE1JQAi5Cj/lTFQHLGTCm21c1fJ5HTI+pTt' \
+		'O+HwJg4Wj3DEn7o+5VXj5JBtPmDxU0U6cR3vABEBAAG0QE1hbmFnZWQgTGFuZ3Vh' \
+		'Z2VzIENvbXBpbGVyIERldiBUZWFtIDxtbGFuZ2NvbXBkZXZAbWljcm9zb2Z0LmNv' \
+		'bT6JATgEEwEIACIFAmBt3ocCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJ' \
+		'EIEQBTR7jnMsdlQH/1XJO01wECeC1AMIQhNJueb5hBv+7AfSeKF36uQuX9rx5Lxp' \
+		'hBgb9x3iEK5CE+xDtLmXx2yJZJIUtLbqxXhAa0Ph1dyLXRKAbVgv3dPlsAzPusMu' \
+		'GjTyGeHNAVwodyTp3pggxzWtjoBGnVxpCNpqVDlepzoyBAfP51dd0oQ2JBfaBpNP' \
+		'ft04A69W8eS/6pwFvUL5g5zPvczsBJmqMmSiDrNKeSa68/2k9ey1DlbhfA3FPPUx' \
+		'13xCFv9pwieHHSyunbTbLzPnfRVdSlA16W7WT9aeF46R4/QyHc4AeU1p8HJtlDPz' \
+		'jy3zx0Vd4u+rvgekEhHI7zFyHIdwHWD3UoV9Flk=' \
+		'=EZkZ' \
+		'-----END PGP PUBLIC KEY BLOCK-----' \
+		> microsoft-managed-lang-compiler.asc; \
+	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+		| grep -q '^fpr:::::::::B035FAC203AB9A45AAC802B4811005347B8E732C:$'; \
+	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
 # Azure Linux doesn't include dirmngr, which is required for keyserver import. Skipping keyserver
 # import. In microsoft/go-images, we use a manually imported key anyway.

--- a/src/microsoft/1.26/azurelinux3.0/Dockerfile
+++ b/src/microsoft/1.26/azurelinux3.0/Dockerfile
@@ -55,7 +55,7 @@ RUN set -eux; \
 	\
 # https://github.com/golang/go/issues/14739#issuecomment-324767697
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-# Vendor the Microsoft build of Go signature. See https://github.com/microsoft/go-lab/issues/423
+# Vendor the Microsoft build of Go public key. See https://github.com/microsoft/go-lab/issues/423
 	printf '%s\n' \
 		'-----BEGIN PGP PUBLIC KEY BLOCK-----' \
 		'Version: BSN Pgp v1.1.0.0' \
@@ -77,11 +77,12 @@ RUN set -eux; \
 		'=EZkZ' \
 		'-----END PGP PUBLIC KEY BLOCK-----' \
 		> microsoft-managed-lang-compiler.asc; \
-	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+	gpg --batch --show-keys --with-colons --with-fingerprint microsoft-managed-lang-compiler.asc \
 		| grep -q '^fpr:::::::::B035FAC203AB9A45AAC802B4811005347B8E732C:$'; \
-	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+	gpg --batch --show-keys --with-colons --with-fingerprint microsoft-managed-lang-compiler.asc \
 		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
+	rm microsoft-managed-lang-compiler.asc; \
 # Azure Linux doesn't include dirmngr, which is required for keyserver import. Skipping keyserver
 # import. In microsoft/go-images, we use a manually imported key anyway.
 # See https://microsoft.visualstudio.com/OS/_workitems/edit/62225284

--- a/src/microsoft/1.26/bookworm/Dockerfile
+++ b/src/microsoft/1.26/bookworm/Dockerfile
@@ -46,7 +46,32 @@ RUN set -eux; \
 	\
 # https://github.com/golang/go/issues/14739#issuecomment-324767697
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
+# Vendor the Microsoft build of Go signature. See https://github.com/microsoft/go-lab/issues/423
+	printf '%s\n' \
+		'-----BEGIN PGP PUBLIC KEY BLOCK-----' \
+		'Version: BSN Pgp v1.1.0.0' \
+		'' \
+		'mQENBGBt3ocBCAC0eCjRdhrHwMGh4pxw/JFulp+QcqymS9eYr7leZutRB9CpjW4O' \
+		'lXUzHzr8nIKoTbgNiak5Ws80LYvoPHwUjKqVypeRqG1vHoWzwy1t5U6imtcCspLK' \
+		'nbqkx2JFG6zcG5Dve4Kp1VeiJBQ+SwVaZfwEFFPDeCFqg2MptC7xIka2WqSTXZyL' \
+		'3PY/hNKXVeBJEg/et31FLZxWVr4/AJszu+aqhNqVMsqM8ldQF4QwVmoJQjCS/+Uy' \
+		'Nw8Dt/THbaFQvn5Tnio3Yjc+7wiKhcE1JQAi5Cj/lTFQHLGTCm21c1fJ5HTI+pTt' \
+		'O+HwJg4Wj3DEn7o+5VXj5JBtPmDxU0U6cR3vABEBAAG0QE1hbmFnZWQgTGFuZ3Vh' \
+		'Z2VzIENvbXBpbGVyIERldiBUZWFtIDxtbGFuZ2NvbXBkZXZAbWljcm9zb2Z0LmNv' \
+		'bT6JATgEEwEIACIFAmBt3ocCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJ' \
+		'EIEQBTR7jnMsdlQH/1XJO01wECeC1AMIQhNJueb5hBv+7AfSeKF36uQuX9rx5Lxp' \
+		'hBgb9x3iEK5CE+xDtLmXx2yJZJIUtLbqxXhAa0Ph1dyLXRKAbVgv3dPlsAzPusMu' \
+		'GjTyGeHNAVwodyTp3pggxzWtjoBGnVxpCNpqVDlepzoyBAfP51dd0oQ2JBfaBpNP' \
+		'ft04A69W8eS/6pwFvUL5g5zPvczsBJmqMmSiDrNKeSa68/2k9ey1DlbhfA3FPPUx' \
+		'13xCFv9pwieHHSyunbTbLzPnfRVdSlA16W7WT9aeF46R4/QyHc4AeU1p8HJtlDPz' \
+		'jy3zx0Vd4u+rvgekEhHI7zFyHIdwHWD3UoV9Flk=' \
+		'=EZkZ' \
+		'-----END PGP PUBLIC KEY BLOCK-----' \
+		> microsoft-managed-lang-compiler.asc; \
+	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+		| grep -q '^fpr:::::::::B035FAC203AB9A45AAC802B4811005347B8E732C:$'; \
+	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \

--- a/src/microsoft/1.26/bookworm/Dockerfile
+++ b/src/microsoft/1.26/bookworm/Dockerfile
@@ -46,7 +46,7 @@ RUN set -eux; \
 	\
 # https://github.com/golang/go/issues/14739#issuecomment-324767697
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-# Vendor the Microsoft build of Go signature. See https://github.com/microsoft/go-lab/issues/423
+# Vendor the Microsoft build of Go public key. See https://github.com/microsoft/go-lab/issues/423
 	printf '%s\n' \
 		'-----BEGIN PGP PUBLIC KEY BLOCK-----' \
 		'Version: BSN Pgp v1.1.0.0' \
@@ -68,11 +68,12 @@ RUN set -eux; \
 		'=EZkZ' \
 		'-----END PGP PUBLIC KEY BLOCK-----' \
 		> microsoft-managed-lang-compiler.asc; \
-	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+	gpg --batch --show-keys --with-colons --with-fingerprint microsoft-managed-lang-compiler.asc \
 		| grep -q '^fpr:::::::::B035FAC203AB9A45AAC802B4811005347B8E732C:$'; \
-	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+	gpg --batch --show-keys --with-colons --with-fingerprint microsoft-managed-lang-compiler.asc \
 		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
+	rm microsoft-managed-lang-compiler.asc; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
 # let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it

--- a/src/microsoft/1.26/bullseye/Dockerfile
+++ b/src/microsoft/1.26/bullseye/Dockerfile
@@ -46,7 +46,32 @@ RUN set -eux; \
 	\
 # https://github.com/golang/go/issues/14739#issuecomment-324767697
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-	wget -O microsoft-managed-lang-compiler.asc 'https://download.microsoft.com/download/f/a/2/fa2420dd-3f08-4621-82cf-5a22abcbc8f9/microsoft-managed-lang-compiler.asc'; \
+# Vendor the Microsoft build of Go signature. See https://github.com/microsoft/go-lab/issues/423
+	printf '%s\n' \
+		'-----BEGIN PGP PUBLIC KEY BLOCK-----' \
+		'Version: BSN Pgp v1.1.0.0' \
+		'' \
+		'mQENBGBt3ocBCAC0eCjRdhrHwMGh4pxw/JFulp+QcqymS9eYr7leZutRB9CpjW4O' \
+		'lXUzHzr8nIKoTbgNiak5Ws80LYvoPHwUjKqVypeRqG1vHoWzwy1t5U6imtcCspLK' \
+		'nbqkx2JFG6zcG5Dve4Kp1VeiJBQ+SwVaZfwEFFPDeCFqg2MptC7xIka2WqSTXZyL' \
+		'3PY/hNKXVeBJEg/et31FLZxWVr4/AJszu+aqhNqVMsqM8ldQF4QwVmoJQjCS/+Uy' \
+		'Nw8Dt/THbaFQvn5Tnio3Yjc+7wiKhcE1JQAi5Cj/lTFQHLGTCm21c1fJ5HTI+pTt' \
+		'O+HwJg4Wj3DEn7o+5VXj5JBtPmDxU0U6cR3vABEBAAG0QE1hbmFnZWQgTGFuZ3Vh' \
+		'Z2VzIENvbXBpbGVyIERldiBUZWFtIDxtbGFuZ2NvbXBkZXZAbWljcm9zb2Z0LmNv' \
+		'bT6JATgEEwEIACIFAmBt3ocCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJ' \
+		'EIEQBTR7jnMsdlQH/1XJO01wECeC1AMIQhNJueb5hBv+7AfSeKF36uQuX9rx5Lxp' \
+		'hBgb9x3iEK5CE+xDtLmXx2yJZJIUtLbqxXhAa0Ph1dyLXRKAbVgv3dPlsAzPusMu' \
+		'GjTyGeHNAVwodyTp3pggxzWtjoBGnVxpCNpqVDlepzoyBAfP51dd0oQ2JBfaBpNP' \
+		'ft04A69W8eS/6pwFvUL5g5zPvczsBJmqMmSiDrNKeSa68/2k9ey1DlbhfA3FPPUx' \
+		'13xCFv9pwieHHSyunbTbLzPnfRVdSlA16W7WT9aeF46R4/QyHc4AeU1p8HJtlDPz' \
+		'jy3zx0Vd4u+rvgekEhHI7zFyHIdwHWD3UoV9Flk=' \
+		'=EZkZ' \
+		'-----END PGP PUBLIC KEY BLOCK-----' \
+		> microsoft-managed-lang-compiler.asc; \
+	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+		| grep -q '^fpr:::::::::B035FAC203AB9A45AAC802B4811005347B8E732C:$'; \
+	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \

--- a/src/microsoft/1.26/bullseye/Dockerfile
+++ b/src/microsoft/1.26/bullseye/Dockerfile
@@ -46,7 +46,7 @@ RUN set -eux; \
 	\
 # https://github.com/golang/go/issues/14739#issuecomment-324767697
 	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
-# Vendor the Microsoft build of Go signature. See https://github.com/microsoft/go-lab/issues/423
+# Vendor the Microsoft build of Go public key. See https://github.com/microsoft/go-lab/issues/423
 	printf '%s\n' \
 		'-----BEGIN PGP PUBLIC KEY BLOCK-----' \
 		'Version: BSN Pgp v1.1.0.0' \
@@ -68,11 +68,12 @@ RUN set -eux; \
 		'=EZkZ' \
 		'-----END PGP PUBLIC KEY BLOCK-----' \
 		> microsoft-managed-lang-compiler.asc; \
-	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+	gpg --batch --show-keys --with-colons --with-fingerprint microsoft-managed-lang-compiler.asc \
 		| grep -q '^fpr:::::::::B035FAC203AB9A45AAC802B4811005347B8E732C:$'; \
-	gpg --batch --show-keys --with-colons microsoft-managed-lang-compiler.asc \
+	gpg --batch --show-keys --with-colons --with-fingerprint microsoft-managed-lang-compiler.asc \
 		| grep -q '^uid:.*:Managed Languages Compiler Dev Team <mlangcompdev@microsoft.com>:'; \
 	gpg --batch --import microsoft-managed-lang-compiler.asc; \
+	rm microsoft-managed-lang-compiler.asc; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
 # let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it


### PR DESCRIPTION
Remove source of flakiness by embedding the public key rather than downloading it during each build.

This also theoretically improves security by not relying on the download service to deliver the same content every time.

It may also protect against some outages. The build still relies on download.visualstudio.microsoft.com, but not download.microsoft.com.

The patch includes thumbprint and author verification to clarify for readers what this blob represents, not necessarily for a security purpose. This also points out a way to check what the asc blob represents is in future reviews in case it changes.

* For https://github.com/microsoft/go-lab/issues/423 (more info)