### PR TITLE
Revise documentation, include digest pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docker images containing the Microsoft build of Go
 
 This project maintains [`mcr.microsoft.com/oss/go/microsoft/golang`](https://mcr.microsoft.com/artifact/mar/oss/go/microsoft/golang/about), a repository of Docker images that contain the [Microsoft build of Go](https://github.com/microsoft/go).
-This repository is hosted by the [Microsoft Artifact Registry (MAR, formerly MCR)](https://mcr.microsoft.com/), a public container registry for Microsoft projects.
+These images are hosted on the [Microsoft Artifact Registry (MAR, formerly MCR)](https://mcr.microsoft.com/), a public container registry for Microsoft projects.
 
 The images produced by this repository are intended for general use within Microsoft and to help produce FIPS-compliant Go apps.
 For other purposes, we recommend using the [Docker Official Image `golang`](https://hub.docker.com/_/golang).

--- a/README.md
+++ b/README.md
@@ -29,32 +29,19 @@ This occurs even when the Microsoft build of Go has not been updated.
 
 ## Recommended tags
 
-The tag we recommend for Go projects inside Microsoft that are migrating to the Microsoft build of Go is [the 1.25 Azure Linux 3.0 tag](https://mcr.microsoft.com/en-us/artifact/mar/oss/go/microsoft/golang/tag/1.25).
+The tags we recommend for Go projects inside Microsoft that are migrating to the Microsoft build of Go are:
 
-```
-mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0
-```
+* The [1.26 Azure Linux 3.0 tag](https://mcr.microsoft.com/en-us/artifact/mar/oss/go/microsoft/golang/tag/1.26-azurelinux3.0)
+  ```
+  mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
+  ```
 
-We also recommend moving from 1.25 to 1.26 as soon as possible.
-This way, you can detect bugs that have to do with the new Go version as soon as possible and maximize the time remaining to address them before 1.25 is out of support.
+* The [1.25 Azure Linux 3.0 tag](https://mcr.microsoft.com/en-us/artifact/mar/oss/go/microsoft/golang/tag/1.25-azurelinux3.0)
+  ```
+  mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0
+  ```
 
-If your project is already using 1.26, use the 1.26 tag.
-
-A `1.X` tag contains the latest version of the Microsoft build of Go for that `X` version.
-
-> [!NOTE]
-> Both the N (1.26) and N-1 (1.25) releases of Go are supported, so why do we recommend starting with the N-1 release?
->
-> A new version of Go may have breaking changes that require you to change your project.
-> Also, when a new Go version N just comes out (1.26.0), it may have some initial bugs that will be fixed in the next handful of patches.
-> Therefore, we recommend that if you don't have a reason to pick a specific version, start with N-1 to avoid compatibility issues that might delay your migration to the Microsoft build of Go.
->
-> We also encourage upgrading from N-1 to N as soon as possible, so that any compatibility issues can be detected and addressed before N-1 is out of support.
-> Otherwise, compatibility issues may compound with security issues, causing delays in your project's ability to address security vulnerabilities.
-
-> [!NOTE]
-> Go libraries should be compatible with both N-1 and N to leave the choice up to the library's users.
-> Testing against both N-1 and N is recommended.
+For additional guidance, see the [Migration Guide][Migration Guide].
 
 ## Usage
 
@@ -81,32 +68,48 @@ The right image to use may depend on your organization, or it may need to be cus
 > Our `1.25-bullseye` (Debian) tag and other Debian tags are capable of building a FIPS-compliant Go app, but they contain a copy of OpenSSL that is **not** FIPS certified.
 > These tags may be suitable for a `build` stage, but not for FIPS-compliant deployment.
 
-### Using image digests to pin a specific image
-
-You can use a digest to pin a container image dependency to a specific immutable version.
-See the ["Image digests" Docker documentation](https://docs.docker.com/dhi/core-concepts/digests/).
+## Tag mutability
 
 Docker container image tags are mutable, meaning that the same tag may point to different image versions over time.
-Even a tag with a fully specified Go version may change, e.g. when we build a new version with updated OS dependencies.
+Even a tag with a fully specified Go version may change.
+For example, we build new images roughly twice a week (to get the latest OS and package updates), and the tags always point to the latest of those builds.
+
 Unlike image tags, image digests are immutable.
+See the ["Image digests" Docker documentation](https://docs.docker.com/dhi/core-concepts/digests/).
 
-In general, pinning dependencies is good, and Docker container tags are no exception.
-It has security benefits, and it means problems show up in dependency upgrade PRs rather than breaking a production build.
+See [Finding image digests](docs/finding-image-digests.md) for details on how to find current and historical digests that correspond with Microsoft build of Go container images.
 
-See [Image digests](docs/image-digests.md) for information about using image digests with the Microsoft build of Go.
-This page contains two ways to get digests, and how to use digests to roll back to a previous image version.
+### Using image digests to pin a specific image
 
-Unfortunately, there are currently a few feature gaps in the infrastructure that lead us to not consider image digests feasible for everyday use.
-Fixing some combination of these limitations would let us recommend using digests in more situations:
+There are many benefits to committing an immutable version of a dependency to source control rather than a mutable reference.
+The ["Image digests" Docker documentation](https://docs.docker.com/dhi/core-concepts/digests/) describes several security and consistency benefits in detail.
+A workflow benefit is that problems show up in dependency upgrade PRs, isolated from other changes, rather than interrupting CI or breaking a production build.
 
-* Dependabot is unable to upgrade a digest outside of Dockerfiles. ([Internal tracking issue](https://github.com/microsoft/go-lab/issues/479))
+Unfortunately, there are feature gaps in the current dependency update infrastructure available to some projects that may make it infeasible to use image digests for dependency pinning.
+These are the limitations we've identified:
+
+* GitHub Dependabot is unable to upgrade a digest outside of Dockerfiles. ([Internal tracking issue](https://github.com/microsoft/go-lab/issues/479))
   * For example, it can't update Azure Pipelines container job image references.
 * Azure Pipelines container jobs can't use a Dockerfile as the dependency of a container job. ([Internal tracking issue](https://github.com/microsoft/go-lab/issues/477))
-* Microsoft internal Dependabot is unable to upgrade a dependency on our container images to a new digest. ([Internal tracking issue](https://github.com/microsoft/go-lab/issues/476))
+* Microsoft's internal version of Dependabot is unable to upgrade a dependency on our container images to a new digest. ([Internal tracking issue](https://github.com/microsoft/go-lab/issues/476))
+  * This limitation applies to all targets, even Dockerfiles.
   * There appears to be an allowlist that doesn't include our tags.
 
-There are alternative dependency upgrade tools without the limitations mentioned above, but they don't seem to be widely used inside Microsoft.
-([Internal tracking issue](https://github.com/microsoft/go-lab/issues/478))
+> [!TIP]
+> We're evaluating alternative dependency upgrade tools that may not have the limitations mentioned above.
+> ([Internal tracking issue](https://github.com/microsoft/go-lab/issues/478))
+
+### Using image digests to roll back from a broken image
+
+If you encounter a problem with a new build of the Microsoft build of Go images, you can perform a rollback by pinning to a previous image digest.
+See [Finding image digests](docs/finding-image-digests.md) for details on how to find the old digest to use.
+
+Please [report the problem to us](SUPPORT.md).
+We can help find the digest to use for a rollback and investigate the root cause of the problem.
+
+> [!WARNING]
+> Make sure to revert the rollback when the issue is fixed!
+> Leaving a rollback in place may prevent you from getting important security updates and other fixes.
 
 ## Tag organization
 
@@ -175,5 +178,6 @@ our privacy statement. Your use of the software operates as your consent to
 these practices.
 
 [Migration Guide]: https://github.com/microsoft/go/blob/microsoft/main/eng/doc/MigrationGuide.md
+[Migration Guide version]: https://github.com/microsoft/go/blob/microsoft/main/eng/doc/MigrationGuide.md#what-version-should-i-use
 [FIPS readme]: https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 [MAR]: https://mcr.microsoft.com/product/oss/go/microsoft/golang/about

--- a/README.md
+++ b/README.md
@@ -97,16 +97,16 @@ See [Image digests](docs/image-digests.md) for information about using image dig
 This page contains two ways to get digests, and how to use digests to roll back to a previous image version.
 
 Unfortunately, there are currently a few feature gaps in the infrastructure that lead us to not consider image digests feasible for everyday use.
-Tracking issue: [microsoft/go-lab#440](https://github.com/microsoft/go-lab/issues/440).
 Fixing some combination of these limitations would let us recommend using digests in more situations:
 
-* Dependabot is unable to upgrade a digest outside of Dockerfiles.
+* Dependabot is unable to upgrade a digest outside of Dockerfiles. ([Internal tracking issue](https://github.com/microsoft/go-lab/issues/479))
   * For example, it can't update Azure Pipelines container job image references.
-* Azure Pipelines container jobs can't use a Dockerfile as the dependency of a container job.
-* Microsoft internal Dependabot is unable to upgrade a dependency on our container images to a new digest.
+* Azure Pipelines container jobs can't use a Dockerfile as the dependency of a container job. ([Internal tracking issue](https://github.com/microsoft/go-lab/issues/477))
+* Microsoft internal Dependabot is unable to upgrade a dependency on our container images to a new digest. ([Internal tracking issue](https://github.com/microsoft/go-lab/issues/476))
   * There appears to be an allowlist that doesn't include our tags.
 
 There are alternative dependency upgrade tools without the limitations mentioned above, but they don't seem to be widely used inside Microsoft.
+([Internal tracking issue](https://github.com/microsoft/go-lab/issues/478))
 
 ## Tag organization
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,119 @@
 # Docker images containing the Microsoft build of Go
 
-This repository creates Docker images that contain the Microsoft build of Go produced by the [microsoft/go](https://github.com/microsoft/go) repository. The tags are published on the Microsoft Artifact Registry (MAR), formerly Microsoft Container Registry (MCR), in the `oss/go/microsoft/golang` repository.
+This project maintains [`mcr.microsoft.com/oss/go/microsoft/golang`](https://mcr.microsoft.com/artifact/mar/oss/go/microsoft/golang/about), a repository of Docker images that contain the [Microsoft build of Go](https://github.com/microsoft/go).
+This repository is hosted by the [Microsoft Artifact Registry (MAR, formerly MCR)](https://mcr.microsoft.com/), a public container registry for Microsoft projects.
 
-The images produced by this repository are for general use within Microsoft and to help produce FIPS-compliant Go apps. For other purposes, we recommend using the [Docker Hub golang official images](https://hub.docker.com/_/golang).
+The images produced by this repository are intended for general use within Microsoft and to help produce FIPS-compliant Go apps.
+For other purposes, we recommend using the [Docker Official Image `golang`](https://hub.docker.com/_/golang).
 
-For more information about building FIPS-compatible Go apps with the Microsoft build of Go tools, visit the [FIPS readme] and [user guide](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/fips/UserGuide.md) in the microsoft/go repository.
-
-The [Migration Guide](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/MigrationGuide.md) contains more general information about migrating from official Go to the Microsoft build of Go.
+The [**Migration Guide** for the Microsoft build of Go][Migration Guide] contains additional information.
 
 ## Support
 
-GitHub issues for microsoft/go-images are maintained in the [microsoft/go](https://github.com/microsoft/go) project. For help and questions about the Microsoft build of Go images, please [file an issue in microsoft/go](https://github.com/microsoft/go/issues/new/choose).
+See [SUPPORT.md](SUPPORT.md) for more information about reporting bugs, requesting features, and asking questions.
 
-The supported tags in this repository are rebuilt approximately twice a week to update base image and distro package dependencies.
+There are a few additional support resources internal to Microsoft:
+
+* [(Microsoft-internal) Languages at Microsoft: Introduction to Go](https://eng.ms/docs/more/languages-at-microsoft/go/articles/overview).
+* [(Microsoft-internal) Languages at Microsoft: Get Help with Go](https://eng.ms/docs/more/languages-at-microsoft/go/articles/support).
+  * Includes internal Microsoft support channels such as an email contact for our team and a community Teams group.
+
+## Release cycle and policy
+
+New images are built and published when a new release of the Microsoft build of Go is available.
+The images are published before the new release is announced.
+See the [Microsoft build of Go release cycle and policy](https://github.com/microsoft/go/tree/microsoft/main#release-cycle-and-policy).
+
+New images are also built approximately twice a week to update base image and distro package dependencies.
+This occurs even when the Microsoft build of Go has not been updated.
 
 ## Recommended tags
 
-The tag we recommend for use inside Microsoft is the Go 1.25 Azure Linux 3.0 tag.
+The tag we recommend for Go projects inside Microsoft that are migrating to the Microsoft build of Go is [the 1.25 Azure Linux 3.0 tag](https://mcr.microsoft.com/en-us/artifact/mar/oss/go/microsoft/golang/tag/1.25).
 
 ```
 mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0
 ```
 
+We also recommend moving from 1.25 to 1.26 as soon as possible.
+This way, you can detect bugs that have to do with the new Go version as soon as possible and maximize the time remaining to address them before 1.25 is out of support.
+
+If your project is already using 1.26, use the 1.26 tag.
+
+A `1.X` tag contains the latest version of the Microsoft build of Go for that `X` version.
+
 > [!NOTE]
-> Why 1.25 (N-1) and not the latest, 1.26 (N)?
-> By the time a Go major version has been out long enough to be N-1, it has had several patch releases that may fix bugs found in the `.0` release and other early patch versions.
-> We recommend starting with N-1 rather than N so this timing-specific nuance doesn't come up.
+> Both the N (1.26) and N-1 (1.25) releases of Go are supported, so why do we recommend starting with the N-1 release?
 >
-> Both N and N-1 tags are currently supported.
-> If you want or need to use the latest, N, simply increment the major version number in the tag you use.
+> A new version of Go may have breaking changes that require you to change your project.
+> Also, when a new Go version N just comes out (1.26.0), it may have some initial bugs that will be fixed in the next handful of patches.
+> Therefore, we recommend that if you don't have a reason to pick a specific version, start with N-1 to avoid compatibility issues that might delay your migration to the Microsoft build of Go.
 >
-> To continue using Go without a support continuity gap, you must move from N-1 to N **before** N+1 ships, because the old N-1 reaches end of support immediately when N+1 releases.
-> Ideally, we recommend moving from N-1 to N as soon as possible. This way, you can detect bugs that have to do with the new Go version as soon as possible and maximize the time remaining to address them.
-> This may seem to contradict our image recommendation; however, we *do* recommend starting with N-1 and upgrading to N as soon as you can feasibly do so for the most incremental and safe migration.
+> We also encourage upgrading from N-1 to N as soon as possible, so that any compatibility issues can be detected and addressed before N-1 is out of support.
+> Otherwise, compatibility issues may compound with security issues, causing delays in your project's ability to address security vulnerabilities.
+
+> [!NOTE]
+> Go libraries should be compatible with both N-1 and N to leave the choice up to the library's users.
+> Testing against both N-1 and N is recommended.
+
+## Usage
+
+### Building a Go project
+
+If you use a Dockerfile, we recommend using `mcr.microsoft.com/oss/go/microsoft/golang` tags in the `build` stage of a [multi-stage Dockerfile](https://docs.docker.com/develop/develop-images/multistage-build/).
+The final stage in the Dockerfile should be based on a minimal image.
+This avoids unnecessarily deploying build-time dependencies to production.
+
+These tags are also suitable for use in an [Azure Pipelines container job](https://learn.microsoft.com/azure/devops/pipelines/process/container-phases?view=azure-devops) that builds a Go project.
+
+See the [Migration Guide][Migration Guide].
+
+### Deploying a container image
+
+The `mcr.microsoft.com/oss/go/microsoft/golang` tags may not be suitable for deployment.
+To comply with internal Microsoft cryptography policy, a Linux Go app must run in a container with a system-wide OpenSSL library.
+If you need FIPS compliance, there are additional requirements.
+See the [Migration Guide][Migration Guide].
+
+The right image to use may depend on your organization, or it may need to be custom-built to include product-specific runtime dependencies.
+
+> [!IMPORTANT]
+> Our `1.25-bullseye` (Debian) tag and other Debian tags are capable of building a FIPS-compliant Go app, but they contain a copy of OpenSSL that is **not** FIPS certified.
+> These tags may be suitable for a `build` stage, but not for FIPS-compliant deployment.
+
+### Using image digests to pin a specific image
+
+You can use a digest to pin a container image dependency to a specific immutable version.
+See the ["Image digests" Docker documentation](https://docs.docker.com/dhi/core-concepts/digests/).
+
+Docker container image tags are mutable, meaning that the same tag may point to different image versions over time.
+Even a tag with a fully specified Go version may change, e.g. when we build a new version with updated OS dependencies.
+Unlike image tags, image digests are immutable.
+
+In general, pinning dependencies is good, and Docker container tags are no exception.
+It has security benefits, and it means problems show up in dependency upgrade PRs rather than breaking a production build.
+
+See [Image digests](docs/image-digests.md) for information about using image digests with the Microsoft build of Go.
+This page contains two ways to get digests, and how to use digests to roll back to a previous image version.
+
+Unfortunately, there are currently a few feature gaps in the infrastructure that lead us to not consider image digests feasible for everyday use.
+Tracking issue: [microsoft/go-lab#440](https://github.com/microsoft/go-lab/issues/440).
+Fixing some combination of these limitations would let us recommend using digests in more situations:
+
+* Dependabot is unable to upgrade a digest outside of Dockerfiles.
+  * For example, it can't update Azure Pipelines container job image references.
+* Azure Pipelines container jobs can't use a Dockerfile as the dependency of a container job.
+* Microsoft internal Dependabot is unable to upgrade a dependency on our container images to a new digest.
+  * There appears to be an allowlist that doesn't include our tags.
+
+There are alternative dependency upgrade tools without the limitations mentioned above, but they don't seem to be widely used inside Microsoft.
+
+## Tag organization
+
+To view the full list of available Go tags in MAR, visit [`golang` on the MAR Discovery Portal][MAR].
+Go to the `Tags` tab to find a filterable list of tags and expand one to see the command to use to pull it.
+
+See [Tags of microsoft/go-images](docs/tags.md) for more information about tag support, more tag names, and the purpose of each image.
 
 > [!NOTE]
 > If you've used our 1.24 or earlier images, you may expect to see a `-fips` variant.
@@ -41,41 +122,18 @@ mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0
 >
 > For more background information about this change, see [Microsoft build of Go 1.25 crypto backend changes](https://devblogs.microsoft.com/go/microsoft-go-defaults-to-system-crypto/).
 
-If you use a Dockerfile, we recommend using `golang` tags in the `build` stage of a [multi-stage Dockerfile](https://docs.docker.com/develop/develop-images/multistage-build/).
-The final stage in the Dockerfile should be based on a minimal image.
-This avoids unnecessarily deploying build-time dependencies to production.
-
-These tags are also suitable for use in an Azure Pipelines job that builds a Go project.
-
-The tags may not be suitable for deployment.
-To comply with internal Microsoft cryptography policy, a Linux Go app must run in a container with a system-wide OpenSSL library.
-If you need FIPS compliance, there are additional requirements.
-The right image to use may depend on your organization, or it may need to be custom-built to include product-specific runtime dependencies.
-More guidance is available at [Containers Secure Supply Chain - Selecting base images (internal Microsoft link)](https://eng.ms/docs/more/containers-secure-supply-chain/images).
-
-> [!IMPORTANT]
-> Our `1.25-bullseye` (Debian) tag and other Debian tags are capable of building a FIPS compliant Go app, but they contain a copy of OpenSSL that is **not** FIPS certified.
-> These tags are suitable for a `build` stage, but not for FIPS-compliant deployment.
-
-## Tag organization
-
-To view the full list of available Go tags in MAR:
-
-* Visit [`golang` on the MAR Discovery Portal][MAR]
-  * Go to the `Tags` tab to find a filterable list of tags and expand one to see the command to use to pull it.
-* Use the [Microsoft Artifact Registry API](https://mcr.microsoft.com/v2/oss/go/microsoft/golang/tags/list)
-  * The full tag URL is `mcr.microsoft.com/{name}:{tag}`
-
-See [Tags of microsoft/go-images](docs/tags.md) for more information about tag support, more tag names, and the purpose of each image.
-
 > [!NOTE]
 > We don't build any Alpine images. See [microsoft/go#446](https://github.com/microsoft/go/issues/446).
+
+> [!TIP]
+> Prefer raw data?
+> Try the [Microsoft Artifact Registry API tag list for `golang`](https://mcr.microsoft.com/v2/oss/go/microsoft/golang/tags/list)
 
 ## Is this repository a fork?
 
 We think it's accurate to call this repository a fork of the official Golang image repository, [docker-library/golang](https://github.com/docker-library/golang). The branches here do not share Git ancestry with docker-library/golang. However, the repository serves the same purpose as a Git fork: maintaining a modified version of the Go source code over time.
 
-The submodule named `go` contains the official image source code. The templates in `go` are used to create the Dockerfiles in this repo, at [`src/microsoft`](src/microsoft). See the [eng README file](eng) for more information about this repository's infrastructure.
+The submodule named `go` contains the official image source code. The templates in `go` are used to create the Dockerfiles in this repo, at [`src/microsoft`](src/microsoft). See the [eng README file](eng/README.md) for more information about this repository's infrastructure.
 
 ## Contributing
 
@@ -91,7 +149,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-The [README in `eng`](/eng/README.md) contains more information about the build infrastructure for this repository.
+The [README in `eng`](eng/README.md) contains more information about the build infrastructure for this repository.
 
 ## Trademarks
 
@@ -100,9 +158,6 @@ trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
-
-[FIPS readme]: https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
-[MAR]: https://mcr.microsoft.com/product/oss/go/microsoft/golang/about
 
 ## Data Collection
 
@@ -118,3 +173,7 @@ statement. Our privacy statement is located at https://go.microsoft.com/fwlink/?
 You can learn more about data collection and use in the help documentation and
 our privacy statement. Your use of the software operates as your consent to
 these practices.
+
+[Migration Guide]: https://github.com/microsoft/go/blob/microsoft/main/eng/doc/MigrationGuide.md
+[FIPS readme]: https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
+[MAR]: https://mcr.microsoft.com/product/oss/go/microsoft/golang/about

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,7 +4,7 @@ For help and questions about the Go programming language and tools, visit the of
 
 ## How to file issues and get help
 
-This project uses GitHub Issues in the [microsoft/go repository][microsoft/go] to track bugs and feature requests.
+This project uses GitHub Issues in the [microsoft/go repository][microsoft/go] to track bugs, feature requests, and answer questions.
 Please search the existing issues before filing new issues to avoid duplicates.
 For new issues, [file your bug or feature request as a new Issue in microsoft/go][file].
 

--- a/docs/finding-image-digests.md
+++ b/docs/finding-image-digests.md
@@ -1,7 +1,7 @@
-# Image digests
+# Finding image digests
 
-See the [README's description of Docker image digests](/README.md#using-image-digests-to-pin-a-specific-image) for an overview of what image digests are and why you might want to use them.
-This document describes how to find the digests and how to use them to roll back to a previous version of the Microsoft build of Go images.
+See the [README's description of Docker image digests](/README.md#tag-mutability) for an overview of what image digests are and why you might want to use them.
+This document describes how to find the digests of Microsoft build of Go images.
 
 ## Current digests
 
@@ -19,18 +19,15 @@ It should look like this:
 mcr.microsoft.com/oss/go/microsoft/golang@sha256:<digest>
 ```
 
-## Rolling back to a previous image version
+## Historical digests
 
-If you encounter a problem with a new build of the Microsoft build of Go images, you can perform a rollback by pinning to a previous image digest.
 The microsoft/go-images-versions [image-info JSON file][image-info] tracks the build output history using Git source control.
 
-If you encounter a problem, [look for an existing open issue or contact us first](/SUPPORT.md).
-We can provide the image digest to use to roll back to a working dependency.
-
-The steps to roll back are:
+The steps to find a historical digest that's suitable for a [rollback](/README.md#using-image-digests-to-roll-back-from-a-broken-image) are:
 
 1. Use the Git history of the [image-info JSON file][image-info] to find older versions of the containers.
-    * Consider finding a commit timestamp before the problem started happening. Using a known good version helps confirm that the image is truly the root cause of the problem.
+    * Find a commit timestamp before the problem started happening. Using a known good version helps confirm that the image is truly the root cause of the problem.
+    * For deeper investigation, consider finding the last known good and first known bad versions and performing a binary search to narrow down the problem.
 1. Look for the correct `productVersion` in the JSON.
 1. Grab the `manifest` object's `digest` property value.
     * Use the manifest's digest rather than a specific platform's digest to ensure the digest has multi-architecture support.

--- a/docs/image-digests.md
+++ b/docs/image-digests.md
@@ -23,7 +23,7 @@ mcr.microsoft.com/oss/go/microsoft/golang@sha256:<digest>
 If you encounter a problem with a new build of the Microsoft build of Go images, you can perform a rollback by pinning to a previous image digest.
 The microsoft/go-images-versions [image-info JSON file][image-info] tracks the build output history using Git source control.
 
-If you encounter a problem, [look for an existing open issue or contact us first](./SUPPORT.md).
+If you encounter a problem, [look for an existing open issue or contact us first](/SUPPORT.md).
 We can provide the image digest to use to roll back to a working dependency.
 
 The steps to roll back are:

--- a/docs/image-digests.md
+++ b/docs/image-digests.md
@@ -1,0 +1,41 @@
+# Image digests
+
+See the [README's description of Docker image digests](/README.md#using-image-digests-to-pin-a-specific-image) for an overview of what image digests are and why you might want to use them.
+This document describes how to find the digests and how to use them to roll back to a previous version of the Microsoft build of Go images.
+
+## Current digests
+
+To find the digest for the current Microsoft build of Go tag, use a command mentioned in the ["Image digests" documentation](https://docs.docker.com/dhi/core-concepts/digests/), or this direct command:
+
+```sh
+docker image inspect --format '{{index .RepoDigests 0}}' mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
+```
+
+Then, use the output in your Dockerfile, Azure Pipelines job, or elsewhere.
+It should look like this:
+
+```
+mcr.microsoft.com/oss/go/microsoft/golang@sha256:<digest>
+```
+
+## Rolling back to a previous image version
+
+If you encounter a problem with a new build of the Microsoft build of Go images, you can perform a rollback by pinning to a previous image digest.
+The microsoft/go-images-versions [image-info JSON file][image-info] tracks the build output history using Git source control.
+
+If you encounter a problem, [look for an existing open issue or contact us first](./SUPPORT.md).
+We can provide the image digest to use to roll back to a working dependency.
+
+The steps to roll back are:
+
+1. Use the Git history of the [image-info JSON file][image-info] to find older versions of the containers.
+    * Consider finding a commit timestamp before the problem started happening. Using a known good version helps confirm that the image is truly the root cause of the problem.
+1. Look for the correct `productVersion` in the JSON.
+1. Grab the `manifest` object's `digest` property value.
+    * Use the manifest's digest rather than a specific platform's digest to ensure the digest has multi-architecture support.
+1. Replace your reference to the tag with the `digest` property's value.
+    * The value contains the full path, including repository, ready to use in any context that the tag was used.
+1. Verify that the replacement pulls the expected platform-specific image and fixes the problem.
+    1. If not, repeat these steps with a different version.
+
+[image-info]: https://github.com/microsoft/go-images-versions/blob/main/go-images/image-info.microsoft-go-images-main.json 

--- a/docs/image-digests.md
+++ b/docs/image-digests.md
@@ -39,4 +39,4 @@ The steps to roll back are:
 1. Verify that the replacement pulls the expected platform-specific image and fixes the problem.
     1. If not, repeat these steps with a different version.
 
-[image-info]: https://github.com/microsoft/go-images-versions/blob/main/go-images/image-info.microsoft-go-images-main.json 
+[image-info]: https://github.com/microsoft/go-images-versions/blob/main/go-images/image-info.microsoft-go-images-main.json

--- a/docs/image-digests.md
+++ b/docs/image-digests.md
@@ -5,10 +5,11 @@ This document describes how to find the digests and how to use them to roll back
 
 ## Current digests
 
-To find the digest for the current Microsoft build of Go tag, use a command mentioned in the ["Image digests" documentation](https://docs.docker.com/dhi/core-concepts/digests/), or this direct command:
+To find the digest for the current Microsoft build of Go tag, use a command mentioned in the ["Image digests" documentation](https://docs.docker.com/dhi/core-concepts/digests/), or these direct commands, where `<tag>` is the tag you want to find the digest for:
 
-```sh
-docker image inspect --format '{{index .RepoDigests 0}}' mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0
+```
+docker pull mcr.microsoft.com/oss/go/microsoft/golang:<tag>
+docker image inspect --format '{{index .RepoDigests 0}}' mcr.microsoft.com/oss/go/microsoft/golang:<tag>
 ```
 
 Then, use the output in your Dockerfile, Azure Pipelines job, or elsewhere.


### PR DESCRIPTION
Update the documentation:
* Changes based on similar changes in microsoft/go
* General revision for clarity
* Attempt to clarify our N-1 recommendation further
* Improve documentation links and remove a dead eng.ms link
* Document digest pinning. List current limitations and describe the rollback use case
---
* Fixes https://github.com/microsoft/go-lab/issues/441
* Fixes https://github.com/microsoft/go-lab/issues/444