### PR TITLE
Add description and polish pipeline Run dialog

### DIFF
--- a/eng/pipeline/cleanup-acr-images-pipeline-unofficial.yml
+++ b/eng/pipeline/cleanup-acr-images-pipeline-unofficial.yml
@@ -17,15 +17,19 @@ parameters:
     values:
       - "\U0001F535  cleanup-acr-images-pipeline-unofficial.yml  \U0001F535 \U0001F535"
   - name: enableDryRun
-    displayName: Enable to perform Dry Run
+    displayName: Dry run. Use this to see what would be deleted without performing the deletion.
     default: true
     type: boolean
   - name: age
-    displayName: Provide the minimum age (in days) of images to clean up. Reduce if necessary to clear an s360 alert.
+    displayName: >
+      Minimum age (in days) of images to clean up. Reduce if you need to clean up young images. For example, reducing it may be necessary to clear an unusually aggressive s360 alert.
+
     type: number
     default: 15
   - name: disableTSA
-    displayName: "[Debug input] Enable to skip TSA reporting. May be useful for dev branch builds."
+    displayName: >
+      [Debug input] Skip TSA reporting. Use when running a dev branch. This lets you avoid triggering false positive TSA notifications when testing out new modifications.
+
     type: boolean
     default: true
 schedules: []

--- a/eng/pipeline/cleanup-acr-images-pipeline-unofficial.yml
+++ b/eng/pipeline/cleanup-acr-images-pipeline-unofficial.yml
@@ -5,28 +5,29 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# This pipeline is used to clean up old images in our Azure Container Registries.
-# It's derived from https://github.com/dotnet/docker-tools/blob/main/eng/pipelines/cleanup-acr-images.yml
-
 # official: https://dev.azure.com/dnceng/internal/_build?definitionId=1521
 # unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1522
 
 trigger: none
 pr: none
-# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
+  - name: _info
+    displayName: ℹ️ This pipeline cleans up old images in our Azure Container Registries.
+    type: string
+    values:
+      - "\U0001F535  cleanup-acr-images-pipeline-unofficial.yml  \U0001F535 \U0001F535"
   - name: enableDryRun
-    displayName: Enable Dry Run
+    displayName: Enable to perform Dry Run
     default: true
     type: boolean
-  - name: disableTSA
-    displayName: "[Debug input] Disable TSA reporting. Use to try modifications in dev branches."
-    type: boolean
-    default: true
   - name: age
-    displayName: Minimum age (in days) of images to clean up; reduce if necessary to clear s360
+    displayName: Provide the minimum age (in days) of images to clean up. Reduce if necessary to clear an s360 alert.
     type: number
     default: 15
+  - name: disableTSA
+    displayName: "[Debug input] Enable to skip TSA reporting. May be useful for dev branch builds."
+    type: boolean
+    default: true
 schedules: []
 variables:
   - template: /eng/pipeline/variables/go-common.yml@self
@@ -36,6 +37,7 @@ resources:
       type: git
       name: 1ESPipelineTemplates/1ESPipelineTemplates
       ref: refs/tags/release
+# This pipeline is derived from https://github.com/dotnet/docker-tools/blob/main/eng/pipelines/cleanup-acr-images.yml
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:

--- a/eng/pipeline/cleanup-acr-images-pipeline.yml
+++ b/eng/pipeline/cleanup-acr-images-pipeline.yml
@@ -5,28 +5,29 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# This pipeline is used to clean up old images in our Azure Container Registries.
-# It's derived from https://github.com/dotnet/docker-tools/blob/main/eng/pipelines/cleanup-acr-images.yml
-
 # official: https://dev.azure.com/dnceng/internal/_build?definitionId=1521
 # unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1522
 
 trigger: none
 pr: none
-# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
+  - name: _info
+    displayName: ℹ️ This pipeline cleans up old images in our Azure Container Registries.
+    type: string
+    values:
+      - "\U0001F535  cleanup-acr-images-pipeline.yml  \U0001F535 \U0001F535"
   - name: enableDryRun
-    displayName: Enable Dry Run
+    displayName: Enable to perform Dry Run
     default: false
     type: boolean
