### PR TITLE
Enable scheduled builds

### DIFF
--- a/eng/pipeline/go-docker-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline.yml
@@ -7,7 +7,13 @@
 
 trigger: none
 pr: none
-schedules: []
+schedules:
+  - cron: '0 10 * * Mon,Wed'
+    displayName: Periodic build to refresh dependencies
+    branches:
+      include:
+        - microsoft/main
+    always: true
 parameters:
   - name: sourceBuildPipelineRunId
     displayName: >

--- a/eng/pipeline/go-docker-rolling-internal.gen.yml
+++ b/eng/pipeline/go-docker-rolling-internal.gen.yml
@@ -11,7 +11,7 @@ pipelineymlgen:
     - file: go-docker-rolling-internal-pipeline.yml
       data:
         official: true
-        schedule: false
+        schedule: true
 ---
 
 trigger: none


### PR DESCRIPTION
Undo https://github.com/microsoft/go-images/pull/624, but leave the scheduling disable mechanism in place for easy disables in the future.

https://github.com/microsoft/go-images/pull/629 brought in [3002630](https://dev.azure.com/dnceng/internal/_build/results?buildId=3002630&view=results) which [has](https://github.com/dotnet/docker-tools/commits/518baf2531204185c78dce8c390543d22947fb56) the validation change.

* For https://github.com/microsoft/go/issues/2313