### PR TITLE
Include default value for _info, use template

### DIFF
--- a/eng/pipeline/cleanup-acr-images-pipeline-unofficial.yml
+++ b/eng/pipeline/cleanup-acr-images-pipeline-unofficial.yml
@@ -16,6 +16,7 @@ parameters:
     type: string
     values:
       - "\U0001F535  cleanup-acr-images-pipeline-unofficial.yml  \U0001F535 \U0001F535"
+    default: "\U0001F535  cleanup-acr-images-pipeline-unofficial.yml  \U0001F535 \U0001F535"
   - name: enableDryRun
     displayName: Dry run. Use this to see what would be deleted without performing the deletion.
     default: true

--- a/eng/pipeline/cleanup-acr-images-pipeline.yml
+++ b/eng/pipeline/cleanup-acr-images-pipeline.yml
@@ -16,6 +16,7 @@ parameters:
     type: string
     values:
       - "\U0001F535  cleanup-acr-images-pipeline.yml  \U0001F535 \U0001F535"
+    default: "\U0001F535  cleanup-acr-images-pipeline.yml  \U0001F535 \U0001F535"
   - name: enableDryRun
     displayName: Dry run. Use this to see what would be deleted without performing the deletion.
     default: false

--- a/eng/pipeline/cleanup-acr-images.gen.yml
+++ b/eng/pipeline/cleanup-acr-images.gen.yml
@@ -19,11 +19,8 @@ trigger: none
 pr: none
 
 parameters:
-  - name: _info
-    displayName: ℹ️ This pipeline cleans up old images in our Azure Container Registries.
-    type: string
-    values:
-      - ${ cat "🔵 " .output " 🔵 🔵" }
+  - ${ inlinetemplate "util/info.gen.yml" }:
+      desc: This pipeline cleans up old images in our Azure Container Registries.
 
   - name: enableDryRun
     displayName: Dry run. Use this to see what would be deleted without performing the deletion.

--- a/eng/pipeline/go-docker-rolling-internal-pipeline-unofficial.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline-unofficial.yml
@@ -17,6 +17,7 @@ parameters:
     type: string
     values:
       - "\U0001F535  go-docker-rolling-internal-pipeline-unofficial.yml  \U0001F535 \U0001F535"
+    default: "\U0001F535  go-docker-rolling-internal-pipeline-unofficial.yml  \U0001F535 \U0001F535"
   - name: sourceBuildPipelineRunId
     displayName: >
       The run ID (build ID) that produced the images that this run should publish. Use the default value to build and publish new images during this run.

--- a/eng/pipeline/go-docker-rolling-internal-pipeline.yml
+++ b/eng/pipeline/go-docker-rolling-internal-pipeline.yml
@@ -23,6 +23,7 @@ parameters:
     type: string
     values:
       - "\U0001F535  go-docker-rolling-internal-pipeline.yml  \U0001F535 \U0001F535"
+    default: "\U0001F535  go-docker-rolling-internal-pipeline.yml  \U0001F535 \U0001F535"
   - name: sourceBuildPipelineRunId
     displayName: >
       The run ID (build ID) that produced the images that this run should publish. Use the default value to build and publish new images during this run.

--- a/eng/pipeline/go-docker-rolling-internal.gen.yml
+++ b/eng/pipeline/go-docker-rolling-internal.gen.yml
@@ -29,11 +29,8 @@ schedules:
       always: true
 
 parameters:
-  - name: _info
-    displayName: ℹ️ This pipeline builds and publishes the Microsoft build of Go images.
-    type: string
-    values:
-      - ${ cat "🔵 " .output " 🔵 🔵" }
+  - ${ inlinetemplate "util/info.gen.yml" }:
+      desc: This pipeline builds and publishes the Microsoft build of Go images.
 
   - name: sourceBuildPipelineRunId
     displayName: >

--- a/eng/pipeline/rolling-internal-validation-pipeline-unofficial.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline-unofficial.yml
@@ -16,6 +16,7 @@ parameters:
     type: string
     values:
       - "\U0001F535  rolling-internal-validation-pipeline-unofficial.yml  \U0001F535 \U0001F535"
+    default: "\U0001F535  rolling-internal-validation-pipeline-unofficial.yml  \U0001F535 \U0001F535"
   - name: enableCodeQL
     displayName: >
       [Debug input] Force CodeQL to run, ignoring its built-in skip cadence. Use this to try modifications in dev branches.

--- a/eng/pipeline/rolling-internal-validation-pipeline.yml
+++ b/eng/pipeline/rolling-internal-validation-pipeline.yml
@@ -16,6 +16,7 @@ parameters:
     type: string
     values:
       - "\U0001F535  rolling-internal-validation-pipeline.yml  \U0001F535 \U0001F535"
+    default: "\U0001F535  rolling-internal-validation-pipeline.yml  \U0001F535 \U0001F535"
   - name: enableCodeQL
     displayName: >
       [Debug input] Force CodeQL to run, ignoring its built-in skip cadence. Use this to try modifications in dev branches.

--- a/eng/pipeline/rolling-internal-validation.gen.yml
+++ b/eng/pipeline/rolling-internal-validation.gen.yml
@@ -19,11 +19,8 @@ trigger: none
 pr: none
 
 parameters:
-  - name: _info
-    displayName: ℹ️ This pipeline runs rolling validation, like CodeQL.
-    type: string
-    values:
-      - ${ cat "🔵 " .output " 🔵 🔵" }
+  - ${ inlinetemplate "util/info.gen.yml" }:
+      desc: This pipeline runs rolling validation, like CodeQL.
 
   - name: enableCodeQL
     displayName: >

--- a/eng/pipeline/util/info.gen.yml
+++ b/eng/pipeline/util/info.gen.yml
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# This pipelineymlgen template creates a placeholder parameter object that shows
+# important information to the user who hit the "Run" button so they can make a
+# more informed decision about whether they should use this pipeline.
+#
+# data inputs:
+# - desc - The description text to include.
+# - output - An output file of the template. Generally a pipeline .gen.yml file
+#   will automatically populate this data.
+#
+# The value is chosen to make it seem less out of place:
+#
+# The emoji fits in with the radio selection that shows up in the Run dialog to
+# obscure the oddity of a single-option choice. The yml filename is included
+# because it's technically potentially useful and fits in, even though it's
+# likely not important.
+
+name: _info
+displayName: ${ cat "ℹ️" .desc }
+type: string
+values:
+  - ${ cat "🔵 " .output " 🔵 🔵" }
+default: ${ cat "🔵 " .output " 🔵 🔵" }


### PR DESCRIPTION
* For https://github.com/microsoft/go-lab/issues/469

For `_info`, `default` isn't necessary for human-initiated runs (the sole option is automatically selected), but it seems that lacking a `default` breaks automatic triggers (scheduled and via AzDO API). Add a `default` to try to fix this.

This AzDO behavior is not documented. https://github.com/microsoft/go-infra/pull/518 updates the doc that keeps track of quirks like this, if this ends up being a working solution.

Also, creates and uses a new pipelineymlgen template to avoid excessive duplication. It's also a central place to document the strategy involved.