-  - name: disableTSA
-    displayName: "[Debug input] Disable TSA reporting. Use to try modifications in dev branches."
-    type: boolean
-    default: false
   - name: age
-    displayName: Minimum age (in days) of images to clean up; reduce if necessary to clear s360
+    displayName: Provide the minimum age (in days) of images to clean up. Reduce if necessary to clear an s360 alert.
     type: number
     default: 15
+  - name: disableTSA
+    displayName: "[Debug input] Enable to skip TSA reporting. May be useful for dev branch builds."
+    type: boolean
+    default: false
 schedules:
   - cron: "0 5 * * *"
     displayName: Nightly build
@@ -42,6 +43,7 @@ resources:
       type: git
       name: 1ESPipelineTemplates/1ESPipelineTemplates
       ref: refs/tags/release
+# This pipeline is derived from https://github.com/dotnet/docker-tools/blob/main/eng/pipelines/cleanup-acr-images.yml
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:

--- a/eng/pipeline/cleanup-acr-images-pipeline.yml
+++ b/eng/pipeline/cleanup-acr-images-pipeline.yml
@@ -17,15 +17,19 @@ parameters:
     values:
       - "\U0001F535  cleanup-acr-images-pipeline.yml  \U0001F535 \U0001F535"
   - name: enableDryRun
-    displayName: Enable to perform Dry Run
+    displayName: Dry run. Use this to see what would be deleted without performing the deletion.
     default: false
     type: boolean
   - name: age
-    displayName: Provide the minimum age (in days) of images to clean up. Reduce if necessary to clear an s360 alert.
+    displayName: >
+      Minimum age (in days) of images to clean up. Reduce if you need to clean up young images. For example, reducing it may be necessary to clear an unusually aggressive s360 alert.
+
     type: number
     default: 15
   - name: disableTSA
-    displayName: "[Debug input] Enable to skip TSA reporting. May be useful for dev branch builds."
+    displayName: >
+      [Debug input] Skip TSA reporting. Use when running a dev branch. This lets you avoid triggering false positive TSA notifications when testing out new modifications.
+
     type: boolean
     default: false
 schedules:

--- a/eng/pipeline/cleanup-acr-images.gen.yml
+++ b/eng/pipeline/cleanup-acr-images.gen.yml
@@ -22,7 +22,7 @@ parameters:
   - name: _info
     displayName: ℹ️ This pipeline cleans up old images in our Azure Container Registries.
     type: string
-    values: 
+    values:
       - ${ cat "🔵 " .output " 🔵 🔵" }
 
   - name: enableDryRun

--- a/eng/pipeline/cleanup-acr-images.gen.yml
+++ b/eng/pipeline/cleanup-acr-images.gen.yml
@@ -2,9 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# This pipeline is used to clean up old images in our Azure Container Registries.
-# It's derived from https://github.com/dotnet/docker-tools/blob/main/eng/pipelines/cleanup-acr-images.yml
-
 # official: https://dev.azure.com/dnceng/internal/_build?definitionId=1521
 # unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1522
 
@@ -21,22 +18,27 @@ pipelineymlgen:
 trigger: none
 pr: none
 
-# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
-  - name: enableDryRun
-    displayName: Enable Dry Run
-    default: ${ yml (not .official) }
-    type: boolean
+  - name: _info
+    displayName: ℹ️ This pipeline cleans up old images in our Azure Container Registries.
+    type: string
+    values: 
+      - ${ cat "🔵 " .output " 🔵 🔵" }
 
-  - name: disableTSA
-    displayName: "[Debug input] Disable TSA reporting. Use to try modifications in dev branches."
-    type: boolean
+  - name: enableDryRun
+    displayName: Enable to perform Dry Run
     default: ${ yml (not .official) }
+    type: boolean
 
   - name: age
-    displayName: Minimum age (in days) of images to clean up; reduce if necessary to clear s360
+    displayName: Provide the minimum age (in days) of images to clean up. Reduce if necessary to clear an s360 alert.
     type: number
     default: 15
+
+  - name: disableTSA
+    displayName: "[Debug input] Enable to skip TSA reporting. May be useful for dev branch builds."
+    type: boolean
+    default: ${ yml (not .official) }
 
 schedules:
   - ${ inlineif .official }:
