### PR TITLE
Update docs for pipeline info reachability

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
+The [README in `eng`](/eng/README.md) contains more information about the build infrastructure for this repository.
+
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 

--- a/eng/README.md
+++ b/eng/README.md
@@ -8,6 +8,8 @@ it matches the engineering directory used in microsoft/go, and also because
 auto-updates to the "eng/common" directory only work with this absolute
 location.
 
+The Azure DevOps pipelines are described in the [`/eng/pipeline` README](/eng/pipeline/README.md).
+
 ## Prerequisites
 
 * [PowerShell 6+](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell)

--- a/eng/ci-tools/README.md
+++ b/eng/ci-tools/README.md
@@ -4,3 +4,6 @@ This module exists to store CI dependencies. Using a module dependency lets CI d
 
 This directory contains `local.Dockerfile`, which creates an image with `dockerupdate` installed.
 See [eng/README.md#windows](../README.md#windows) for instructions on using it.
+
+This module also contains the code generator for the Azure DevOps build pipelines.
+Use `go generate .` in this directory to regenerate the pipelines.

--- a/eng/pipeline/README.md
+++ b/eng/pipeline/README.md
@@ -5,4 +5,4 @@ This directory contains the Azure DevOps build pipelines for the go-images repos
 A code generator turns the `*.gen.yml` files into the actual `*.yml` files that Azure DevOps uses.
 See [`eng/ci-tools/README.md`](../ci-tools/README.md) for more information about the code generator.
 
-See [Azure pipeline YML style](https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md) for more information about how these pipelines are written.
+See [Azure Pipelines YAML style](https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md) for more information about how these pipelines are written.

--- a/eng/pipeline/README.md
+++ b/eng/pipeline/README.md
@@ -1,0 +1,8 @@
+# go-images build pipelines
+
+This directory contains the Azure DevOps build pipelines for the go-images repository.
+
+A code generator turns the `*.gen.yml` files into the actual `*.yml` files that Azure DevOps uses.
+See [`eng/ci-tools/README.md`](../ci-tools/README.md) for more information about the code generator.
+
+See [Azure pipeline YML style](https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md) for more information about how these pipelines are written.


### PR DESCRIPTION
* For https://github.com/microsoft/go-lab/issues/435

Add `eng/pipeline/README.md` and add a path to get there from the root `README.md`. While here, include information about how the pipelines are generated and a pointer to the pipeline style doc.