@@ -57,6 +59,7 @@ resources:
       name: 1ESPipelineTemplates/1ESPipelineTemplates
       ref: refs/tags/release
 
+# This pipeline is derived from https://github.com/dotnet/docker-tools/blob/main/eng/pipelines/cleanup-acr-images.yml
 extends:
   ${ inlineif .official }:
     template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates

--- a/eng/pipeline/cleanup-acr-images.gen.yml
+++ b/eng/pipeline/cleanup-acr-images.gen.yml
@@ -26,17 +26,21 @@ parameters:
       - ${ cat "🔵 " .output " 🔵 🔵" }
 
   - name: enableDryRun
-    displayName: Enable to perform Dry Run
+    displayName: Dry run. Use this to see what would be deleted without performing the deletion.
     default: ${ yml (not .official) }
     type: boolean
 
   - name: age
-    displayName: Provide the minimum age (in days) of images to clean up. Reduce if necessary to clear an s360 alert.
+    displayName: >
+      Minimum age (in days) of images to clean up. Reduce if you need to clean up young images. For
+      example, reducing it may be necessary to clear an unusually aggressive s360 alert.
     type: number
     default: 15
 
   - name: disableTSA
-    displayName: "[Debug input] Enable to skip TSA reporting. May be useful for dev branch builds."
+    displayName: >
+      [Debug input] Skip TSA reporting. Use when running a dev branch. This lets you avoid
+      triggering false positive TSA notifications when testing out new modifications.
     type: boolean
     default: ${ yml (not .official) }
 

--- a/eng/pipeline/go-docker-pr-pipeline.yml
+++ b/eng/pipeline/go-docker-pr-pipeline.yml
@@ -1,3 +1,9 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# public: https://dev.azure.com/dnceng-public/public/_build?definitionId=193
+
 trigger: none
 pr:
   branches:

--- a/eng/pipeline/go-docker-rolling-internal-pipeline-unofficial.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline-unofficial.yml
@@ -13,19 +13,19 @@ pr: none
 schedules: []
 parameters:
   - name: _info
-    displayName: ℹ️ This pipeline builds and publishes the Microsoft build of Go images on MAR.
+    displayName: ℹ️ This pipeline builds and publishes the Microsoft build of Go images.
     type: string
     values:
       - "\U0001F535  go-docker-rolling-internal-pipeline-unofficial.yml  \U0001F535 \U0001F535"
   - name: sourceBuildPipelineRunId
     displayName: >
-      Enter the build ID of this pipeline to publish images from. Use the default value (representing self) to build new images.
+      The run ID (build ID) that produced the images that this run should publish. Use the default value to build and publish new images during this run.
 
     type: string
     default: '$(Build.BuildId)'
   - name: publishRepoPrefix
     displayName: >
-      Enter the repo prefix to use when publishing images to the intermediate ACR. Use the default value (public/) when building an official branch. Switch to "dev/" when building an unofficial or custom branch. (If you forget, your custom branch build will fail, for safety.)
+      The repo prefix to use when publishing images to the intermediate ACR. Use "public/" when building an official branch. Use "dev/" when building an unofficial or custom branch that shouldn't be published to MAR.
 
     type: string
     default: dev/

--- a/eng/pipeline/go-docker-rolling-internal-pipeline-unofficial.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline-unofficial.yml
@@ -5,19 +5,27 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+# official: https://dev.azure.com/dnceng/internal/_build?definitionId=1023
+# unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1492
+
 trigger: none
 pr: none
 schedules: []
 parameters:
+  - name: _info
+    displayName: ℹ️ This pipeline builds and publishes the Microsoft build of Go images on MAR.
+    type: string
+    values:
+      - "\U0001F535  go-docker-rolling-internal-pipeline-unofficial.yml  \U0001F535 \U0001F535"
   - name: sourceBuildPipelineRunId
     displayName: >
-      The build ID of this pipeline to publish images from. Use the default value when building new images.
+      Enter the build ID of this pipeline to publish images from. Use the default value (representing self) to build new images.
 
     type: string
     default: '$(Build.BuildId)'
   - name: publishRepoPrefix
     displayName: >
-      Publish repo prefix to use when publishing images. Switch to "dev/" for an unofficial branch.
+      Enter the repo prefix to use when publishing images to the intermediate ACR. Use the default value (public/) when building an official branch. Switch to "dev/" when building an unofficial or custom branch. (If you forget, your custom branch build will fail, for safety.)
 
     type: string
     default: dev/

--- a/eng/pipeline/go-docker-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline.yml
@@ -19,19 +19,19 @@ schedules:
     always: true
 parameters:
   - name: _info
-    displayName: ℹ️ This pipeline builds and publishes the Microsoft build of Go images on MAR.
+    displayName: ℹ️ This pipeline builds and publishes the Microsoft build of Go images.
     type: string
     values:
       - "\U0001F535  go-docker-rolling-internal-pipeline.yml  \U0001F535 \U0001F535"
   - name: sourceBuildPipelineRunId
     displayName: >
-      Enter the build ID of this pipeline to publish images from. Use the default value (representing self) to build new images.
+      The run ID (build ID) that produced the images that this run should publish. Use the default value to build and publish new images during this run.
 
     type: string
     default: '$(Build.BuildId)'
   - name: publishRepoPrefix
     displayName: >
-      Enter the repo prefix to use when publishing images to the intermediate ACR. Use the default value (public/) when building an official branch. Switch to "dev/" when building an unofficial or custom branch. (If you forget, your custom branch build will fail, for safety.)
+      The repo prefix to use when publishing images to the intermediate ACR. Use "public/" when building an official branch. Use "dev/" when building an unofficial or custom branch that shouldn't be published to MAR.
 
     type: string
     default: public/

--- a/eng/pipeline/go-docker-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline.yml
@@ -5,6 +5,9 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+# official: https://dev.azure.com/dnceng/internal/_build?definitionId=1023
+# unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1492
+
 trigger: none
 pr: none
 schedules:
@@ -15,15 +18,20 @@ schedules:
         - microsoft/main
     always: true
 parameters:
+  - name: _info
+    displayName: ℹ️ This pipeline builds and publishes the Microsoft build of Go images on MAR.
+    type: string
+    values:
+      - "\U0001F535  go-docker-rolling-internal-pipeline.yml  \U0001F535 \U0001F535"
   - name: sourceBuildPipelineRunId
     displayName: >
-      The build ID of this pipeline to publish images from. Use the default value when building new images.
+      Enter the build ID of this pipeline to publish images from. Use the default value (representing self) to build new images.
 
     type: string
     default: '$(Build.BuildId)'
   - name: publishRepoPrefix
     displayName: >
-      Publish repo prefix to use when publishing images. Switch to "dev/" for an unofficial branch.
+      Enter the repo prefix to use when publishing images to the intermediate ACR. Use the default value (public/) when building an official branch. Switch to "dev/" when building an unofficial or custom branch. (If you forget, your custom branch build will fail, for safety.)
 
     type: string
     default: public/

--- a/eng/pipeline/go-docker-rolling-internal.gen.yml
+++ b/eng/pipeline/go-docker-rolling-internal.gen.yml
@@ -2,6 +2,9 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+# official: https://dev.azure.com/dnceng/internal/_build?definitionId=1023
+# unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1492
+
 pipelineymlgen:
   output:
     - file: go-docker-rolling-internal-pipeline-unofficial.yml
@@ -26,17 +29,25 @@ schedules:
       always: true
 
 parameters:
+  - name: _info
+    displayName: ℹ️ This pipeline builds and publishes the Microsoft build of Go images on MAR.
+    type: string
+    values: 
+      - ${ cat "🔵 " .output " 🔵 🔵" }
+
   - name: sourceBuildPipelineRunId
     displayName: >
-      The build ID of this pipeline to publish images from.
-      Use the default value when building new images.
+      Enter the build ID of this pipeline to publish images from.
+      Use the default value (representing self) to build new images.
     type: string
     default: '$(Build.BuildId)'
 
   - name: publishRepoPrefix
     displayName: >
-      Publish repo prefix to use when publishing images.
-      Switch to "dev/" for an unofficial branch.
+      Enter the repo prefix to use when publishing images to the intermediate ACR.
+      Use the default value (public/) when building an official branch.
+      Switch to "dev/" when building an unofficial or custom branch.
+      (If you forget, your custom branch build will fail, for safety.)
     type: string
     default:
       ${ inlineif .official }: 'public/'

--- a/eng/pipeline/go-docker-rolling-internal.gen.yml
+++ b/eng/pipeline/go-docker-rolling-internal.gen.yml
@@ -32,7 +32,7 @@ parameters:
   - name: _info
     displayName: ℹ️ This pipeline builds and publishes the Microsoft build of Go images.
     type: string
-    values: 
+    values:
       - ${ cat "🔵 " .output " 🔵 🔵" }
 
   - name: sourceBuildPipelineRunId

--- a/eng/pipeline/go-docker-rolling-internal.gen.yml
+++ b/eng/pipeline/go-docker-rolling-internal.gen.yml
@@ -30,24 +30,23 @@ schedules:
 
 parameters:
   - name: _info
-    displayName: ℹ️ This pipeline builds and publishes the Microsoft build of Go images on MAR.
+    displayName: ℹ️ This pipeline builds and publishes the Microsoft build of Go images.
     type: string
     values: 
       - ${ cat "🔵 " .output " 🔵 🔵" }
 
   - name: sourceBuildPipelineRunId
     displayName: >
-      Enter the build ID of this pipeline to publish images from.
-      Use the default value (representing self) to build new images.
+      The run ID (build ID) that produced the images that this run should publish. Use the default
+      value to build and publish new images during this run.
     type: string
     default: '$(Build.BuildId)'
 
   - name: publishRepoPrefix
     displayName: >
-      Enter the repo prefix to use when publishing images to the intermediate ACR.
-      Use the default value (public/) when building an official branch.
-      Switch to "dev/" when building an unofficial or custom branch.
-      (If you forget, your custom branch build will fail, for safety.)
+      The repo prefix to use when publishing images to the intermediate ACR.
+      Use "public/" when building an official branch.
+      Use "dev/" when building an unofficial or custom branch that shouldn't be published to MAR.
     type: string
     default:
       ${ inlineif .official }: 'public/'

--- a/eng/pipeline/rolling-internal-validation-pipeline-unofficial.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline-unofficial.yml
@@ -5,12 +5,17 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# This pipeline runs rolling validation, like CodeQL.
+# official: https://dev.azure.com/dnceng/internal/_build?definitionId=1355
+# unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1493
 
 trigger: none
 pr: none
-# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
+  - name: _info
+    displayName: ℹ️ This pipeline runs rolling validation, like CodeQL.
+    type: string
+    values:
+      - "\U0001F535  rolling-internal-validation-pipeline-unofficial.yml  \U0001F535 \U0001F535"
   - name: enableCodeQL
     displayName: '[Debug input] Enable CodeQL, ignoring cadence. Use to try modifications in dev branches.'
     type: boolean

--- a/eng/pipeline/rolling-internal-validation-pipeline-unofficial.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline-unofficial.yml
@@ -17,11 +17,15 @@ parameters:
     values:
       - "\U0001F535  rolling-internal-validation-pipeline-unofficial.yml  \U0001F535 \U0001F535"
   - name: enableCodeQL
-    displayName: '[Debug input] Enable CodeQL, ignoring cadence. Use to try modifications in dev branches.'
+    displayName: >
+      [Debug input] Force CodeQL to run, ignoring its built-in skip cadence. Use this to try modifications in dev branches.
+
     type: boolean
     default: false
   - name: disableTSA
-    displayName: '[Debug input] Disable TSA reporting. Use to try modifications in dev branches.'
+    displayName: >
+      [Debug input] Skip TSA reporting. Use when running a dev branch. This lets you avoid triggering false positive TSA notifications when testing out new modifications.
+
     type: boolean
     default: false
 variables:

--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -5,12 +5,17 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# This pipeline runs rolling validation, like CodeQL.
+# official: https://dev.azure.com/dnceng/internal/_build?definitionId=1355
+# unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1493
 
 trigger: none
 pr: none
-# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
+  - name: _info
+    displayName: ℹ️ This pipeline runs rolling validation, like CodeQL.
+    type: string
+    values:
+      - "\U0001F535  rolling-internal-validation-pipeline.yml  \U0001F535 \U0001F535"
   - name: enableCodeQL
     displayName: '[Debug input] Enable CodeQL, ignoring cadence. Use to try modifications in dev branches.'
     type: boolean

--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -17,11 +17,15 @@ parameters:
     values:
       - "\U0001F535  rolling-internal-validation-pipeline.yml  \U0001F535 \U0001F535"
   - name: enableCodeQL
-    displayName: '[Debug input] Enable CodeQL, ignoring cadence. Use to try modifications in dev branches.'
+    displayName: >
+      [Debug input] Force CodeQL to run, ignoring its built-in skip cadence. Use this to try modifications in dev branches.
+
     type: boolean
     default: false
   - name: disableTSA
-    displayName: '[Debug input] Disable TSA reporting. Use to try modifications in dev branches.'
+    displayName: >
+      [Debug input] Skip TSA reporting. Use when running a dev branch. This lets you avoid triggering false positive TSA notifications when testing out new modifications.
+
     type: boolean
     default: false
 variables:

--- a/eng/pipeline/rolling-internal-validation.gen.yml
+++ b/eng/pipeline/rolling-internal-validation.gen.yml
@@ -22,7 +22,7 @@ parameters:
   - name: _info
     displayName: ℹ️ This pipeline runs rolling validation, like CodeQL.
     type: string
-    values: 
+    values:
       - ${ cat "🔵 " .output " 🔵 🔵" }
 
   - name: enableCodeQL

--- a/eng/pipeline/rolling-internal-validation.gen.yml
+++ b/eng/pipeline/rolling-internal-validation.gen.yml
@@ -2,7 +2,8 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# This pipeline runs rolling validation, like CodeQL.
+# official: https://dev.azure.com/dnceng/internal/_build?definitionId=1355
+# unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1493
 
 pipelineymlgen:
   output:
@@ -17,12 +18,18 @@ pipelineymlgen:
 trigger: none
 pr: none
 
-# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
+  - name: _info
+    displayName: ℹ️ This pipeline runs rolling validation, like CodeQL.
+    type: string
+    values: 
+      - ${ cat "🔵 " .output " 🔵 🔵" }
+
   - name: enableCodeQL
     displayName: '[Debug input] Enable CodeQL, ignoring cadence. Use to try modifications in dev branches.'
     type: boolean
     default: false
+
   - name: disableTSA
     displayName: '[Debug input] Disable TSA reporting. Use to try modifications in dev branches.'
     type: boolean

--- a/eng/pipeline/rolling-internal-validation.gen.yml
+++ b/eng/pipeline/rolling-internal-validation.gen.yml
@@ -26,12 +26,16 @@ parameters:
       - ${ cat "🔵 " .output " 🔵 🔵" }
 
   - name: enableCodeQL
-    displayName: '[Debug input] Enable CodeQL, ignoring cadence. Use to try modifications in dev branches.'
+    displayName: >
+      [Debug input] Force CodeQL to run, ignoring its built-in skip cadence. Use this to try
+      modifications in dev branches.
     type: boolean
     default: false
 
   - name: disableTSA
-    displayName: '[Debug input] Disable TSA reporting. Use to try modifications in dev branches.'
+    displayName: >
+      [Debug input] Skip TSA reporting. Use when running a dev branch. This lets you avoid
+      triggering false positive TSA notifications when testing out new modifications.
     type: boolean
     default: false
 


### PR DESCRIPTION
* For https://github.com/microsoft/go-lab/issues/434 (run dialog improvements)
* For https://github.com/microsoft/go-lab/issues/435 (fix missing links in pipeline yml to pipelines that use it)

A few changes make the pipeline Run dialogs more usable for devs without full context:

Add an explicit description of what the pipeline is for by including a parameter with only one choice. The radio select is a bit ugly, but some emoji make it blend in a little, and the pipeline filename seems like a reasonable thing to include that makes the line seem less useless/out-of-place:

> <img width="460" height="294" alt="image" src="https://github.com/user-attachments/assets/f4e2727a-1e0b-45e5-90bd-eb9fb81d5c65" />

(This change will also be done in go-infra-images, and that change is really the one that directly addresses the recommendation in the RCA, by making it clear that that pipeline is the *wrong* one to use for this.)

Also, clarify the parameter display names.